### PR TITLE
Maximize cache hits

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "koa-router": "^7.1.0",
     "koa-static": "^3.0.0",
     "lru-cache": "^4.0.2",
+    "lru-ram": "~1.1.0",
     "normalize.css": "^5.0.0",
     "performance-now": "^2.1.0",
     "preact": "^7.1.0",


### PR DESCRIPTION
Hello,

I noted you are using an LRU cache, that's great, but with more than 350K packages at npm registry, keeping a cache with a max of 500 is too small.

For maximize hits, I added [lru-ram](https://github.com/Kikobeats/lru-ram) for calculate the optimal number of items to keep into the cache, based on the machine RAM and a fixture of data that represent a single item.