### PR TITLE
Add Rollpkg to the built using bundlephobia list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [bundlephobia-cli](https://github.com/AdrieanKhisbe/bundle-phobia-cli) - A Command Line client for bundlephobia
 - [importcost](https://atom.io/packages/importcost) - An Atom plugin to display size of imported packages
 - [JS Bundle Size Cross-Browser Extension](https://github.com/vicrazumov/js-bundle-size) - Chrome and Firefox extension automatically adding package size to the github and npm pages.
+- [Rollpkg](https://github.com/rafgraph/rollpkg) - A build tool to create packages with Rollup and TypeScript
 
 ## Support
 


### PR DESCRIPTION
[Rollpkg](https://github.com/rafgraph/rollpkg) calculates Bundlephobia package stats (locally) as part of each `rollpkg build`.

Thanks for creating and maintaining Bundlephobia, it's super useful, both the website and for calculating stats locally with `package-build-stats`.

![](https://user-images.githubusercontent.com/11911299/100155245-ebad0180-2e74-11eb-86bc-71da0ba95866.gif)
