### PR TITLE
feat: add support for custom registry urls

### DIFF
--- a/utils/server.utils.js
+++ b/utils/server.utils.js
@@ -12,7 +12,10 @@ const CustomError = require('../server/CustomError')
  */
 async function resolvePackage(packageString) {
   try {
-    return await pacote.manifest(packageString, { fullMetadata: true })
+     const registryObj = process.env.REGISTRY_URL
+      ? { registry: process.env.REGISTRY_URL }
+      : {}
+    return await pacote.manifest(packageString, { fullMetadata: true, ...registryObj })
   } catch (err) {
     if (err.code === 'ETARGET') {
       throw new CustomError('PackageVersionMismatchError', null, {


### PR DESCRIPTION
If an organization has a private registry with modules stored in it, they cannot use Bundlephobia stats due to the current implementation.

Therefore, I have added a custom registry environment variable to enable them to use Bundlephobia for checking the size of their modules.

package-build-stats correspondence PR - (https://github.com/pastelsky/package-build-stats)