### PR TITLE
only block packages in @types org, not anything starting with "@types"

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -32,7 +32,7 @@ module.exports = {
   ],
 
   unsupported: [
-    { test: /@types/, reason: 'Type packages don\'t usually contain any runtime code.'}
+    { test: /^@types\//, reason: 'Type packages don\'t usually contain any runtime code.'}
   ],
 
   CACHE: {


### PR DESCRIPTION
Right now it blocks this package: https://unpkg.com/@typestrange/decode.