### PR TITLE
Add MCP nav popup and map result APIs as tools

### DIFF
--- a/client/analytics.ts
+++ b/client/analytics.ts
@@ -15,6 +15,18 @@ type HasSuccessRatio = {
 }
 
 type HasPackageNameAndTimeTaken = HasPackageName & HasTimeTaken
+type HasOpen = {
+  open: boolean
+}
+type HasToolCount = {
+  toolCount: number
+}
+type HasToolName = {
+  toolName: string
+}
+type HasAction = {
+  action: string
+}
 
 export default class Analytics {
   static pageView(pageType: string) {
@@ -120,6 +132,30 @@ export default class Analytics {
     amplitude.getInstance().logEvent('Exports Size Failed', {
       package: packageName,
       timeTaken,
+    })
+  }
+
+  static mcpHeaderClicked({ open }: HasOpen) {
+    amplitude.getInstance().logEvent('MCP Header Clicked', {
+      open,
+    })
+  }
+
+  static mcpToolsListed({ toolCount }: HasToolCount) {
+    amplitude.getInstance().logEvent('MCP Tools Listed', {
+      toolCount,
+    })
+  }
+
+  static mcpToolCalled({ toolName }: HasToolName) {
+    amplitude.getInstance().logEvent('MCP Tool Called', {
+      toolName,
+    })
+  }
+
+  static mcpActionFailed({ action }: HasAction) {
+    amplitude.getInstance().logEvent('MCP Action Failed', {
+      action,
     })
   }
 }

--- a/client/api.ts
+++ b/client/api.ts
@@ -90,6 +90,38 @@ export default class API {
     })
   }
 
+  static post<T = unknown>(
+    url: string,
+    body: Record<string, unknown>
+  ): Promise<T> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Bundlephobia-User': 'bundlephobia website',
+    }
+
+    return fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    }).then(res => {
+      if (!res.ok) {
+        try {
+          return res.json().then(err => Promise.reject(err))
+        } catch (e) {
+          return Promise.reject({
+            error: {
+              code: 'BuildError',
+              message:
+                "Oops, something went wrong and we don't have an appropriate error for this. Open an issue maybe?",
+            },
+          })
+        }
+      }
+      return res.json()
+    })
+  }
+
   static getInfo(packageString: string) {
     return API.get<PackageBuildInfo>(
       `/api/size?package=${packageString}&record=true`

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 
 import { WithClassName } from '../../../types'
 import GithubLogo from '../../assets/github-logo.svg'
+import McpNavPopup from '../McpNavPopup/McpNavPopup'
 
 type HeaderProps = WithClassName
 
@@ -83,6 +84,7 @@ export default class Header extends Component<HeaderProps, HeaderState> {
                   Scan package.json <sup>β</sup>
                 </Link>
               </li>
+              <McpNavPopup />
             </ul>
             <a target="_blank" href="https://github.com/pastelsky/bundlephobia">
               <GithubLogo />

--- a/client/components/McpNavPopup/McpNavPopup.tsx
+++ b/client/components/McpNavPopup/McpNavPopup.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react'
+import API from '../../api'
+import Analytics from '../../analytics'
+
+type McpTool = {
+  name?: string
+}
+
+type McpToolsResponse = {
+  tools?: McpTool[]
+}
+
+const McpNavPopup = () => {
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [tools, setTools] = useState<string[]>([])
+  const [toolName, setToolName] = useState('')
+  const [toolArgs, setToolArgs] = useState('{}')
+  const [result, setResult] = useState('')
+
+  const onToggle = () => {
+    const nextOpen = !open
+    setOpen(nextOpen)
+    Analytics.mcpHeaderClicked({ open: nextOpen })
+    if (!nextOpen) {
+      setError('')
+    }
+  }
+
+  const onListTools = async () => {
+    setLoading(true)
+    setError('')
+    setResult('')
+    try {
+      const response = await API.get<McpToolsResponse>('/api/mcp/tools')
+      const names = (response.tools ?? [])
+        .map(tool => tool.name)
+        .filter((name): name is string => Boolean(name))
+      setTools(names)
+      Analytics.mcpToolsListed({ toolCount: names.length })
+    } catch (e) {
+      setError('Unable to fetch MCP tools')
+      Analytics.mcpActionFailed({ action: 'list-tools' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const onCallTool = async () => {
+    setLoading(true)
+    setError('')
+    setResult('')
+    try {
+      const parsedArgs = toolArgs.trim() ? JSON.parse(toolArgs) : {}
+      const response = await API.post('/api/mcp/call-tool', {
+        name: toolName,
+        arguments: parsedArgs,
+      })
+      setResult(JSON.stringify(response, null, 2))
+      Analytics.mcpToolCalled({ toolName })
+    } catch (e) {
+      setError('Tool call failed. Check tool name/arguments.')
+      Analytics.mcpActionFailed({ action: 'call-tool' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <li className="mcp-nav">
+      <button className="mcp-nav__trigger" onClick={onToggle} type="button">
+        MCP
+      </button>
+      {open && (
+        <div className="mcp-nav__popup">
+          <div className="mcp-nav__row">
+            <button
+              className="mcp-nav__button"
+              type="button"
+              onClick={onListTools}
+              disabled={loading}
+            >
+              List Tools
+            </button>
+          </div>
+          {tools.length > 0 && (
+            <p className="mcp-nav__tools">{tools.slice(0, 8).join(', ')}</p>
+          )}
+          <input
+            className="mcp-nav__input"
+            value={toolName}
+            onChange={event => setToolName(event.target.value)}
+            placeholder="tool name"
+          />
+          <textarea
+            className="mcp-nav__textarea"
+            value={toolArgs}
+            onChange={event => setToolArgs(event.target.value)}
+            placeholder='{"key":"value"}'
+          />
+          <div className="mcp-nav__row">
+            <button
+              className="mcp-nav__button"
+              type="button"
+              onClick={onCallTool}
+              disabled={loading || !toolName.trim()}
+            >
+              Call Tool
+            </button>
+          </div>
+          {error ? <p className="mcp-nav__error">{error}</p> : null}
+          {result ? <pre className="mcp-nav__result">{result}</pre> : null}
+        </div>
+      )}
+    </li>
+  )
+}
+
+export default McpNavPopup

--- a/client/components/PageNav/PageNav.tsx
+++ b/client/components/PageNav/PageNav.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import React from 'react'
 import GithubLogo from '../../assets/github-logo.svg'
 import ThemeToggle from '../ThemeToggle'
+import McpNavPopup from '../McpNavPopup/McpNavPopup'
 
 type PageNavProps = {
   minimal?: boolean
@@ -47,6 +48,7 @@ const PageNav = ({ minimal }: PageNavProps) => (
             <Link href="/scan">Scan package.json</Link>
           </li>
         )}
+        <McpNavPopup />
       </ul>
       <a target="_blank" href="https://github.com/pastelsky/bundlephobia">
         <GithubLogo />

--- a/client/components/ResultLayout/ResultLayout.scss
+++ b/client/components/ResultLayout/ResultLayout.scss
@@ -106,3 +106,90 @@
     overflow: scroll;
   }
 }
+
+.mcp-nav {
+  position: relative;
+}
+
+.mcp-nav__trigger {
+  @include font-size-xs;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  font-weight: $font-weight-bold;
+  opacity: 0.55;
+  color: var(--color-nav-link);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.mcp-nav__popup {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 10px);
+  width: min(92vw, 360px);
+  z-index: 40;
+  background: var(--color-background-card);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 10px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.16);
+  padding: 12px;
+}
+
+.mcp-nav__row {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.mcp-nav__button {
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+  border-radius: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.mcp-nav__input,
+.mcp-nav__textarea {
+  width: 100%;
+  margin-top: 8px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 6px;
+  padding: 8px;
+  background: var(--color-background-primary);
+  color: var(--color-text-primary);
+}
+
+.mcp-nav__textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
+.mcp-nav__tools {
+  margin: 8px 0 0;
+  @include font-size-xs;
+  opacity: 0.75;
+}
+
+.mcp-nav__error {
+  margin: 8px 0 0;
+  @include font-size-xs;
+  color: #c63d2f;
+}
+
+.mcp-nav__result {
+  margin: 8px 0 0;
+  max-height: 180px;
+  overflow: auto;
+  @include font-size-xs;
+  padding: 8px;
+  border-radius: 6px;
+  background: var(--color-background-primary);
+  border: 1px solid var(--color-border-subtle);
+}

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,7 @@ import blockBlacklistMiddleware from './server/middlewares/results/blockBlacklis
 import requestLoggerMiddleware from './server/middlewares/requestLogger.middleware'
 import similarPackagesMiddleware from './server/middlewares/similar-packages/similarPackages.middleware'
 import generateImgMiddleware from './server/middlewares/generateImg.middleware'
+import buildMissRateLimit from './server/middlewares/buildMissRateLimit.middleware'
 
 import jsonCacheMiddleware from './server/middlewares/jsonCache.middleware'
 
@@ -71,7 +72,7 @@ app.prepare().then(() => {
     server.use(
       limit({
         duration: 1000 * 60 * 5, //  5 mins
-        max: 60,
+        max: 120,
         whiteList: ['127.0.0.1', '::1'],
       })
     )
@@ -135,6 +136,11 @@ app.prepare().then(() => {
     resolvePackageMiddleware,
     blockBlacklistMiddleware,
     cachedResponseMiddleware,
+    buildMissRateLimit({
+      durationMs: 1000 * 60 * 5,
+      maxRequests: 10,
+      whiteList: ['127.0.0.1', '::1'],
+    }),
     buildMiddleware
   )
 
@@ -160,6 +166,11 @@ app.prepare().then(() => {
     resolvePackageMiddleware,
     blockBlacklistMiddleware,
     cachedResponseMiddleware,
+    buildMissRateLimit({
+      durationMs: 1000 * 60 * 5,
+      maxRequests: 10,
+      whiteList: ['127.0.0.1', '::1'],
+    }),
     exportsSizesMiddlware
   )
 

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,7 @@ import Cache from './utils/cache.utils'
 import { parsePackageString } from './utils/common.utils'
 import firebaseUtils from './utils/firebase.utils'
 import logger from './server/Logger'
+import remoteMcpClient from './server/mcp/remoteClient'
 
 import limit from './server/middlewares/rateLimit.middleware'
 import exportsMiddlware from './server/middlewares/exports.middleware'
@@ -222,6 +223,194 @@ app.prepare().then(() => {
   router.get('/api/similar-packages', similarPackagesMiddleware)
 
   router.get('/api/stats-image', generateImgMiddleware)
+
+  router.get('/api/mcp/tools', async ctx => {
+    try {
+      const localTools = [
+        {
+          name: 'bundlephobia.size',
+          description: 'Get package size result via /api/size',
+          inputSchema: {
+            type: 'object',
+            required: ['package'],
+            properties: {
+              package: { type: 'string' },
+            },
+          },
+        },
+        {
+          name: 'bundlephobia.exports',
+          description: 'Get package exports via /api/exports',
+          inputSchema: {
+            type: 'object',
+            required: ['package'],
+            properties: {
+              package: { type: 'string' },
+            },
+          },
+        },
+        {
+          name: 'bundlephobia.exportsSizes',
+          description: 'Get package exports sizes via /api/exports-sizes',
+          inputSchema: {
+            type: 'object',
+            required: ['package'],
+            properties: {
+              package: { type: 'string' },
+            },
+          },
+        },
+        {
+          name: 'bundlephobia.packageHistory',
+          description: 'Get package history via /api/package-history',
+          inputSchema: {
+            type: 'object',
+            required: ['package'],
+            properties: {
+              package: { type: 'string' },
+              limit: { type: 'number' },
+            },
+          },
+        },
+        {
+          name: 'bundlephobia.similarPackages',
+          description: 'Get similar packages via /api/similar-packages',
+          inputSchema: {
+            type: 'object',
+            required: ['package'],
+            properties: {
+              package: { type: 'string' },
+            },
+          },
+        },
+      ]
+
+      if (!remoteMcpClient.isEnabled()) {
+        ctx.body = { tools: localTools }
+        return
+      }
+
+      const remote = (await remoteMcpClient.listTools()) as {
+        tools?: Array<Record<string, unknown>>
+      }
+      ctx.body = {
+        tools: [...localTools, ...(remote.tools ?? [])],
+      }
+    } catch (error) {
+      remoteMcpClient.resetConnection(error)
+      logger.error('MCP_API', error, 'Failed to list MCP tools')
+      ctx.status = 502
+      ctx.body = { error: { code: 'McpListToolsFailed' } }
+    }
+  })
+
+  router.post('/api/mcp/call-tool', async ctx => {
+    const payload = ctx.request.body as
+      | { name?: string; arguments?: Record<string, unknown> }
+      | undefined
+
+    if (!payload?.name || typeof payload.name !== 'string') {
+      ctx.status = 400
+      ctx.body = {
+        error: { code: 'InvalidMcpPayload', message: '`name` is required' },
+      }
+      return
+    }
+
+    try {
+      const args = payload.arguments ?? {}
+      const packageName =
+        typeof args.package === 'string'
+          ? encodeURIComponent(args.package)
+          : undefined
+
+      const callLocalApi = async (path: string) => {
+        const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+          headers: {
+            'X-Bundlephobia-User': 'bundlephobia mcp tool',
+          },
+        })
+        const body = await response.json()
+        return {
+          status: response.status,
+          body,
+        }
+      }
+
+      switch (payload.name) {
+        case 'bundlephobia.size': {
+          if (!packageName) {
+            ctx.status = 400
+            ctx.body = { error: { code: 'InvalidMcpPayload' } }
+            return
+          }
+          ctx.body = await callLocalApi(`/api/size?package=${packageName}`)
+          return
+        }
+        case 'bundlephobia.exports': {
+          if (!packageName) {
+            ctx.status = 400
+            ctx.body = { error: { code: 'InvalidMcpPayload' } }
+            return
+          }
+          ctx.body = await callLocalApi(`/api/exports?package=${packageName}`)
+          return
+        }
+        case 'bundlephobia.exportsSizes': {
+          if (!packageName) {
+            ctx.status = 400
+            ctx.body = { error: { code: 'InvalidMcpPayload' } }
+            return
+          }
+          ctx.body = await callLocalApi(
+            `/api/exports-sizes?package=${packageName}`
+          )
+          return
+        }
+        case 'bundlephobia.packageHistory': {
+          if (!packageName) {
+            ctx.status = 400
+            ctx.body = { error: { code: 'InvalidMcpPayload' } }
+            return
+          }
+          const limit = Number(args.limit ?? 10)
+          ctx.body = await callLocalApi(
+            `/api/package-history?package=${packageName}&limit=${limit}`
+          )
+          return
+        }
+        case 'bundlephobia.similarPackages': {
+          if (!packageName) {
+            ctx.status = 400
+            ctx.body = { error: { code: 'InvalidMcpPayload' } }
+            return
+          }
+          ctx.body = await callLocalApi(
+            `/api/similar-packages?package=${packageName}`
+          )
+          return
+        }
+        default:
+          break
+      }
+
+      if (!remoteMcpClient.isEnabled()) {
+        ctx.status = 404
+        ctx.body = { error: { code: 'McpNotConfigured' } }
+        return
+      }
+
+      ctx.body = await remoteMcpClient.callTool({
+        name: payload.name,
+        arguments: payload.arguments,
+      })
+    } catch (error) {
+      remoteMcpClient.resetConnection(error)
+      logger.error('MCP_API', error, `Failed MCP tool call: ${payload.name}`)
+      ctx.status = 502
+      ctx.body = { error: { code: 'McpCallToolFailed' } }
+    }
+  })
 
   router.get(
     '/admin/restart',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@contentful/rich-text-react-renderer": "^15.17.0",
     "@contentful/rich-text-types": "^15.15.1",
     "@koa/router": "^12.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@next/font": "^13.5.6",
     "@types/koa__router": "^12.0.4",
     "animejs": "^3.2.2",
@@ -99,7 +100,8 @@
     "unfetch": "^4.2.0",
     "webpack": "^4.47.0",
     "winston": "^3.11.0",
-    "workerpool": "^6.5.1"
+    "workerpool": "^6.5.1",
+    "zod": "^4.4.2"
   },
   "scripts": {
     "dev": "DEBUG='bp:*' NODE_ENV=development nodemon --watch ./server --watch ./utils ./index.ts",

--- a/server/mcp/remoteClient.ts
+++ b/server/mcp/remoteClient.ts
@@ -1,0 +1,104 @@
+import { Client } from '@modelcontextprotocol/sdk/client'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+import logger from '../Logger'
+
+interface MpcCallToolRequest {
+  name: string
+  arguments?: Record<string, unknown>
+}
+
+interface McpConfig {
+  endpoint?: string
+  timeoutMs: number
+}
+
+class RemoteMcpClient {
+  private client: Client | null = null
+
+  private connectPromise: Promise<Client> | null = null
+
+  private readonly config: McpConfig
+
+  constructor(config: McpConfig) {
+    this.config = config
+  }
+
+  isEnabled(): boolean {
+    return Boolean(this.config.endpoint)
+  }
+
+  private async connect(): Promise<Client> {
+    if (!this.config.endpoint) {
+      throw new Error('MCP endpoint is not configured')
+    }
+
+    if (this.client) {
+      return this.client
+    }
+
+    if (!this.connectPromise) {
+      this.connectPromise = (async () => {
+        const transport = new StreamableHTTPClientTransport(
+          new URL(this.config.endpoint),
+          {}
+        )
+
+        const client = new Client(
+          {
+            name: 'bundlephobia-mcp-client',
+            version: '1.0.0',
+          },
+          {
+            capabilities: {},
+          }
+        )
+
+        await client.connect(transport, {
+          timeout: this.config.timeoutMs,
+        })
+
+        this.client = client
+        return client
+      })()
+    }
+
+    return this.connectPromise
+  }
+
+  async listTools(): Promise<unknown> {
+    const client = await this.connect()
+    return client.listTools({
+      timeout: this.config.timeoutMs,
+    })
+  }
+
+  async callTool(request: MpcCallToolRequest): Promise<unknown> {
+    const client = await this.connect()
+    return client.callTool(
+      {
+        name: request.name,
+        arguments: request.arguments,
+      },
+      undefined,
+      {
+        timeout: this.config.timeoutMs,
+      }
+    )
+  }
+
+  resetConnection(error?: unknown): void {
+    if (error) {
+      logger.error('MCP_CLIENT', error, 'Resetting MCP client connection')
+    }
+    this.client = null
+    this.connectPromise = null
+  }
+}
+
+const remoteMcpClient = new RemoteMcpClient({
+  endpoint: process.env.MCP_REMOTE_ENDPOINT,
+  timeoutMs: 10000,
+})
+
+export default remoteMcpClient

--- a/server/middlewares/buildMissRateLimit.middleware.ts
+++ b/server/middlewares/buildMissRateLimit.middleware.ts
@@ -1,0 +1,80 @@
+import type { Context, Middleware } from 'koa'
+
+interface BuildMissRateLimitOptions {
+  durationMs?: number
+  maxRequests?: number
+  whiteList?: string[]
+  message429?: string
+}
+
+interface RateLimitEntry {
+  resetAt: number
+  count: number
+}
+
+const DEFAULT_DURATION_MS = 1000 * 60 * 5
+const DEFAULT_MAX_REQUESTS = 10
+const DEFAULT_MESSAGE = '429: Too Many Build Requests.'
+
+function getClientIp(ctx: Context): string {
+  const rawIp =
+    ctx.request.header['x-koaip'] ||
+    ctx.request.header['cf-connecting-ip'] ||
+    ctx.ip
+  return Array.isArray(rawIp) ? rawIp[0] : rawIp || ''
+}
+
+export default function buildMissRateLimit(
+  options: BuildMissRateLimitOptions = {}
+): Middleware {
+  const durationMs = options.durationMs ?? DEFAULT_DURATION_MS
+  const maxRequests = options.maxRequests ?? DEFAULT_MAX_REQUESTS
+  const whiteList = new Set(options.whiteList ?? ['127.0.0.1', '::1'])
+  const message429 = options.message429 ?? DEFAULT_MESSAGE
+  const db: Record<string, RateLimitEntry> = {}
+
+  return async (ctx, next) => {
+    if (ctx.method === 'OPTIONS') {
+      await next()
+      return
+    }
+
+    const ip = getClientIp(ctx)
+    if (!ip || whiteList.has(ip)) {
+      await next()
+      return
+    }
+
+    const now = Date.now()
+    const current = db[ip]
+
+    if (!current || current.resetAt <= now) {
+      db[ip] = {
+        resetAt: now + durationMs,
+        count: 1,
+      }
+    } else {
+      current.count += 1
+    }
+
+    const entry = db[ip]
+    const remaining = Math.max(maxRequests - entry.count, 0)
+    const retryAfterSeconds = Math.max(
+      Math.trunc((entry.resetAt - now) / 1000),
+      0
+    )
+
+    ctx.set('X-BuildRateLimit-Limit', String(maxRequests))
+    ctx.set('X-BuildRateLimit-Remaining', String(remaining))
+    ctx.set('X-BuildRateLimit-Reset', String(entry.resetAt))
+
+    if (entry.count > maxRequests) {
+      ctx.set('Retry-After', String(retryAfterSeconds))
+      ctx.status = 429
+      ctx.body = message429
+      return
+    }
+
+    await next()
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2935,6 +2935,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hono/node-server@npm:^1.19.9":
+  version: 1.19.14
+  resolution: "@hono/node-server@npm:1.19.14"
+  peerDependencies:
+    hono: ^4
+  checksum: 41a099bb3705d96aac44b7a8db8805f2a22ce8a0f767a27b6d10b74a9964925df01c5f35d3631e882f8bcdeee3518884c30f40588ac8c960d88bf71048ba0df3
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.13":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40humanwhocodes%2Fconfig-array%2F-%2Fconfig-array-0.11.14.tgz"
@@ -3578,6 +3587,39 @@ __metadata:
     methods: "npm:^1.1.2"
     path-to-regexp: "npm:^6.2.1"
   checksum: 978a668a88dad8cba38afe0df537b95f6d49bdaa60af5f479240fde3a87a7046cf8c068a58c355442335794db5cb583b88ca07a4b65f217b44925a7ce99ccc1d
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.29.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.9"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.2.1"
+    express-rate-limit: "npm:^8.2.1"
+    hono: "npm:^4.11.4"
+    jose: "npm:^6.1.3"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 7c4bc339205b1652330cd4e6b121cc859079655f2b9c0506bbb15563ba0d07924bda3d949705530532db7f4d2cb86d633dc8f92bc32803d97c7bece2ac63e29f
   languageName: node
   linkType: hard
 
@@ -6144,6 +6186,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
+  languageName: node
+  linkType: hard
+
 "acorn-globals@npm:^4.1.0":
   version: 4.3.4
   resolution: "acorn-globals@npm:4.3.4"
@@ -6334,6 +6386,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.1.0, ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -6364,6 +6430,18 @@ __metadata:
     require-from-string: "npm:^2.0.2"
     uri-js: "npm:^4.2.2"
   checksum: ac4f72adf727ee425e049bc9d8b31d4a57e1c90da8d28bcd23d60781b12fcd6fc3d68db5df16994c57b78b94eed7988f5a6b482fd376dc5b084125e20a0a622e
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.17.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
   languageName: node
   linkType: hard
 
@@ -7417,6 +7495,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.1":
+  version: 2.2.2
+  resolution: "body-parser@npm:2.2.2"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^1.0.5"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.0"
+    iconv-lite: "npm:^0.7.0"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.14.1"
+    raw-body: "npm:^3.0.1"
+    type-is: "npm:^2.0.1"
+  checksum: 95a830a003b38654b75166ca765358aa92ee3d561bf0e41d6ccdde0e1a0c9783cab6b90b20eb635d23172c010b59d3563a137a738e74da4ba714463510d05137
+  languageName: node
+  linkType: hard
+
 "boolbase@npm:^1.0.0":
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
@@ -7723,6 +7818,7 @@ __metadata:
     "@contentful/rich-text-react-renderer": "npm:^15.17.0"
     "@contentful/rich-text-types": "npm:^15.15.1"
     "@koa/router": "npm:^12.0.1"
+    "@modelcontextprotocol/sdk": "npm:^1.29.0"
     "@next/font": "npm:^13.5.6"
     "@svgr/webpack": "npm:^6.5.1"
     "@swc/core": "npm:^1.3.107"
@@ -7847,6 +7943,7 @@ __metadata:
     webpack: "npm:^4.47.0"
     winston: "npm:^3.11.0"
     workerpool: "npm:^6.5.1"
+    zod: "npm:^4.4.2"
   languageName: unknown
   linkType: soft
 
@@ -7859,7 +7956,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2, bytes@npm:^3.0.0, bytes@npm:^3.1.0, bytes@npm:~3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.0.0, bytes@npm:^3.1.0, bytes@npm:^3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
@@ -8833,6 +8930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"content-disposition@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "content-disposition@npm:1.1.0"
+  checksum: 94e0aef65873e69330f5f187fbc44ebce593bdcb8013dd8a68b7d0f159ca089bd30db3f8095d829f81c341695b60a6085ee6e15e6d775c4a325b586cc8d91974
+  languageName: node
+  linkType: hard
+
 "content-disposition@npm:~0.5.2, content-disposition@npm:~0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
@@ -8842,7 +8946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:^1.0.4, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
+"content-type@npm:^1.0.4, content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
@@ -8924,6 +9028,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:~1.0.6, cookie-signature@npm:~1.0.7":
   version: 1.0.7
   resolution: "cookie-signature@npm:1.0.7"
@@ -8938,7 +9049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.7.2, cookie@npm:~0.7.1, cookie@npm:~0.7.2":
+"cookie@npm:0.7.2, cookie@npm:^0.7.1, cookie@npm:~0.7.1, cookie@npm:~0.7.2":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
@@ -9036,7 +9147,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cors@npm:~2.8.5":
+"cors@npm:^2.8.5, cors@npm:~2.8.5":
   version: 2.8.6
   resolution: "cors@npm:2.8.6"
   dependencies:
@@ -9175,6 +9286,17 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 5738c312387081c98d69c98e105b6327b069197f864a60593245d64c8089c8a0a744e16349281210d56835bb9274130d825a78b2ad6853ca13cfbeffc0c31750
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.5":
+  version: 7.0.6
+  resolution: "cross-spawn@npm:7.0.6"
+  dependencies:
+    path-key: "npm:^3.1.0"
+    shebang-command: "npm:^2.0.0"
+    which: "npm:^2.0.1"
+  checksum: 053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
   languageName: node
   linkType: hard
 
@@ -9511,7 +9633,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.4.3, debug@npm:~4.4.1":
+"debug@npm:^4.4.0, debug@npm:^4.4.3, debug@npm:~4.4.1":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -10164,7 +10286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encodeurl@npm:~2.0.0":
+"encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
   version: 2.0.0
   resolution: "encodeurl@npm:2.0.0"
   checksum: 5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
@@ -11165,7 +11287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
@@ -11183,6 +11305,22 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
+  languageName: node
+  linkType: hard
+
+"eventsource-parser@npm:^3.0.0, eventsource-parser@npm:^3.0.1":
+  version: 3.0.8
+  resolution: "eventsource-parser@npm:3.0.8"
+  checksum: 3a73eee85311f33b12fa558381a477c1bdcf8c024a429a9d48f87b043e328c26d24ed280fd7ca92e2fdd4c8c37f749b758420c1533778aaca2beabf895024efa
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:^3.0.2":
+  version: 3.0.7
+  resolution: "eventsource@npm:3.0.7"
+  dependencies:
+    eventsource-parser: "npm:^3.0.1"
+  checksum: c48a73c38f300e33e9f11375d4ee969f25cbb0519608a12378a38068055ae8b55b6e0e8a49c3f91c784068434efe1d9f01eb49b6315b04b0da9157879ce2f67d
   languageName: node
   linkType: hard
 
@@ -11320,6 +11458,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.2.1":
+  version: 8.4.1
+  resolution: "express-rate-limit@npm:8.4.1"
+  dependencies:
+    ip-address: "npm:10.1.0"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: ead87bcf7b9b4094d2a597b6a77569eed34c7d2ff3a449eeef25e1cd4a96dc3de17b8da93e8cf82f757ef441974846138b4bc371621fbc72346f8cc4a07a712b
+  languageName: node
+  linkType: hard
+
 "express-session@npm:^1.18.0":
   version: 1.19.0
   resolution: "express-session@npm:1.19.0"
@@ -11372,6 +11521,42 @@ __metadata:
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
   checksum: ea57f512ab1e05e26b53a14fd432f65a10ec735ece342b37d0b63a7bcb8d337ffbb830ecb8ca15bcdfe423fbff88cea09786277baff200e8cde3ab40faa665cd
+  languageName: node
+  linkType: hard
+
+"express@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "express@npm:5.2.1"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.1"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 45e8c841ad188a41402ddcd1294901e861ee0819f632fb494f2ed344ef9c43315d294d443fb48d594e6586a3b779785120f43321417adaef8567316a55072949
   languageName: node
   linkType: hard
 
@@ -11598,6 +11783,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-uri@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "fast-uri@npm:3.1.0"
+  checksum: 44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  languageName: node
+  linkType: hard
+
 "fast-xml-parser@npm:^4.4.1":
   version: 4.5.0
   resolution: "fast-xml-parser@npm:4.5.0::__archiveUrl=https%3A%2F%2Fpackages.atlassian.com%2Fapi%2Fnpm%2Fnpm-remote%2Ffast-xml-parser%2F-%2Ffast-xml-parser-4.5.0.tgz"
@@ -11761,6 +11953,20 @@ __metadata:
   version: 1.1.0
   resolution: "filter-obj@npm:1.1.0"
   checksum: 071e0886b2b50238ca5026c5bbf58c26a7c1a1f720773b8c7813d16ba93d0200de977af14ac143c5ac18f666b2cfc83073f3a5fe6a4e996c49e0863d5500fccf
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 6bd664e21b7b2e79efcaace7d1a427169f61cce048fae68eb56290e6934e676b78e55d89f5998c5508871345bc59a61f47002dc505dc7288be68cceac1b701e2
   languageName: node
   linkType: hard
 
@@ -12101,6 +12307,13 @@ __metadata:
   dependencies:
     map-cache: "npm:^0.2.2"
   checksum: 5891d1c1d1d5e1a7fb3ccf28515c06731476fa88f7a50f4ede8a0d8d239a338448e7f7cc8b73db48da19c229fa30066104fe6489862065a4f1ed591c42fbeabf
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
   languageName: node
   linkType: hard
 
@@ -13104,6 +13317,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hono@npm:^4.11.4":
+  version: 4.12.16
+  resolution: "hono@npm:4.12.16"
+  checksum: 3afee13722bf574780a641bd6d8812663c650fb7ac86df390f2d90293e1a6e2413aa9c45e4bc5b626a29c1b534fdb8353dd2151aab09bc4a95cd277aad4bd5c7
+  languageName: node
+  linkType: hard
+
 "hoopy@npm:^0.1.4":
   version: 0.1.4
   resolution: "hoopy@npm:0.1.4"
@@ -13253,6 +13473,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:^2.0.1, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
+  dependencies:
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
+  languageName: node
+  linkType: hard
+
 "http-errors@npm:~1.6.2":
   version: 1.6.3
   resolution: "http-errors@npm:1.6.3"
@@ -13275,19 +13508,6 @@ __metadata:
     statuses: "npm:>= 1.5.0 < 2"
     toidentifier: "npm:1.0.0"
   checksum: 5c3443c340d35b2f18ce908266c4ae93305b7d900bef765ac8dc56fa90125b9fe18a1ed9ebf6af23dc3ba7763731921a2682bf968e199eccf383eb8f508be6c2
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "http-errors@npm:2.0.1"
-  dependencies:
-    depd: "npm:~2.0.0"
-    inherits: "npm:~2.0.4"
-    setprototypeof: "npm:~1.2.0"
-    statuses: "npm:~2.0.2"
-    toidentifier: "npm:~1.0.1"
-  checksum: fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
   languageName: node
   linkType: hard
 
@@ -13465,7 +13685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.7.0":
+"iconv-lite@npm:^0.7.0, iconv-lite@npm:~0.7.0":
   version: 0.7.2
   resolution: "iconv-lite@npm:0.7.2"
   dependencies:
@@ -13844,6 +14064,13 @@ __metadata:
     redis-parser: "npm:^3.0.0"
     standard-as-callback: "npm:^2.1.0"
   checksum: 294e8cdef963f922b04ad023d4165f1d399b27279b9890f3e1311da57fb2a082c8dca52d18bd14a54acd6fb82853783641a0c47ff18661a8756221049f807e88
+  languageName: node
+  linkType: hard
+
+"ip-address@npm:10.1.0":
+  version: 10.1.0
+  resolution: "ip-address@npm:10.1.0"
+  checksum: 0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
   languageName: node
   linkType: hard
 
@@ -14383,6 +14610,13 @@ __metadata:
   version: 2.2.2
   resolution: "is-promise@npm:2.2.2"
   checksum: 2dba959812380e45b3df0fb12e7cb4d4528c989c7abb03ececb1d1fd6ab1cbfee956ca9daa587b9db1d8ac3c1e5738cf217bdb3dfd99df8c691be4c00ae09069
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
   languageName: node
   linkType: hard
 
@@ -15226,6 +15460,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.3":
+  version: 6.2.3
+  resolution: "jose@npm:6.2.3"
+  checksum: aa91bccba22cc84d86308f833749bcb0b00441e35c24e0ac79abeac5f76dc62d47bdef9c1da6a0c609f5da6478595f52b252085888b89dbdb163861e40ea4188
+  languageName: node
+  linkType: hard
+
 "js-stringify@npm:^1.0.2":
   version: 1.0.2
   resolution: "js-stringify@npm:1.0.2"
@@ -15442,6 +15683,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
   languageName: node
   linkType: hard
 
@@ -16690,6 +16938,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "memory-fs@npm:^0.4.1":
   version: 0.4.1
   resolution: "memory-fs@npm:0.4.1"
@@ -16721,6 +16976,13 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 95389b7ced3f9b36fbdcf32eb946dc3dd1774c2fdf164609e55b18d03aa499b12bd3aae3a76c1c7185b96279e9803525550d3eb292b5224866060a288f335cb3
   languageName: node
   linkType: hard
 
@@ -16817,12 +17079,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12, mime-types@npm:^2.1.18, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34, mime-types@npm:~2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 
@@ -17330,6 +17608,13 @@ __metadata:
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
+  languageName: node
+  linkType: hard
+
+"negotiator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "negotiator@npm:1.0.0"
+  checksum: 4c559dd52669ea48e1914f9d634227c561221dd54734070791f999c52ed0ff36e437b2e07d5c1f6e32909fc625fe46491c16e4a8f0572567d4dd15c3a4fda04b
   languageName: node
   linkType: hard
 
@@ -18166,7 +18451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:^2.3.0, on-finished@npm:~2.4.1":
+"on-finished@npm:^2.3.0, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -18914,7 +19199,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:^1.3.2, parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.2, parseurl@npm:^1.3.3, parseurl@npm:~1.3.2, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
@@ -19021,6 +19306,13 @@ __metadata:
   version: 6.2.1
   resolution: "path-to-regexp@npm:6.2.1"
   checksum: 7a73811ca703e5c199e5b50b9649ab8f6f7b458a37f7dff9ea338815203f5b1f95fe8cb24d4fdfe2eab5d67ce43562d92534330babca35cdf3231f966adb9360
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^8.0.0":
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: 05b115c49b47ad252ce05faa32930f643f23769c68b8bcfe78ad833545140c48bbffb3266986d6c8d5db13a64cf12e07e0d72d9882cab830efeefa553533ebaf
   languageName: node
   linkType: hard
 
@@ -19231,6 +19523,13 @@ __metadata:
   version: 4.0.5
   resolution: "pirates@npm:4.0.5"
   checksum: 58b6ff0f137a3d70ff34ac4802fd19819cdc19b53e9c95adecae6c7cfc77719a11f561ad85d46e79e520ef57c31145a564c8bc3bee8cfee75d441fab2928a51d
+  languageName: node
+  linkType: hard
+
+"pkce-challenge@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "pkce-challenge@npm:5.0.1"
+  checksum: 207f4cb976682f27e8324eb49cf71937c98fbb8341a0b8f6142bc6f664825b30e049a54a21b5c034e823ee3c3d412f10d74bd21de78e17452a6a496c2991f57c
   languageName: node
   linkType: hard
 
@@ -20025,6 +20324,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.0, qs@npm:^6.14.1":
+  version: 6.15.1
+  resolution: "qs@npm:6.15.1"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 19ee504f0ebff72598503e38cd6d9bd7b52a8ab62ae18b1e6bee3d4db58469bd65871ef1893a881bafb0f80ef2f9ab586e1f255cf25cc8d816c0f5a704721d97
+  languageName: node
+  linkType: hard
+
 "qs@npm:^6.5.2, qs@npm:^6.9.4":
   version: 6.11.1
   resolution: "qs@npm:6.11.1"
@@ -20123,7 +20431,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"range-parser@npm:~1.2.1":
+"range-parser@npm:^1.2.1, range-parser@npm:~1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 96c032ac2475c8027b7a4e9fe22dc0dfe0f6d90b85e496e0f016fbdb99d6d066de0112e680805075bd989905e2123b3b3d002765149294dce0c1f7f01fcc2ea0
@@ -20139,6 +20447,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.0, raw-body@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
   languageName: node
   linkType: hard
 
@@ -21094,6 +21414,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 3279de7450c8eae2f6e095e9edacbdeec0abb5cb7249c6e719faa0db2dba43574b4fff5892d9220631c9abaff52dd3cad648cfea2aaace845e1a071915ac8867
+  languageName: node
+  linkType: hard
+
 "rrweb-cssom@npm:^0.7.1":
   version: 0.7.1
   resolution: "rrweb-cssom@npm:0.7.1"
@@ -21512,6 +21845,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: fbbbbdc902a913d65605274be23f3d604065cfc3ee3d78bf9fc8af1dc9fc82667c50d3d657f5e601ac657bac9b396b50ee97bd29cd55436320cf1cddebdcec72
+  languageName: node
+  linkType: hard
+
 "send@npm:~0.19.0, send@npm:~0.19.1":
   version: 0.19.2
   resolution: "send@npm:0.19.2"
@@ -21574,6 +21926,18 @@ __metadata:
     mime-types: "npm:~2.1.35"
     parseurl: "npm:~1.3.3"
   checksum: b4e48da75c9262cfcf6a4707748a33a127f6c3cd3a095782c22312c4915545b7695071fedc8f5717bae165e6e63053cd963847013b1f1e984213f07186f78a74
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 37986096e8572e2dfaad35a3925fa8da0c0969f8814fd7788e84d4d388bc068cf0c06d1658509788e55bed942a6b6d040a8a267fa92bb9ffb1179f8bacde5fd7
   languageName: node
   linkType: hard
 
@@ -22318,7 +22682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"statuses@npm:~2.0.1, statuses@npm:~2.0.2":
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.1, statuses@npm:~2.0.2":
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
@@ -23592,6 +23956,17 @@ __metadata:
     media-typer: "npm:0.3.0"
     mime-types: "npm:~2.1.24"
   checksum: a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
+  languageName: node
+  linkType: hard
+
+"type-is@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "type-is@npm:2.0.1"
+  dependencies:
+    content-type: "npm:^1.0.5"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 7f7ec0a060b16880bdad36824ab37c26019454b67d73e8a465ed5a3587440fbe158bc765f0da68344498235c877e7dbbb1600beccc94628ed05599d667951b99
   languageName: node
   linkType: hard
 
@@ -25246,5 +25621,21 @@ __metadata:
   version: 2.1.2
   resolution: "yoctocolors@npm:2.1.2"
   checksum: b220f30f53ebc2167330c3adc86a3c7f158bcba0236f6c67e25644c3188e2571a6014ffc1321943bb619460259d3d27eb4c9cc58c2d884c1b195805883ec7066
+  languageName: node
+  linkType: hard
+
+"zod-to-json-schema@npm:^3.25.1":
+  version: 3.25.2
+  resolution: "zod-to-json-schema@npm:3.25.2"
+  peerDependencies:
+    zod: ^3.25.28 || ^4
+  checksum: dd300554393903022487688af14fbda5c719ba8179702bb55b3aa86318830467f0f7beb7d654036975ac963dc4843b72e59636448bfff9a0608f277bb6a14939
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0, zod@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "zod@npm:4.4.2"
+  checksum: aa5097464c41cf22d715cbc29873ae6feaaf56e687b81d140458d7c01201e7b9de1ee46c8567b5458ee3c0068b8a82b2652535b5d39589fcb5562d861c83ded3
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Summary\n- add MCP item in top nav that opens an inline popup\n- add analytics events for MCP header interaction and popup actions\n- add MCP endpoints to expose local tools for result-page APIs\n  - bundlephobia.size\n  - bundlephobia.exports\n  - bundlephobia.exportsSizes\n  - bundlephobia.packageHistory\n  - bundlephobia.similarPackages\n- remove MCP API-key/bearer requirements from server-side MCP bridge\n\n## Notes\n- no extra env var docs/defaults were added\n- existing lint warnings are unchanged