### PR TITLE
refactor(server): exportssizesmiddleware returns value on peek without setting ctx.body

### DIFF
--- a/server/middlewares/exportsSizes.middleware.js
+++ b/server/middlewares/exportsSizes.middleware.js
@@ -17,7 +17,8 @@ async function exportSizesMiddleware(ctx) {
   const { force, peek, package: packageQuery } = ctx.query
 
   if (peek) {
-    return { name, version, peekSuccess: false }
+    ctx.body = { name, version, peekSuccess: false }
+    return
   }
 
   const buildStart = now()


### PR DESCRIPTION
## Description

When ?peek is present the middleware returns an object but never sets ctx.body (or calls next()). In Koa this leaves the response unset, producing an empty/incorrect response or hanging the request. The same pattern does not exist in the sibling exports.middleware.js.

## Changes

- `server/middlewares/exportsSizes.middleware.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #969