### PR TITLE
Revert "Improve <BarGraph/> styling"

### DIFF
--- a/client/components/BarGraph/BarGraph.js
+++ b/client/components/BarGraph/BarGraph.js
@@ -5,21 +5,6 @@ import TreeShakeIcon from '../Icons/TreeShakeIcon'
 import SideEffectIcon from '../Icons/SideEffectIcon'
 import './BarGraph.scss'
 
-const BarLegend = () => {
-  return (
-    <div className="bar-graph__legend">
-      <div className="bar-graph__legend__bar1">
-        <div className="bar-graph__legend__colorbox"/>
-        Min
-      </div>
-      <div className="bar-graph__legend__bar2">
-        <div className="bar-graph__legend__colorbox"/>
-        GZIP
-      </div>
-    </div>
-  )
-}
-
 
 export default class BarGraph extends PureComponent {
   static propTypes = {
@@ -142,7 +127,6 @@ export default class BarGraph extends PureComponent {
 
     return (
       <div className="bar-graph-container">
-        <BarLegend/>
         <figure className="bar-graph">
           {
             readings.map((reading, index) => (
@@ -155,6 +139,16 @@ export default class BarGraph extends PureComponent {
             ))
           }
         </figure>
+        <div className="bar-graph__legend">
+          <div className="bar-graph__legend__bar1">
+            <div className="bar-graph__legend__colorbox"/>
+            Min
+          </div>
+          <div className="bar-graph__legend__bar2">
+            <div className="bar-graph__legend__colorbox"/>
+            GZIP
+          </div>
+        </div>
       </div>
     )
   }

--- a/client/components/BarGraph/BarGraph.scss
+++ b/client/components/BarGraph/BarGraph.scss
@@ -96,17 +96,15 @@ $bar-grow-duration: 0.4s;
 
 .bar-graph__bar-version {
   @include font-size-xs;
-  position: absolute;
   z-index: 33;
   font-weight: $font-weight-light;
-  white-space: nowrap;
-  transform-origin: right;
-  transform: translate(calc(-100% + #{-$global-spacing * 1.5}), #{-$global-spacing * 1.5}) rotate(-90deg);
+  transform: rotate(-90deg) translateX(#{-$global-spacing * 1.5});
   font-variant-numeric: tabular-nums;
   color: lighten($raven, 15%);
   transition: opacity 0.2s, color 0.2s;
   font-family: $font-family-code;
   letter-spacing: -1px;
+  direction: rtl;
   line-height: 1;
   cursor: pointer;
   max-height: $bar-width;
@@ -128,7 +126,7 @@ $bar-grow-duration: 0.4s;
 
 .bar-graph__legend {
   @include font-size-xs;
-  padding-bottom: $global-spacing;
+  padding-top: $global-spacing;
   display: flex;
   text-transform: uppercase;
   justify-content: center;


### PR DESCRIPTION
Reverts pastelsky/bundlephobia#241, seems to be causing issues with version number alignment 
<img width="599" alt="Screenshot 2019-12-30 at 10 29 15 AM" src="https://user-images.githubusercontent.com/8946207/71568681-3c926980-2aef-11ea-9cf0-837c3acba08a.png">
