### PR TITLE
Fixed npmjs.com link

### DIFF
--- a/client/components/QuickStatsBar/QuickStatsBar.js
+++ b/client/components/QuickStatsBar/QuickStatsBar.js
@@ -95,7 +95,7 @@ class QuickStatsBar extends Component {
         <div className="quick-stats-bar__stat">
           <a
             className="quick-stats-bar__link"
-            href={'https://npmjs.org/package/' + name}
+            href={'https://npmjs.com/package/' + name}
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
On certain browser configurations, npmjs.org doesn't re-route to npmjs.com for some reason, and this would fix that