### PR TITLE
fix: status codes and request queue cancellation

### DIFF
--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -1,0 +1,48 @@
+import Queue from '../server/Queue'
+
+describe('Queue cancellation', () => {
+  it('cancels a ready job in the queue', async () => {
+    const queue = new Queue({ concurrency: 1 })
+
+    let resolveFirstJob: any
+    const firstJobPromise = new Promise(resolve => {
+      resolveFirstJob = resolve
+    })
+
+    queue.addExecutor('TEST', () => firstJobPromise)
+
+    const p1 = queue.process('job-1', 'TEST', {})
+    const p2 = queue.process('job-2', 'TEST', {})
+
+    expect(queue.getReadyJobs().length).toBe(1)
+    expect(queue.getRunningJobs().length).toBe(1)
+
+    queue.cancel('job-2', 'TEST')
+
+    await expect(p2).rejects.toThrow('JOB_CANCELLED')
+    expect(queue.getReadyJobs().length).toBe(0)
+
+    resolveFirstJob()
+    await p1
+  })
+
+  it('cancels a processing job and calls its cancel handler', async () => {
+    const queue = new Queue({ concurrency: 1 })
+
+    const mockCancel = jest.fn()
+    const mockPromise: any = new Promise(() => {})
+    mockPromise.cancel = mockCancel
+
+    queue.addExecutor('TEST', () => mockPromise)
+
+    const p1 = queue.process('job-1', 'TEST', {})
+
+    expect(queue.getRunningJobs().length).toBe(1)
+
+    queue.cancel('job-1', 'TEST')
+
+    expect(mockCancel).toHaveBeenCalledTimes(1)
+    await expect(p1).rejects.toThrow('JOB_CANCELLED')
+    expect(queue.getRunningJobs().length).toBe(0)
+  })
+})

--- a/__tests__/errors-cache.test.ts
+++ b/__tests__/errors-cache.test.ts
@@ -73,7 +73,9 @@ describe('build api', () => {
     expect(result.headers.get('cache-control')).toBe('max-age=60')
     expect(errorJSON.error.code).toBe('BlocklistedPackageError')
     expect(errorJSON.error.message).toBe(
-      'The package you were looking for is blocklisted due to suspicious activity in the past'
+      'The package you were looking for is blocklisted ' +
+        "because it failed to build multiple times in the past and further tries aren't likely to succeed. This can " +
+        "happen if this package wasn't meant to be bundled in a client side application."
     )
   })
 
@@ -82,7 +84,7 @@ describe('build api', () => {
     const result = await fetch(resultURL)
     const errorJSON: ErrorResponse = await result.json()
 
-    expect(result.status).toBe(500)
+    expect(result.status).toBe(422)
     expect(result.headers.get('cache-control')).toBe('max-age=3600')
     expect(errorJSON.error.code).toBe('EntryPointError')
     expect(errorJSON.error.message).toBe(

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -29,6 +29,7 @@ interface QueueJob<TParams = unknown, TResult = unknown> {
   params: TParams
   successListeners: Array<(result: TResult) => void>
   failureListeners: Array<(error: unknown) => void>
+  cancel?: () => void
 }
 
 interface QueueOptions {
@@ -133,6 +134,23 @@ class Queue {
     this.jobs = this.jobs.filter(job => job.id !== id || job.type !== type)
   }
 
+  cancel(id: string, type: JobType): void {
+    const job = this.jobs.find(job => job.id === id && job.type === type)
+    if (job) {
+      log('cancelling job %s (%s)', id, job.status.toString())
+      if (job.status === JobStatus.PROCESSING) {
+        if (job.cancel) {
+          job.cancel()
+        }
+      }
+      job.failureListeners.forEach(listener => {
+        listener(new Error('JOB_CANCELLED'))
+      })
+      this.removeJob(id, type)
+      this.executeNextJobIfPossible()
+    }
+  }
+
   clear(): void {
     this.jobs
       .filter(job => job.status === JobStatus.READY)
@@ -190,7 +208,21 @@ class Queue {
 
     try {
       const handler = this.executorMap[nextJob.type]
-      const result = await handler.call(this, nextJob.params)
+      const promiseOrValue = handler.call(this, nextJob.params)
+
+      if (promiseOrValue && typeof promiseOrValue === 'object') {
+        const cancelablePromise = promiseOrValue as Promise<unknown> & {
+          cancel?: () => void
+        }
+        if (typeof cancelablePromise.cancel === 'function') {
+          nextJob.cancel = () => {
+            log('terminating running task for job %s', nextJob.id)
+            cancelablePromise.cancel!()
+          }
+        }
+      }
+
+      const result = await promiseOrValue
       log('job %s was a success, removing it', nextJob.id, nextJob.type)
       nextJob.successListeners.forEach(listener => {
         listener.call(this, result)

--- a/server/api/BuildService.ts
+++ b/server/api/BuildService.ts
@@ -121,6 +121,10 @@ export default class BuildService {
     )
   }
 
+  cancelPackageBuildStats(packageString: string): void {
+    requestQueue.cancel(packageString, OperationType.PACKAGE_BUILD_STATS)
+  }
+
   async getPackageExports<T>(
     packageString: string,
     priority: number

--- a/server/middlewares/results/build.middleware.ts
+++ b/server/middlewares/results/build.middleware.ts
@@ -23,10 +23,31 @@ const buildMiddleware: Middleware = async ctx => {
     typeof packageQuery === 'string' ? packageQuery : packageQuery?.join('/')
 
   const buildStart = now()
-  const result = await buildService.getPackageBuildStats<PackageBuildResult>(
-    packageString,
-    priority
-  )
+
+  const onAborted = () => {
+    logger.info(
+      'BUILD_ABORTED',
+      {
+        requestId: ctx.state.id,
+        packageString,
+      },
+      `BUILD_ABORTED: client closed connection for package ${packageString}`
+    )
+    buildService.cancelPackageBuildStats(packageString)
+  }
+
+  ctx.req.on('close', onAborted)
+
+  let result: PackageBuildResult
+  try {
+    result = await buildService.getPackageBuildStats<PackageBuildResult>(
+      packageString,
+      priority
+    )
+  } finally {
+    ctx.req.off('close', onAborted)
+  }
+
   const buildEnd = now()
 
   ctx.cacheControl = {

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -82,6 +82,27 @@ const errorHandler: Middleware = async (ctx, next) => {
     }
 
     if (!(error instanceof Error)) {
+      const errObj = error as Record<string, unknown> | null
+      if (errObj && errObj.code === 'JOB_EXPIRED') {
+        ctx.cacheControl = { maxAge: 0 }
+        respondWithError(503, {
+          code: 'QueueTimeoutError',
+          message:
+            'The build queue is currently full and this request timed out. ' +
+            'Please try again in a few minutes.',
+        })
+        return
+      }
+      if (errObj && errObj.code === 'QUEUE_CLEARED') {
+        ctx.cacheControl = { maxAge: 0 }
+        respondWithError(503, {
+          code: 'QueueClearedError',
+          message:
+            'The build queue was cleared. Please try building the package again.',
+        })
+        return
+      }
+
       respondWithError(500, { code: 'UnknownError', details: error })
       return
     }
@@ -144,7 +165,7 @@ const errorHandler: Middleware = async (ctx, next) => {
         break
 
       case 'EntryPointError': {
-        const status = 500
+        const status = 422
         const body = {
           error: {
             code: 'EntryPointError',
@@ -165,7 +186,7 @@ const errorHandler: Middleware = async (ctx, next) => {
       }
 
       case 'MissingDependencyError': {
-        const status = 500
+        const status = 422
         const missingModulesList = err.extra?.missingModules ?? []
         const missingModules = formatSentence(
           missingModulesList.map(module => `\`<code>${module}</code>\``)
@@ -193,7 +214,7 @@ const errorHandler: Middleware = async (ctx, next) => {
       }
 
       case 'MinifyError': {
-        const status = 500
+        const status = 422
         const body = {
           error: {
             code: 'MinifyError',
@@ -220,13 +241,13 @@ const errorHandler: Middleware = async (ctx, next) => {
 
       case 'BuildError':
       default: {
-        const status = 500
+        const status = 422
         const errorJSON = {
           code: 'BuildError',
           message: 'Failed to build this package.',
           details: err,
         }
-        respondWithError(500, errorJSON)
+        respondWithError(status, errorJSON)
         debug('saved %s to failure cache', packageString)
         failureCache.set(packageString, {
           status,


### PR DESCRIPTION
Maps package-specific build failures (EntryPointError, MissingDependencyError, MinifyError, BuildError) to HTTP 422 Unprocessable Entity instead of 500. Maps request queue timeouts/clears to HTTP 503 Service Unavailable instead of 500 UnknownError. Implements request abort propagation in Koa and the queue to immediately abort worker pool builds and clean up slots when clients disconnect.