### PR TITLE
Accept grouped Renovate branch name

### DIFF
--- a/.github/workflows/approve-renovate.yml
+++ b/.github/workflows/approve-renovate.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "$HEAD_REF" != renovate/package-build-stats-* ]]; then
+          if [[ "$HEAD_REF" != "renovate/package-build-stats" && "$HEAD_REF" != renovate/package-build-stats-* ]]; then
             echo "Unexpected Renovate branch: $HEAD_REF"
             exit 1
           fi


### PR DESCRIPTION
Allows the approval guard to accept Renovate's exact configured group slug as well as version-suffixed variants. All author, file, and version validation remains unchanged.