### PR TITLE
Fix download sizes and time estimates according to ISO

### DIFF
--- a/pages/package/[...packageString]/ResultPage.js
+++ b/pages/package/[...packageString]/ResultPage.js
@@ -383,7 +383,7 @@ class ResultPage extends PureComponent {
                         label="Emerging 4G"
                         infoText={`Download Speed: ⬇️ ${
                           DownloadSpeed.FOUR_G / 1000
-                        } mB/s`}
+                        } MB/s`}
                       />
                     </div>
                   </div>

--- a/utils/index.js
+++ b/utils/index.js
@@ -15,10 +15,10 @@ const formatSize = value => {
     size = value
   } else if (Math.log10(value) < 6) {
     unit = 'kB'
-    size = value / 1024
+    size = value / 1000
   } else {
     unit = 'MB'
-    size = value / 1024 / 1024
+    size = value / 1000 / 1000
   }
 
   return { unit, size }
@@ -49,8 +49,8 @@ const DownloadSpeed = {
 }
 const getTimeFromSize = sizeInBytes => {
   return {
-    threeG: sizeInBytes / 1024 / DownloadSpeed.THREE_G,
-    fourG: sizeInBytes / 1024 / DownloadSpeed.FOUR_G,
+    threeG: sizeInBytes / 1000 / DownloadSpeed.THREE_G,
+    fourG: sizeInBytes / 1000 / DownloadSpeed.FOUR_G,
   }
 }
 


### PR DESCRIPTION
Values shown for sizes and time estimates are incorrect. _Kilo_ is a prefix for 10^3, _Mega_ for 10^6. _mB/s_ makes no sense -- millibytes.

Let's stick to ISO/IEC 80000-13. Either we can change the divisors to 1000, or change the prefixes to _kiB_ and _MiB_. Let's not confuse users by binary prefixes, though.