### PR TITLE
Add JS Bundle Size Cross-Browser Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - Size in browser - As seen on package searches at [yarnpkg.com](https://yarnpkg.com)
 - [bundlephobia-cli](https://github.com/AdrieanKhisbe/bundle-phobia-cli) - A Command Line client for bundlephobia
 - [importcost](https://atom.io/packages/importcost) - An Atom plugin to display size of imported packages
+- [JS Bundle Size Cross-Browser Extension](https://github.com/vicrazumov/js-bundle-size) - Chrome and Firefox extension automatically adding package size to the github and npm pages.
 
 ## Support 
 Liked bundlephobia? Used it's API to build something cool? Let us know! 


### PR DESCRIPTION
Hi. This adds a link to my cross-browser extension, that automatically fetches bundle size data from bundlephobia and adds it to the github and npm pages.
![image](https://user-images.githubusercontent.com/4419866/52996122-dba0fc00-341c-11e9-8d0c-6ee68500541c.png)
![image](https://user-images.githubusercontent.com/4419866/52996130-e3f93700-341c-11e9-8d69-214ea6d2dd33.png)
