### PR TITLE
In AutocompleteInput, show package name if highlight is not present

### DIFF
--- a/client/components/AutocompleteInput/AutocompleteInput.js
+++ b/client/components/AutocompleteInput/AutocompleteInput.js
@@ -32,7 +32,11 @@ export default class AutocompleteInput extends PureComponent {
         'autocomplete-input__suggestion--highlight': isHighlighted,
       })}
     >
-      <div dangerouslySetInnerHTML={{ __html: item.highlight }} />
+      {item.highlight != null ? (
+        <div dangerouslySetInnerHTML={{ __html: item.highlight }} />
+      ) : (
+        <div>{item.package.name}</div>
+      )}
 
       <div className="autocomplete-input__suggestion-description">
         {item.package.description}


### PR DESCRIPTION
Fixes #332.

This falls back to `package.name` if `highlight` is not present. The item will not get a highlight, but at least it's there 🤷‍♂️

This is akin to how npms.io itself does it: https://github.com/npms-io/npms-www/blob/47e91a387018d27d37e5e1b688369b6cdfdc60da/src/shared/containers/search-box/SearchBox.js#L99-L102

Looks like this (that is, right except without highlighting):
![image](https://user-images.githubusercontent.com/2641501/78609436-fb82c180-7862-11ea-80cc-e6ef428edbb9.png)
