### PR TITLE
Improve tree shaking detection

### DIFF
--- a/pages/result/ResultPage.js
+++ b/pages/result/ResultPage.js
@@ -246,7 +246,7 @@ export default class ResultPage extends PureComponent {
             }
             {
               resultsPromiseState === 'fulfilled' &&
-              (results.hasJSModule || results.hasJSNext) && (
+              (results.hasJSModule || results.hasJSNext) && result.hasSideEffects && (
                 <div className="flash-message">
                 <span className="flash-message__info-icon">
                   i


### PR DESCRIPTION
The tree shaking feature detection great, thanks for this!

However, it can be improved a little bit by checking the sideEffects flag. Bundlephobia reports some packages as tree-shaking ready when sometimes it is not the case because the flag in not set which prevents the tree-shaking from happening.