### PR TITLE
fix: version text below bar

### DIFF
--- a/client/components/BarGraph/BarGraph.scss
+++ b/client/components/BarGraph/BarGraph.scss
@@ -104,10 +104,13 @@ $bar-grow-duration: 0.4s;
   transition: opacity 0.2s, color 0.2s;
   font-family: $font-family-code;
   letter-spacing: -1px;
-  direction: rtl;
   line-height: 1;
   cursor: pointer;
-  max-height: $bar-width;
+  height: $bar-width;
+  text-align: end;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 
   .bar-graph-container:hover & {
     color: $raven;


### PR DESCRIPTION
Hi!
A simple PR here to fix #250

I have removed the style `direction: rtl` and added a display flex with some extra.

Before: 
![image](https://user-images.githubusercontent.com/37420305/104079402-11bf1300-5223-11eb-9621-678e9c38f0f1.png)

After:
![image](https://user-images.githubusercontent.com/37420305/104079387-fb18bc00-5222-11eb-9364-3a69b361ff36.png)

Thanks :)
