### PR TITLE
Fix react-pdf put in client-side PDF creation (naming confusion)

### DIFF
--- a/server/middlewares/similar-packages/fixtures.js
+++ b/server/middlewares/similar-packages/fixtures.js
@@ -211,7 +211,7 @@ const categories = {
       { tag: 'client', weight: Weight.NORMAL },
       { tag: 'browser', weight: Weight.NORMAL },
     ],
-    similar: ['jspdf','pdfkit', 'pdfmake','react-pdf']
+    similar: ['jspdf','pdfkit', 'pdfmake','@react-pdf/renderer']
   },
   'promise-polyfill': {
     name: 'Promise polyfills',


### PR DESCRIPTION
React-PDF (react-pdf) is used to display PDFs in browser. @diegomura's React-PDF (@react-pdf/renderer) is used to create PDFs.