### PR TITLE
Use MB for megabytes in 4G speed explanation

### DIFF
--- a/pages/package/[...packageString]/ResultPage.js
+++ b/pages/package/[...packageString]/ResultPage.js
@@ -383,7 +383,7 @@ class ResultPage extends PureComponent {
                         label="Emerging 4G"
                         infoText={`Download Speed: ⬇️ ${
                           DownloadSpeed.FOUR_G / 1000
-                        } mB/s`}
+                        } MB/s`}
                       />
                     </div>
                   </div>


### PR DESCRIPTION
Megabytes is usually written as MB, not mB. I was surprised for a moment when I saw "mB/s" and wasn't quite sure what was being measured.

https://en.wikipedia.org/wiki/Megabyte