### PR TITLE
Fix ProgressHex mount blocking render for several seconds

### DIFF
--- a/client/components/ProgressHex/progress-hex-timeline.js
+++ b/client/components/ProgressHex/progress-hex-timeline.js
@@ -81,9 +81,7 @@ export default class ProgressHexAnimator {
     }
 
     timeline.add(fadeInRings)
-    for (let i = 0; i <= 50; i++) {
-      timeline.add(quakeCircles)
-    }
+    timeline.add(quakeCircles)
     return timeline
   }
 }


### PR DESCRIPTION
Fixes #234 

Seems that `ProgressHexAnimator` mounts to the `anime` timeline redundantly in a loop, where a single invocation does the same thing. This brings `tl.add()` runtime down to 42ms with the same profiler settings, down from 6000ms+

![Screen Shot 2019-10-27 at 9 12 06 AM](https://user-images.githubusercontent.com/13258203/67635968-e0665b80-f899-11e9-8213-1eb308c81e07.png)
