### PR TITLE
Add word-break to SimilarPackageCard component

### DIFF
--- a/client/components/SimilarPackageCard/SimilarPackageCard.scss
+++ b/client/components/SimilarPackageCard/SimilarPackageCard.scss
@@ -70,6 +70,7 @@
   color: $raven;
   line-height: 1.5;
   margin: $global-spacing 0 0 0;
+  word-break: break-word;
 
   .similar-package-card--empty & {
     text-transform: uppercase;


### PR DESCRIPTION
To prevent overflow in the case when a package contains a long description, I added the word-break property with break-word value.

**How to reproduce:**
1. Go to https://bundlephobia.com
2. Type "redux" in the search field
3. Scroll to Similar Packages section

**Actual:**
<img width="1153" alt="Actual" src="https://user-images.githubusercontent.com/15981489/58595224-9c364700-8278-11e9-9499-f3889f2e7358.png">

**Expected:**
<img width="1153" alt="Expected" src="https://user-images.githubusercontent.com/15981489/58595248-b96b1580-8278-11e9-8cfe-c07a705518f3.png">
