### PR TITLE
Add build-miss rate limiting and tune global limits

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import blockBlacklistMiddleware from './server/middlewares/results/blockBlacklis
 import requestLoggerMiddleware from './server/middlewares/requestLogger.middleware'
 import similarPackagesMiddleware from './server/middlewares/similar-packages/similarPackages.middleware'
 import generateImgMiddleware from './server/middlewares/generateImg.middleware'
+import buildMissRateLimit from './server/middlewares/buildMissRateLimit.middleware'
 
 import jsonCacheMiddleware from './server/middlewares/jsonCache.middleware'
 
@@ -71,7 +72,7 @@ app.prepare().then(() => {
     server.use(
       limit({
         duration: 1000 * 60 * 5, //  5 mins
-        max: 60,
+        max: 120,
         whiteList: ['127.0.0.1', '::1'],
       })
     )
@@ -135,6 +136,11 @@ app.prepare().then(() => {
     resolvePackageMiddleware,
     blockBlacklistMiddleware,
     cachedResponseMiddleware,
+    buildMissRateLimit({
+      durationMs: 1000 * 60 * 5,
+      maxRequests: 10,
+      whiteList: ['127.0.0.1', '::1'],
+    }),
     buildMiddleware
   )
 
@@ -160,6 +166,11 @@ app.prepare().then(() => {
     resolvePackageMiddleware,
     blockBlacklistMiddleware,
     cachedResponseMiddleware,
+    buildMissRateLimit({
+      durationMs: 1000 * 60 * 5,
+      maxRequests: 10,
+      whiteList: ['127.0.0.1', '::1'],
+    }),
     exportsSizesMiddlware
   )
 

--- a/server/middlewares/buildMissRateLimit.middleware.ts
+++ b/server/middlewares/buildMissRateLimit.middleware.ts
@@ -1,0 +1,80 @@
+import type { Context, Middleware } from 'koa'
+
+interface BuildMissRateLimitOptions {
+  durationMs?: number
+  maxRequests?: number
+  whiteList?: string[]
+  message429?: string
+}
+
+interface RateLimitEntry {
+  resetAt: number
+  count: number
+}
+
+const DEFAULT_DURATION_MS = 1000 * 60 * 5
+const DEFAULT_MAX_REQUESTS = 10
+const DEFAULT_MESSAGE = '429: Too Many Build Requests.'
+
+function getClientIp(ctx: Context): string {
+  const rawIp =
+    ctx.request.header['x-koaip'] ||
+    ctx.request.header['cf-connecting-ip'] ||
+    ctx.ip
+  return Array.isArray(rawIp) ? rawIp[0] : rawIp || ''
+}
+
+export default function buildMissRateLimit(
+  options: BuildMissRateLimitOptions = {}
+): Middleware {
+  const durationMs = options.durationMs ?? DEFAULT_DURATION_MS
+  const maxRequests = options.maxRequests ?? DEFAULT_MAX_REQUESTS
+  const whiteList = new Set(options.whiteList ?? ['127.0.0.1', '::1'])
+  const message429 = options.message429 ?? DEFAULT_MESSAGE
+  const db: Record<string, RateLimitEntry> = {}
+
+  return async (ctx, next) => {
+    if (ctx.method === 'OPTIONS') {
+      await next()
+      return
+    }
+
+    const ip = getClientIp(ctx)
+    if (!ip || whiteList.has(ip)) {
+      await next()
+      return
+    }
+
+    const now = Date.now()
+    const current = db[ip]
+
+    if (!current || current.resetAt <= now) {
+      db[ip] = {
+        resetAt: now + durationMs,
+        count: 1,
+      }
+    } else {
+      current.count += 1
+    }
+
+    const entry = db[ip]
+    const remaining = Math.max(maxRequests - entry.count, 0)
+    const retryAfterSeconds = Math.max(
+      Math.trunc((entry.resetAt - now) / 1000),
+      0
+    )
+
+    ctx.set('X-BuildRateLimit-Limit', String(maxRequests))
+    ctx.set('X-BuildRateLimit-Remaining', String(remaining))
+    ctx.set('X-BuildRateLimit-Reset', String(entry.resetAt))
+
+    if (entry.count > maxRequests) {
+      ctx.set('Retry-After', String(retryAfterSeconds))
+      ctx.status = 429
+      ctx.body = message429
+      return
+    }
+
+    await next()
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated build-miss IP rate limiter middleware (10 requests / 5 minutes)
- apply build-miss limiter only after cache miss on `/api/size` and `/api/exports-sizes`
- raise app-level fallback limiter from 60 to 120 per 5 minutes

## Why
- protect expensive build paths specifically, while reducing false-positive throttling on cached/non-build requests

## Notes
- nginx layer was updated directly on `bphobia` host separately in ops (not part of this repo commit)
