### PR TITLE
Fix apostrophe escape typo in BarGraph.js

### DIFF
--- a/client/components/BarGraph/BarGraph.js
+++ b/client/components/BarGraph/BarGraph.js
@@ -93,7 +93,7 @@ export default class BarGraph extends PureComponent {
             )}
             {options.isFirstSideEffectFree && (
               <div
-                data-balloon={`Was marked side-effect free. ${(reading.hasJSNext || reading.hasJSModule) ? 'Supports ES2015 exports also, hence fully tree-shakeable' : 'Doesn\t export ESM yet, limited tree-shake ability'}`}
+                data-balloon={`Was marked side-effect free. ${(reading.hasJSNext || reading.hasJSModule) ? 'Supports ES2015 exports also, hence fully tree-shakeable' : 'Doesn\'t export ESM yet, limited tree-shake ability'}`}
                 className="bar-graph__bar-symbol"
               >
                 <SideEffectIcon/>


### PR DESCRIPTION
Hello! A very, very simple PR here... 

A string in BarGraph.js (for the indicator above the bars that indicates side-effect free w/o ESM) read `doesn\t` instead of `doesn\'t`, causing a tab to appear instead of an apostrophe.

Before: (from https://bundlephobia.com/result?p=@sindresorhus/is@1.2.0)

<img width="527" alt="Screen Shot 2019-10-12 at 10 39 39 AM copy" src="https://user-images.githubusercontent.com/1703673/66797015-70d69080-eed7-11e9-8078-3291cba33901.png">


After:

<img width="516" alt="Screen Shot 2019-10-12 at 10 52 46 AM copy" src="https://user-images.githubusercontent.com/1703673/66797028-76cc7180-eed7-11e9-9f26-904af7ffcbe8.png">

Thanks! :)