### PR TITLE
TypeScript migration - scan and scan-results pages

### DIFF
--- a/client/api.ts
+++ b/client/api.ts
@@ -52,7 +52,7 @@ export default class API {
   }
 
   static getInfo(packageString: string) {
-    return API.get(`/api/size?package=${packageString}&record=true`)
+    return API.get<any>(`/api/size?package=${packageString}&record=true`)
   }
 
   static getExports(packageString: string) {

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,7 @@
 const path = require('path')
 
 module.exports = {
-  pageExtensions: ['page.js', 'page.tsx'],
+  pageExtensions: ['page.js', 'page.ts', 'page.tsx'],
   sassOptions: {
     includePaths: [path.join(__dirname, 'stylesheets')],
   },

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "@types/react-autocomplete": "^1.8.6",
     "@types/react-dom": "^18.0.8",
     "@types/react-sidebar": "^3.0.2",
+    "@types/semver": "7.1.0",
     "autoprefixer": "^9.8.6",
     "eslint": "^8.26.0",
     "eslint-config-next": "^13.0.1",

--- a/pages/scan-results/index.page.js
+++ b/pages/scan-results/index.page.js
@@ -1,3 +1,0 @@
-import ScanResults from './ScanResults'
-
-export default ScanResults

--- a/pages/scan-results/index.page.ts
+++ b/pages/scan-results/index.page.ts
@@ -1,0 +1,1 @@
+export { default } from './ScanResults'

--- a/pages/scan/index.page.js
+++ b/pages/scan/index.page.js
@@ -1,3 +1,0 @@
-import Scan from './Scan'
-export { getServerSideProps } from './Scan'
-export default Scan

--- a/pages/scan/index.page.ts
+++ b/pages/scan/index.page.ts
@@ -1,0 +1,1 @@
+export { default } from './Scan'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,6 +3746,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:7.1.0":
+  version: 7.1.0
+  resolution: "@types/semver@npm:7.1.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: 1f10d876b1ef427c031178ac8c92b02a22c9323ed4f932e55f76a2d87713ec0e10d13a7bd1d66bfce31627e065ab57bfeb47bdcc4eafbb181805aaf2ca655536
+  languageName: node
+  linkType: hard
+
 "@types/serve-static@npm:*":
   version: 1.15.0
   resolution: "@types/serve-static@npm:1.15.0"
@@ -5690,6 +5699,7 @@ __metadata:
     "@types/react-autocomplete": ^1.8.6
     "@types/react-dom": ^18.0.8
     "@types/react-sidebar": ^3.0.2
+    "@types/semver": 7.1.0
     animejs: ^3.2.1
     array-to-sentence: ^2.0.0
     autoprefixer: ^9.8.6


### PR DESCRIPTION
Migrate `scan` and `scan-results` pages to TypeScript.