### PR TITLE
Disabled cache for placeholder images in /stats-image API

### DIFF
--- a/server/middlewares/generateImg.middleware.js
+++ b/server/middlewares/generateImg.middleware.js
@@ -29,6 +29,9 @@ async function generateImgMiddleware(ctx, next) {
     })
   } catch (err) {
     console.error(err)
+    ctx.cacheControl = {
+      noCache: true,
+    }
     await send(ctx, 'client/assets/public/android-chrome-192x192.png')
   }
 }


### PR DESCRIPTION
Fixes https://github.com/pastelsky/bundlephobia/issues/424