### PR TITLE
New package suggestion category: react-color-picker

### DIFF
--- a/server/middlewares/similar-packages/fixtures.js
+++ b/server/middlewares/similar-packages/fixtures.js
@@ -414,6 +414,15 @@ const categories = {
       'react-select',
     ],
   },
+  'react-color-picker': {
+    name: 'React based color picker components',
+    tags: [
+      { tag: 'react', weight: Weight.NORMAL },
+      { tag: 'color', weight: Weight.NORMAL },
+      { tag: 'color picker', weight: Weight.NORMAL },
+    ],
+    similar: ['react-color', 'react-colorful', 'react-input-color'],
+  },
   'react-head-meta': {
     name: 'React based meta tags management',
     tags: [


### PR DESCRIPTION
Hi! I really love your project (even [added 2 bundlephobia badges](https://github.com/badgen/badgen.net/pull/428) to badgen.net) and think you help the community a lot.

Several months ago I found out that the most popular React color picker component (`react-color`) costs 140 KB, so I created a lightweight alternative called [`react-colorful`](https://github.com/omgovich/react-colorful) which is 10-20 times lighter. It already has its own community, several maintainers and enough weekly downloads to be offered as an alternative to `react-color`.

See: https://github.com/omgovich/react-colorful#why-react-colorful

![image](https://user-images.githubusercontent.com/206567/94992753-c0084c00-0594-11eb-9de7-32965d788c78.png)

Thanks!