### PR TITLE
Improve <BarGraph/> styling

### DIFF
--- a/client/components/BarGraph/BarGraph.js
+++ b/client/components/BarGraph/BarGraph.js
@@ -5,6 +5,21 @@ import TreeShakeIcon from '../Icons/TreeShakeIcon'
 import SideEffectIcon from '../Icons/SideEffectIcon'
 import './BarGraph.scss'
 
+const BarLegend = () => {
+  return (
+    <div className="bar-graph__legend">
+      <div className="bar-graph__legend__bar1">
+        <div className="bar-graph__legend__colorbox"/>
+        Min
+      </div>
+      <div className="bar-graph__legend__bar2">
+        <div className="bar-graph__legend__colorbox"/>
+        GZIP
+      </div>
+    </div>
+  )
+}
+
 
 export default class BarGraph extends PureComponent {
   static propTypes = {
@@ -127,6 +142,7 @@ export default class BarGraph extends PureComponent {
 
     return (
       <div className="bar-graph-container">
+        <BarLegend/>
         <figure className="bar-graph">
           {
             readings.map((reading, index) => (
@@ -139,16 +155,6 @@ export default class BarGraph extends PureComponent {
             ))
           }
         </figure>
-        <div className="bar-graph__legend">
-          <div className="bar-graph__legend__bar1">
-            <div className="bar-graph__legend__colorbox"/>
-            Min
-          </div>
-          <div className="bar-graph__legend__bar2">
-            <div className="bar-graph__legend__colorbox"/>
-            GZIP
-          </div>
-        </div>
       </div>
     )
   }

--- a/client/components/BarGraph/BarGraph.scss
+++ b/client/components/BarGraph/BarGraph.scss
@@ -96,15 +96,17 @@ $bar-grow-duration: 0.4s;
 
 .bar-graph__bar-version {
   @include font-size-xs;
+  position: absolute;
   z-index: 33;
   font-weight: $font-weight-light;
-  transform: rotate(-90deg) translateX(#{-$global-spacing * 1.5});
+  white-space: nowrap;
+  transform-origin: right;
+  transform: translate(calc(-100% + #{-$global-spacing * 1.5}), #{-$global-spacing * 1.5}) rotate(-90deg);
   font-variant-numeric: tabular-nums;
   color: lighten($raven, 15%);
   transition: opacity 0.2s, color 0.2s;
   font-family: $font-family-code;
   letter-spacing: -1px;
-  direction: rtl;
   line-height: 1;
   cursor: pointer;
   max-height: $bar-width;
@@ -126,7 +128,7 @@ $bar-grow-duration: 0.4s;
 
 .bar-graph__legend {
   @include font-size-xs;
-  padding-top: $global-spacing;
+  padding-bottom: $global-spacing;
   display: flex;
   text-transform: uppercase;
   justify-content: center;


### PR DESCRIPTION
**Before**
<img width="522" alt="Screenshot 2019-11-07 at 17 12 08" src="https://user-images.githubusercontent.com/9800850/68406238-c6722600-0181-11ea-88b6-63694ae66f14.png">

As we may notice there are 2 problems here:
- version label pushes the bar so one might come to wrong conclusions solely by looking at bars' heights
- RTL used for layout purposes~ makes that label look weird (a hyphen is misplaced)

**After**
<img width="528" alt="Screenshot 2019-11-07 at 17 26 38" src="https://user-images.githubusercontent.com/9800850/68407398-c96e1600-0183-11ea-9f72-450b15ec4575.png">
