### PR TITLE
add checksumBehavior with update value to allow installing dependencies with yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ plugins:
     spec: '@yarnpkg/plugin-interactive-tools'
 
 yarnPath: .yarn/releases/yarn-3.2.0.cjs
+
+checksumBehavior: update


### PR DESCRIPTION
By default, Yarn will [throw an exception](https://yarnpkg.com/configuration/yarnrc) on yarn install if it detects that a package doesn't match the checksum stored within the lockfile. This was the change applied:

1.  Open your .yarnrc.yml.
2.  Add the following configuration option: ` checksumBehavior: "update"`