### PR TITLE
fix: incorrect time units for emerging 4G in generation of open graph image

### DIFF
--- a/utils/draw.utils.js
+++ b/utils/draw.utils.js
@@ -198,7 +198,7 @@ function drawStatsImg({
 
   const fourGGroup = createStatGroup(
     fourGTime.unit === 'ms' ? fourGTime.size : fourGTime.size.toFixed(1),
-    threeGTime.unit,
+    fourGTime.unit,
     'emerging 4G',
     {
       // originY: 'center',


### PR DESCRIPTION
Small typo fix for the bug I reported in #549.