### PR TITLE
Fix title of dependency.svg on hover

### DIFF
--- a/client/assets/dependency.svg
+++ b/client/assets/dependency.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="18px" viewBox="0 0 20 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 52.1 (67048) - http://www.bohemiancoding.com/sketch -->
-    <title>Group 11</title>
+    <title>Dependencies</title>
     <desc>Created with Sketch.</desc>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Artboard-6" transform="translate(-514.000000, -242.000000)" fill-rule="nonzero">


### PR DESCRIPTION
Hovering over the icon was showing "Group 11" which was a bit confusing.
This will change the hover to display "Dependencies".