### PR TITLE
fix: Kibibyte to Kilobyte

### DIFF
--- a/pages/package/[...packageString]/ResultPage.js
+++ b/pages/package/[...packageString]/ResultPage.js
@@ -385,7 +385,7 @@ class ResultPage extends PureComponent {
                         label="Slow 3G"
                         infoText={referenceSpeedInfoText(
                           DownloadSpeed.THREE_G,
-                          'kB/s'
+                          'KB/s'
                         )}
                       />
                       <Stat
@@ -394,7 +394,7 @@ class ResultPage extends PureComponent {
                         label="Emerging 4G"
                         infoText={referenceSpeedInfoText(
                           DownloadSpeed.FOUR_G,
-                          'kB/s'
+                          'KB/s'
                         )}
                       />
                     </div>

--- a/pages/scan-results/ScanResults.js
+++ b/pages/scan-results/ScanResults.js
@@ -294,14 +294,14 @@ class ScanResults extends Component {
               />
               <Stat
                 className="scan-results__stat-item"
-                value={totalGZIPSize / 1024 / 30}
+                value={totalGZIPSize / 1000 / 30}
                 type={Stat.type.TIME}
                 label="2G Edge"
                 compact
               />
               <Stat
                 className="scan-results__stat-item"
-                value={totalGZIPSize / 1024 / 50}
+                value={totalGZIPSize / 1000 / 50}
                 type={Stat.type.TIME}
                 label="Slow 3G"
                 compact

--- a/utils/index.js
+++ b/utils/index.js
@@ -14,11 +14,11 @@ const formatSize = value => {
     unit = 'B'
     size = value
   } else if (Math.log10(value) < 6) {
-    unit = 'kB'
-    size = value / 1024
+    unit = 'KB'
+    size = value / 1000
   } else {
     unit = 'MB'
-    size = value / 1024 / 1024
+    size = value / 1000 / 1000
   }
 
   return { unit, size }
@@ -49,8 +49,8 @@ const DownloadSpeed = {
 }
 const getTimeFromSize = sizeInBytes => {
   return {
-    threeG: sizeInBytes / 1024 / DownloadSpeed.THREE_G,
-    fourG: sizeInBytes / 1024 / DownloadSpeed.FOUR_G,
+    threeG: sizeInBytes / 1000 / DownloadSpeed.THREE_G,
+    fourG: sizeInBytes / 1000 / DownloadSpeed.FOUR_G,
   }
 }
 

--- a/utils/rebuild.utils.js
+++ b/utils/rebuild.utils.js
@@ -212,7 +212,7 @@ async function run() {
             '%d fetched %s, diff: %d KB',
             startIndex + index,
             packStr,
-            Math.round(gzipDiff / 1024)
+            Math.round(gzipDiff / 1000)
           )
 
           if (
@@ -223,8 +223,8 @@ async function run() {
               'GZIP sizes for %s vary more than %d. Old: %d KB, After rebuild: %d KB',
               packStr,
               gzipDiff,
-              Math.round(packs[pack.packName][pack.version].gzip / 1024),
-              Math.round(res.gzip / 1024)
+              Math.round(packs[pack.packName][pack.version].gzip / 1000),
+              Math.round(res.gzip / 1000)
             )
           }
           if (
@@ -235,8 +235,8 @@ async function run() {
               'MIN sizes for %s vary more than %d. Old: %d KB, After rebuild: %d KB',
               packStr,
               minDiff,
-              Math.round(packs[pack.packName][pack.version].size / 1024),
-              Math.round(res.size / 1024)
+              Math.round(packs[pack.packName][pack.version].size / 1000),
+              Math.round(res.size / 1000)
             )
           }
         })


### PR DESCRIPTION
Data transmitted over the Internet is measured in the decimal system, so it would be more correct to measure the packet size in it. Converted packet size measurement from binary (KiB) to decimal (KB).

Now the resulting sizes will match those we get from other services and tools.