### PR TITLE
Correct abbreviation for megabyte

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -21,7 +21,7 @@ const formatSize = (value) => {
     unit = 'kB'
     size = value / 1024
   } else {
-    unit = 'mB'
+    unit = 'MB'
     size = value / 1024 / 1024
   }
 


### PR DESCRIPTION
The abbreviation for the mega- prefix is usually “M”, rather than “m”, as the
latter is usually used for milli-. Wikipedia points out that an uppercase “K” is sometimes used for kilobyte (https://en.wikipedia.org/wiki/Kilobyte), but says nothing about using a lowercase “m” for megabyte (https://en.wikipedia.org/wiki/Megabyte), so I don’t think this is common.

While we’re here, what would you say to using ”KiB” and “MiB” as unambiguous prefixes (https://en.wikipedia.org/wiki/Kibibyte), since the definition used in the code is 1 kB = 1024 B?