### PR TITLE
Bump package-build-stats to 8.3.0

### DIFF
--- a/build-service/package.json
+++ b/build-service/package.json
@@ -9,7 +9,7 @@
     "dotenv-defaults": "^2.0.2",
     "fastify": "^4.25.2",
     "now-logs": "^0.0.7",
-    "package-build-stats": "8.2.8"
+    "package-build-stats": "8.3.0"
   },
   "engines": {
     "node": ">= 9.x.x",

--- a/build-service/yarn.lock
+++ b/build-service/yarn.lock
@@ -2714,7 +2714,7 @@ __metadata:
     dotenv-defaults: "npm:^2.0.2"
     fastify: "npm:^4.25.2"
     now-logs: "npm:^0.0.7"
-    package-build-stats: "npm:8.2.8"
+    package-build-stats: "npm:8.3.0"
   languageName: unknown
   linkType: soft
 
@@ -7233,9 +7233,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-build-stats@npm:8.2.8":
-  version: 8.2.8
-  resolution: "package-build-stats@npm:8.2.8"
+"package-build-stats@npm:8.3.0":
+  version: 8.3.0
+  resolution: "package-build-stats@npm:8.3.0"
   dependencies:
     "@babel/core": "npm:^7.28.5"
     "@rspack/core": "npm:^1.6.0"
@@ -7272,7 +7272,7 @@ __metadata:
     yargs: "npm:^18.0.0"
   bin:
     package-stats: bin/cli.js
-  checksum: 51b6f4f9fcd74e4dfb3ab871131afbb78ed0bbdeba94224a0e2449971fc4c88599dfbb0572bee0ce1a5248c742749ec85b5ef01a72e2c12ac6ae986b6d019925
+  checksum: f80e48c4161828578929780bfaaf3dbf8ecded3d25b3e722c58ddcf52d17ffe35a571122955f6de85304b699fe85d188cc23058abde0dfc8b488d81790f5dee5
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node-fetch": "^2.7.0",
     "normalize.css": "^8.0.1",
     "p-queue": "^3.2.0",
-    "package-build-stats": "8.2.8",
+    "package-build-stats": "8.3.0",
     "pacote": "^11.3.5",
     "performance-now": "^2.1.0",
     "progress-stream": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7763,7 +7763,7 @@ __metadata:
     dotenv-defaults: "npm:^2.0.2"
     fastify: "npm:^4.25.2"
     now-logs: "npm:^0.0.7"
-    package-build-stats: "npm:8.2.8"
+    package-build-stats: "npm:8.3.0"
   languageName: unknown
   linkType: soft
 
@@ -7885,7 +7885,7 @@ __metadata:
     nodemon: "npm:^2.0.22"
     normalize.css: "npm:^8.0.1"
     p-queue: "npm:^3.2.0"
-    package-build-stats: "npm:8.2.8"
+    package-build-stats: "npm:8.3.0"
     pacote: "npm:^11.3.5"
     performance-now: "npm:^2.1.0"
     postcss: "npm:^8.4.33"
@@ -18873,9 +18873,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-build-stats@npm:8.2.8":
-  version: 8.2.8
-  resolution: "package-build-stats@npm:8.2.8"
+"package-build-stats@npm:8.3.0":
+  version: 8.3.0
+  resolution: "package-build-stats@npm:8.3.0"
   dependencies:
     "@babel/core": "npm:^7.28.5"
     "@rspack/core": "npm:^1.6.0"
@@ -18912,7 +18912,7 @@ __metadata:
     yargs: "npm:^18.0.0"
   bin:
     package-stats: bin/cli.js
-  checksum: 5fb8202d311f09c61613479bd065acb20701f7881ac72d8155ad5a3cc8d7559fa7be22ecdbc1a335ae891719ad6f5bc6ffbcce8e09848b85dc49b55b88ca7b14
+  checksum: 3da0203c1ea51e095ec189d0b8110e8d4f68c58d886751d33ac8355536d22b9f75435f50076212a722d089b0b1aa794e1c01f2284f2eb7f3df1b733c976cb0ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates both Bundlephobia dependency copies and both lockfiles to the published public npm release package-build-stats@8.3.0.\n\nVerified with a local production build.