### PR TITLE
Fix wrong URL hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 </p>
 
 ## Built using bundlephobia
-- Size in browser - As seen on package searches at [yarnpkg.com](yarnpkg.com)
+- Size in browser - As seen on package searches at [yarnpkg.com](https://yarnpkg.com)
 - [bundlephobia-cli](https://github.com/AdrieanKhisbe/bundle-phobia-cli) - A Command Line client for bundlephobia
 - [importcost](https://atom.io/packages/importcost) - An Atom plugin to display size of imported packages
 


### PR DESCRIPTION
Changes the redirection from `https://github.com/pastelsky/bundlephobia/yarnpkg.com` to the correct url(`https://yarnpkg.com`)