### PR TITLE
styles/contain bar graph when overflow

### DIFF
--- a/client/components/BarGraph/BarGraph.scss
+++ b/client/components/BarGraph/BarGraph.scss
@@ -20,7 +20,8 @@ $bar-grow-duration: 0.4s;
   padding-bottom: 6vh;
   display: flex;
   margin: 0;
-  justify-content: center;
+  justify-content: flex-start;
+  overflow-x: auto;
 }
 
 .bar-graph__bar-group {


### PR DESCRIPTION
This PR revises the styling in the `bar-graph` section. When there's a content overflow, the new CSS contains the bars in the section and display a scrolling control.

**Before**
<img width="1363" alt="Screen Shot 2022-12-26 at 08 02 33" src="https://user-images.githubusercontent.com/4335023/209515517-e31c6b3e-331a-46cc-a290-468367daa8f9.png">

**After**
<img width="1363" alt="Screen Shot 2022-12-26 at 08 02 06" src="https://user-images.githubusercontent.com/4335023/209515509-98d43240-952d-4d64-8790-c08f3b478fcb.png">

