### PR TITLE
Limit bars in graph

### DIFF
--- a/pages/package/[...packageString]/ResultPage.js
+++ b/pages/package/[...packageString]/ResultPage.js
@@ -213,9 +213,9 @@ class ResultPage extends PureComponent {
     const sorted = formattedResults.sort((packageA, packageB) =>
       semver.compare(packageA.version, packageB.version)
     )
-    return typeof window !== 'undefined' && window.innerWidth < 640
+    return typeof window !== 'undefined' && window.innerWidth < 1080
       ? sorted.slice(-10)
-      : sorted
+      : sorted.slice(-15)
   }
 
   handleBarClick = reading => {


### PR DESCRIPTION
Fix #734 

For packages with a long history (such as `react-router`) the bar graph was overflowing over the bundle stats.

<img width="1496" alt="Screenshot 2022-12-24 at 1 36 47 PM" src="https://user-images.githubusercontent.com/19194187/209452562-5e934461-c91d-4919-af29-a11e7bf383fd.png">

My quick fix for this was simply to limit the total historical items shown for all screen sizes. Probably not the perfect long term solution but should sort things out for now. If there is interest I could take a crack at making it scrollable instead in a future pr.

Perhaps related to #714

---

If you would like to test locally, here is how I patched in a long history:

Copy the results of this url:
```
https://bundlephobia.com/api/package-history?package=react-router@6.6.1
```

Return them here something like the following
```ts
// client/api.ts
  static getHistory(packageString: string) {
    if (packageString.startsWith('react-router')) {
      return Promise.resolve(
        /* JSON result from above url here */
      )
    }
  }
```