### PR TITLE
Fix malformed API error response handling

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -1,0 +1,88 @@
+import fetch from 'unfetch'
+
+import API from '../client/api'
+
+jest.mock('unfetch')
+
+const mockedFetch = fetch as jest.MockedFunction<typeof fetch>
+type APIResponse = Awaited<ReturnType<typeof fetch>>
+
+function mockResponse(
+  status: number,
+  json: () => Promise<unknown>
+): APIResponse {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json,
+  } as APIResponse
+}
+
+const requestMethods = [
+  ['GET', () => API.get('/test')],
+  ['POST', () => API.post('/test', { package: 'example' })],
+] as const
+
+describe('API error responses', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset()
+  })
+
+  test.each(requestMethods)(
+    '%s preserves a structured JSON error response',
+    async (_method, request) => {
+      const responseBody = {
+        error: {
+          code: 'PackageNotFoundError',
+          message: "The package you were looking for doesn't exist.",
+        },
+      }
+      mockedFetch.mockResolvedValue(
+        mockResponse(404, () => Promise.resolve(responseBody))
+      )
+
+      await expect(request()).rejects.toEqual(responseBody)
+    }
+  )
+
+  test.each([
+    ...requestMethods.map(
+      ([method, request]) => [method, 502, request] as const
+    ),
+    ...requestMethods.map(
+      ([method, request]) => [method, 503, request] as const
+    ),
+  ])(
+    '%s returns a retryable structured error for a malformed %s response',
+    async (_method, status, request) => {
+      mockedFetch.mockResolvedValue(
+        mockResponse(status, () => Promise.reject(new SyntaxError('HTML')))
+      )
+
+      await expect(request()).rejects.toEqual({
+        error: {
+          code: 'ServiceUnavailableError',
+          message:
+            'The build service is temporarily unavailable. Please try again in a few minutes.',
+        },
+      })
+    }
+  )
+
+  test.each(requestMethods)(
+    '%s returns a generic structured error for another malformed response',
+    async (_method, request) => {
+      mockedFetch.mockResolvedValue(
+        mockResponse(500, () => Promise.reject(new SyntaxError('HTML')))
+      )
+
+      await expect(request()).rejects.toEqual({
+        error: {
+          code: 'BuildError',
+          message:
+            "Oops, something went wrong and we don't have an appropriate error for this. Open an issue maybe?",
+        },
+      })
+    }
+  )
+})

--- a/client/api.ts
+++ b/client/api.ts
@@ -53,6 +53,43 @@ export type PackageExportSizesResponse = {
   assets: PackageExportAsset[]
 }
 
+type APIResponse = Awaited<ReturnType<typeof fetch>>
+
+const getFallbackError = (status: number) => {
+  if (status === 502 || status === 503) {
+    return {
+      error: {
+        code: 'ServiceUnavailableError',
+        message:
+          'The build service is temporarily unavailable. Please try again in a few minutes.',
+      },
+    }
+  }
+
+  return {
+    error: {
+      code: 'BuildError',
+      message:
+        "Oops, something went wrong and we don't have an appropriate error for this. Open an issue maybe?",
+    },
+  }
+}
+
+async function parseResponse<T>(response: APIResponse): Promise<T> {
+  if (response.ok) {
+    return response.json() as Promise<T>
+  }
+
+  let error: unknown
+  try {
+    error = await response.json()
+  } catch {
+    throw getFallbackError(response.status)
+  }
+
+  throw error
+}
+
 export default class API {
   static get<T = unknown>(url: string, isInternal = true): Promise<T> {
     const headers: Record<string, string> = {
@@ -62,32 +99,7 @@ export default class API {
     if (isInternal) {
       headers['X-Bundlephobia-User'] = 'bundlephobia website'
     }
-    return fetch(url, { headers }).then(res => {
-      if (!res.ok) {
-        try {
-          return res.json().then(err => Promise.reject(err))
-        } catch (e) {
-          if (res.status === 503) {
-            return Promise.reject({
-              error: {
-                code: 'TimeoutError',
-                message:
-                  'This is taking unusually long. Check back in a couple of minutes?',
-              },
-            })
-          }
-
-          return Promise.reject({
-            error: {
-              code: 'BuildError',
-              message:
-                "Oops, something went wrong and we don't have an appropriate error for this. Open an issue maybe?",
-            },
-          })
-        }
-      }
-      return res.json()
-    })
+    return fetch(url, { headers }).then(parseResponse<T>)
   }
 
   static post<T = unknown>(
@@ -104,22 +116,7 @@ export default class API {
       method: 'POST',
       headers,
       body: JSON.stringify(body),
-    }).then(res => {
-      if (!res.ok) {
-        try {
-          return res.json().then(err => Promise.reject(err))
-        } catch (e) {
-          return Promise.reject({
-            error: {
-              code: 'BuildError',
-              message:
-                "Oops, something went wrong and we don't have an appropriate error for this. Open an issue maybe?",
-            },
-          })
-        }
-      }
-      return res.json()
-    })
+    }).then(parseResponse<T>)
   }
 
   static getInfo(packageString: string) {


### PR DESCRIPTION
## Summary

- parse failed API response bodies asynchronously so JSON parse rejections are handled
- preserve structured JSON errors for both GET and POST requests
- map malformed 502/503 responses to a retryable `ServiceUnavailableError`
- keep other malformed responses on the structured generic `BuildError` path

## Tests

- `yarn test __tests__/api.test.ts __tests__/Queue.test.ts __tests__/utils.test.ts --runInBand --watchman=false` (16 passed)
- `yarn prettier --check client/api.ts __tests__/api.test.ts`
- `yarn build`
- pre-commit lint/type checks passed

A standalone `yarn tsc --noEmit --incremental false` still reports the repository baseline missing SVG module declarations; the production `yarn build` lint/type/build pipeline passes.