### PR TITLE
[fix] autocomplete empty input request

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,10 +1,11 @@
-import { parsePackageString } from '../utils/common.utils'
+const { parsePackageString, isEmpty } = require('../utils/common.utils')
 
 describe('parsePackageString', () => {
   it('handles scoped packages correctly', () => {
     expect(parsePackageString('@babel/core@9.8.0')).toEqual({
       scoped: true,
       name: '@babel/core',
+      scope: 'babel',
       version: '9.8.0',
     })
   })
@@ -13,6 +14,7 @@ describe('parsePackageString', () => {
     expect(parsePackageString('@babel/core')).toEqual({
       scoped: true,
       name: '@babel/core',
+      scope: 'babel',
       version: null,
     })
   })
@@ -47,5 +49,17 @@ describe('parsePackageString', () => {
       name: 'chart.js',
       version: '0.7.0-beta',
     })
+  })
+})
+
+describe('isEmpty', () => {
+  it('should return true for empty string', () => {
+    expect(isEmpty('')).toBe(true)
+    expect(isEmpty('   ')).toBe(true)
+  })
+
+  it('should return false for non-empty string', () => {
+    expect(isEmpty('Hello')).toBe(false)
+    expect(isEmpty('  Hello   ')).toBe(false)
   })
 })

--- a/client/components/AutocompleteInput/AutocompleteInput.scss
+++ b/client/components/AutocompleteInput/AutocompleteInput.scss
@@ -8,6 +8,34 @@
   width: 100%;
 }
 
+.autocomplete-input__container--error {
+  animation-duration: 0.75s;
+  animation-fill-mode: both;
+  animation-name: shakeX;
+}
+
+@keyframes shakeX {
+  from,
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+
+  10%,
+  30%,
+  50%,
+  70%,
+  90% {
+    transform: translate3d(-6px, 0, 0);
+  }
+
+  20%,
+  40%,
+  60%,
+  80% {
+    transform: translate3d(6px, 0, 0);
+  }
+}
+
 .autocomplete-input {
   width: 40vw;
   border: none;

--- a/client/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/client/components/AutocompleteInput/AutocompleteInput.tsx
@@ -34,6 +34,8 @@ export const AutocompleteInput = ({
     handleInputChange,
     setIsMenuVisible,
     setSuggestions,
+    isValidationError,
+    errorClearHandler,
   } = useAutocompleteInput({ initialValue, onSubmit: onSearchSubmit })
   const { searchFontSize } = useFontSize({ value })
 
@@ -51,7 +53,9 @@ export const AutocompleteInput = ({
         className={cx('autocomplete-input__container', className, {
           'autocomplete-input__container--menu-visible':
             isMenuVisible && !!suggestions.length,
+          'autocomplete-input__container--error': isValidationError,
         })}
+        onAnimationEnd={errorClearHandler}
       >
         <AutoComplete
           getItemValue={item => item.package.name}

--- a/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
+++ b/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import debounce from 'debounce'
 
-import { parsePackageString } from '../../../../utils/common.utils'
+import { parsePackageString, isEmpty } from '../../../../utils/common.utils'
 import API from '../../../api'
 
 interface UseAutocompleteInputArgs {
@@ -16,6 +16,7 @@ export function useAutocompleteInput({
   const [value, setValue] = React.useState(initialValue)
   const [suggestions, setSuggestions] = React.useState<any[]>([])
   const [isMenuVisible, setIsMenuVisible] = React.useState(false)
+  const [isValidationError, setIsValidationError] = React.useState(false)
 
   const getSuggestions = React.useMemo(
     () =>
@@ -27,9 +28,17 @@ export function useAutocompleteInput({
     []
   )
 
+  const errorClearHandler = () => {
+    setIsValidationError(false)
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    onSubmit(value)
+    if (!isEmpty(value)) {
+      onSubmit(value)
+    } else {
+      setIsValidationError(true)
+    }
   }
 
   const handleInputChange = (
@@ -57,5 +66,7 @@ export function useAutocompleteInput({
     handleInputChange,
     setIsMenuVisible,
     setSuggestions,
+    isValidationError,
+    errorClearHandler,
   }
 }

--- a/utils/common.utils.js
+++ b/utils/common.utils.js
@@ -50,4 +50,13 @@ function sanitizeHTML(html) {
   })
 }
 
-module.exports = { parsePackageString, daysFromToday, sanitizeHTML }
+/**
+ * replace it when refactor to TS
+ * @param {string} str - input string
+ * @returns boolean
+ * */
+function isEmpty(str) {
+  return !str.trim().length
+}
+
+module.exports = { parsePackageString, daysFromToday, sanitizeHTML, isEmpty }


### PR DESCRIPTION
### Description
- add check before request send
- add little animation on input error (thought it not form with huge list of inputs, can use some animation)
- add tests and fix parser old test (some of them were fail)

### Related Issue
Closes #770

### Context
I've seen few options to fix this:
- add check to handler in component (with/without animation)
- add `required` attr to autocomplete input [(mean this one)](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_required), it's easier and native, but in diff browser we'll get different design of tooltips. And I thought in this case we can use more complex solution and get animation and controlled view

Check pls and if animation is not need, I can replace it with `required` attr or another way you prefer )

## Screenshots:
![example-shake](https://user-images.githubusercontent.com/12436035/233198746-bc86b3ee-1082-43a0-a13b-2bb3a4263c5f.gif)


