### PR TITLE
Use JSX's sanitizer for descriptions, drop DOMPurify

### DIFF
--- a/client/components/QuickStatsBar/QuickStatsBar.js
+++ b/client/components/QuickStatsBar/QuickStatsBar.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import DOMPurify from 'dompurify'
 import './QuickStatsBar.scss'
 
 import TreeShakeIcon from '../../assets/tree-shake.svg'
@@ -32,7 +31,7 @@ class QuickStatsBar extends Component {
       trimmed = description.trim()
     }
 
-    return DOMPurify.sanitize(trimmed)
+    return trimmed
   }
 
   render() {
@@ -55,11 +54,12 @@ class QuickStatsBar extends Component {
           {statItemCount < 2 && (
             <span
               className="quick-stats-bar__stat--description-content"
-              dangerouslySetInnerHTML={{ __html: this.getTrimmedDescription() }}
               style={{
                 maxWidth: `${500 - statItemCount * 280}px`,
               }}
-            />
+            >
+              {this.getTrimmedDescription()}
+            </span>
           )}
         </div>
 

--- a/client/components/SimilarPackageCard/SimilarPackageCard.js
+++ b/client/components/SimilarPackageCard/SimilarPackageCard.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import cx from 'classnames'
 import { formatSize } from 'utils'
 import Link from 'next/link'
-import DOMPurify from 'dompurify'
 
 import TreeShakeIcon from '../../assets/tree-shake.svg'
 import PlusIcon from '../../assets/plus.svg'
@@ -113,12 +112,9 @@ export default class SimilarPackageCard extends Component {
                 <GithubIcon className="similar-package-card__github-icon" />
               </a>
             </div>
-            <p
-              className="similar-package-card__description"
-              dangerouslySetInnerHTML={{
-                __html: DOMPurify.sanitize(pack.description),
-              }}
-            />
+            <p className="similar-package-card__description">
+              {pack.description}
+            </p>
           </div>
           {footer}
         </a>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "debug": "^4.1.1",
-    "dompurify": "^2.0.8",
     "dotenv": "^8.2.0",
     "dotenv-defaults": "^1.1.1",
     "execa": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5526,11 +5526,6 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-dompurify@^2.0.8:
-  version "2.0.8"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/dompurify/-/dompurify-2.0.8.tgz#6ef89d2d227d041af139c7b01d9f67ed59c2eb3c"
-  integrity sha1-bvidLSJ9BBrxOcewHZ9n7VnC6zw=
-
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"


### PR DESCRIPTION
Fixes #334.

While XSS is not possible due to the use of DOMPurify, what DOMPurify does is not actually what we want there. If the description contains any HTML, we don't want to display it at all, just show the text. That's why I changed these two up to just use JSX/React's normal HTML escaping.

I've also dropped DOMPurify because we don't need it at the moment.