### PR TITLE
Fix when there is no input, click search btn to jump to 404

### DIFF
--- a/pages/index.page.js
+++ b/pages/index.page.js
@@ -15,6 +15,9 @@ export default class Home extends PureComponent {
   }
 
   handleSearchSubmit = value => {
+    if (!value) {
+      return
+    }
     Analytics.performedSearch(value.trim())
     Router.push(`/package/${value.trim()}`)
   }


### PR DESCRIPTION
> Fix when there is no input, click search btn to jump to /package/  and the page is not found (404)

Added judgment of empty string search value