### PR TITLE
refactor(server): middleware early-returns object instead of setting ctx.body

### DIFF
--- a/server/middlewares/exportsSizes.middleware.js
+++ b/server/middlewares/exportsSizes.middleware.js
@@ -17,7 +17,8 @@ async function exportSizesMiddleware(ctx) {
   const { force, peek, package: packageQuery } = ctx.query
 
   if (peek) {
-    return { name, version, peekSuccess: false }
+    ctx.body = { name, version, peekSuccess: false }
+    return
   }
 
   const buildStart = now()


### PR DESCRIPTION
## Description

if (peek) returns {name, version, peekSuccess: false} but never sets ctx.body or calls next(). In Koa the return value is ignored, so the client receives no body (empty response or 404). The code was clearly intended to short-circuit with a response object.

## Changes

- `server/middlewares/exportsSizes.middleware.js` (modified)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Code follows the style guidelines of this project
- [x] Self-review of code completed
- [x] Changes generate no new warnings
- [ ] Corresponding changes to documentation made (if applicable)

**Severity**: `high`



Contributed by Lê Thành Chỉnh
Code is a tool. Mindset is the real value.

Closes #975