### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "prod": "yarn run build && yarn start",
     "test": "jest",
     "test:watch": "jest --watch",
-    "postinstall": "yarn run build",
     "prettier": "prettier --write '**/*.{html,js,json,css,scss,jsx,flow,md,yml,yaml}'",
     "lint": "next lint",
     "deploy": "git branch -D gh-pages && git checkout -b gh-pages && yarn run build && yarn run export && cp -R out/* . "


### PR DESCRIPTION
This is a proposal to remove `postinstall` script.

I'm not entirely sure why it may be needed for an app, so please feel free to toss this PR if there is a valid reason for `postinstall` script in this project.

**Reasoning**

`postinstall` script often interferes with the dev workflow. Here is a sample scenario: 
1) Imagine you are working on a new feature and your code base is not in a perfect shape so it won't pass `tsc` compilation
2) Now imagine you need to add a new dependency to the project, and you run `yarn add <dependency>` which fails due to `yarn build` failure

cc @darasus 