### PR TITLE
Render complete build error details

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,4 +1,5 @@
 import { parsePackageString } from '../utils/common.utils'
+import { resolveBuildError } from '../utils'
 
 describe('parsePackageString', () => {
   it('handles scoped packages correctly', () => {
@@ -53,5 +54,64 @@ describe('parsePackageString', () => {
       version: '0.7.0-beta',
       scope: undefined,
     })
+  })
+})
+
+describe('resolveBuildError', () => {
+  const resolveDetails = (originalError: unknown) =>
+    resolveBuildError({
+      error: {
+        code: 'BuildError',
+        message: 'Failed to build this package.',
+        details: { originalError },
+      },
+    }).errorDetails
+
+  it('preserves string details', () => {
+    expect(resolveDetails('plain failure')).toBe('plain failure')
+  })
+
+  it('preserves every array entry', () => {
+    expect(resolveDetails(['first failure', 'second failure'])).toBe(
+      'first failure\n\nsecond failure'
+    )
+  })
+
+  it('pretty-prints object details', () => {
+    expect(
+      resolveDetails({
+        reason: 'BUILD_SERVICE_UNREACHABLE',
+        retryable: true,
+      })
+    ).toBe(
+      JSON.stringify(
+        {
+          reason: 'BUILD_SERVICE_UNREACHABLE',
+          retryable: true,
+        },
+        null,
+        2
+      )
+    )
+  })
+
+  it('uses an Error message without exposing its stack', () => {
+    expect(resolveDetails(new Error('safe failure message'))).toBe(
+      'safe failure message'
+    )
+  })
+
+  it.each([null, undefined, '', '   ', []])(
+    'omits empty details: %p',
+    value => {
+      expect(resolveDetails(value)).toBeNull()
+    }
+  )
+
+  it('omits an object that cannot be serialized', () => {
+    const circular: { self?: unknown } = {}
+    circular.self = circular
+
+    expect(resolveDetails(circular)).toBeNull()
   })
 })

--- a/pages/package/[...packageString]/ResultPage.tsx
+++ b/pages/package/[...packageString]/ResultPage.tsx
@@ -536,7 +536,7 @@ class ResultPage extends PureComponent<ResultPageProps, ResultPageState> {
               />
               {errorDetails && (
                 <details className="result-error__details">
-                  <summary> Stacktrace</summary>
+                  <summary>Details</summary>
                   <pre>{errorDetails}</pre>
                 </details>
               )}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -78,11 +78,35 @@ export function zeroToN(n: number): number[] {
 }
 
 function toErrorDetail(originalError: unknown): string | null {
-  if (Array.isArray(originalError)) {
-    return originalError[0] == null ? null : String(originalError[0])
+  if (originalError == null) {
+    return null
   }
 
-  return originalError == null ? null : String(originalError)
+  if (typeof originalError === 'string') {
+    return originalError.trim() ? originalError : null
+  }
+
+  if (originalError instanceof Error) {
+    return originalError.message || null
+  }
+
+  if (Array.isArray(originalError)) {
+    const details = originalError
+      .map(toErrorDetail)
+      .filter((detail): detail is string => detail !== null)
+
+    return details.length ? details.join('\n\n') : null
+  }
+
+  if (typeof originalError === 'object') {
+    try {
+      return JSON.stringify(originalError, null, 2)
+    } catch {
+      return null
+    }
+  }
+
+  return String(originalError)
 }
 
 function isBuildErrorResponse(value: unknown): value is BuildErrorResponse {


### PR DESCRIPTION
## Summary

- preserve every entry in array-based build errors instead of showing only the first
- pretty-print structured object details instead of rendering `[object Object]`
- omit empty or unserializable details and show only the message for native `Error` values
- rename the package-page disclosure from `Stacktrace` to `Details`

## Reproduction

Before:
```text
string "plain failure"
array "first failure"
object "[object Object]"
empty null
```

After:
```text
string "plain failure"
array "first failure\n\nsecond failure"
object "{\n  \"reason\": \"BUILD_SERVICE_UNREACHABLE\",\n  \"retryable\": true\n}"
empty null
```

## Validation

- `yarn test __tests__/utils.test.ts __tests__/api.test.ts --runInBand --watchman=false` (24 passed)
- `yarn prettier --check utils/index.ts pages/package/[...packageString]/ResultPage.tsx __tests__/utils.test.ts`
- `yarn build`
- pre-commit lint/type checks passed
