### PR TITLE
fix bug:  Browser back button doesn't work

### DIFF
--- a/pages/package/[...packageString]/ResultPage.js
+++ b/pages/package/[...packageString]/ResultPage.js
@@ -69,7 +69,11 @@ class ResultPage extends PureComponent {
     const currentPackage = parsePackageString(packageString)
     const nextPackage = parsePackageString(nextPackageString)
 
-    if (currentPackage.name !== nextPackage.name) {
+    const isPackageDifferent =
+      currentPackage.name !== nextPackage.name ||
+      currentPackage.version !== nextPackage.version
+
+    if (isPackageDifferent) {
       this.handleSearchSubmit(nextPackageString)
     }
   }


### PR DESCRIPTION
**Description**

Resolved an issue where the browser back button was not working as expected.
Previously, the code only considered package name information for duplicate detection. Now, it also includes the package version in the duplicate detection process to provide more accurate results.

Closes #171 