### PR TITLE
refactor(utils): parsepackagestring crashes on undefined packagestring

### DIFF
--- a/utils/common.utils.js
+++ b/utils/common.utils.js
@@ -4,6 +4,7 @@
 const DOMPurify = require('dompurify')
 
 function parsePackageString(packageString) {
+  if (typeof packageString !== 'string') return { name: null, version: null, scoped: false }
   // Scoped packages
   let name,
     version,


### PR DESCRIPTION
## Description

When ctx.query.package is absent, packageQuery is undefined. Calling parsePackageString(undefined) does `undefined.lastIndexOf` which throws TypeError. This crashes the exports/exportSizes middleware on any request missing the package query param (or malformed requests), taking down the response.

## Changes

- `utils/common.utils.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #971