### PR TITLE
fix: clear suggestions if the input field is an empty string.

### DIFF
--- a/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
+++ b/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
@@ -43,6 +43,10 @@ export function useAutocompleteInput({
     if (trimmedValue.length > 1) {
       getSuggestions(name)
     }
+
+    if (!trimmedValue) {
+      setSuggestions([])
+    }
   }
 
   return {


### PR DESCRIPTION
#### Issue
The autocomplete input will remember suggestions made even after clearing the input field.

#### Solution
Clear the `suggestions` state variable if the input field is an empty string.