### PR TITLE
refactor(server): parsepackagestring called on potentially undefined packagequery

### DIFF
--- a/server/middlewares/exportsSizes.middleware.js
+++ b/server/middlewares/exportsSizes.middleware.js
@@ -7,6 +7,7 @@ const { getRequestPriority } = require('../../utils/server.utils')
 const { parsePackageString } = require('../../utils/common.utils')
 const BuildService = require('../api/BuildService')
 
+
 const cache = new Cache()
 const buildService = new BuildService()
 
@@ -28,7 +29,7 @@ async function exportSizesMiddleware(ctx) {
   ctx.cacheControl = {
     maxAge: force
       ? 0
-      : semver.valid(parsePackageString(packageQuery).version)
+      : semver.valid(parsePackageString(typeof packageQuery === 'string' ? packageQuery : '').version)
       ? CONFIG.CACHE.SIZE_API_HAS_VERSION
       : CONFIG.CACHE.SIZE_API_DEFAULT,
   }


### PR DESCRIPTION
## Description

ctx.query.package can be undefined (missing query param). Passing it to parsePackageString does `packageString.lastIndexOf` which throws TypeError. The line is outside any try/catch and after the build, so the whole request fails. Identical code exists in exports.middleware.js.

## Changes

- `server/middlewares/exportsSizes.middleware.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #973