### PR TITLE
fix: avoid caching build service outages

### DIFF
--- a/__tests__/build-service-unavailable.test.ts
+++ b/__tests__/build-service-unavailable.test.ts
@@ -1,0 +1,136 @@
+import axios from 'axios'
+
+import CustomError from '../server/CustomError'
+import BuildService from '../server/api/BuildService'
+import { failureCache, requestQueue } from '../server/init'
+import errorMiddleware from '../server/middlewares/results/error.middleware'
+
+jest.mock('../server/init', () => ({
+  failureCache: {
+    set: jest.fn(),
+  },
+  pool: {
+    exec: jest.fn(),
+  },
+  requestQueue: {
+    addExecutor: jest.fn(),
+    cancel: jest.fn(),
+    process: jest.fn(),
+  },
+}))
+
+jest.mock('../server/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}))
+
+const mockedFailureCache = failureCache as jest.Mocked<typeof failureCache>
+const mockedRequestQueue = requestQueue as jest.Mocked<typeof requestQueue>
+
+describe('build service unavailability', () => {
+  const originalBuildServiceEndpoint = process.env.BUILD_SERVICE_ENDPOINT
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.BUILD_SERVICE_ENDPOINT = 'http://127.0.0.1:7002'
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  afterAll(() => {
+    if (originalBuildServiceEndpoint === undefined) {
+      delete process.env.BUILD_SERVICE_ENDPOINT
+    } else {
+      process.env.BUILD_SERVICE_ENDPOINT = originalBuildServiceEndpoint
+    }
+  })
+
+  it('identifies a build service request that receives no response', async () => {
+    const url = 'http://127.0.0.1:7002/size?p=%40example%2Funavailable%401.0.0'
+    const networkError = Object.assign(new Error('connect ECONNREFUSED'), {
+      isAxiosError: true,
+      request: { _currentUrl: url },
+    })
+    jest.spyOn(axios, 'get').mockRejectedValue(networkError)
+
+    new BuildService()
+    const executor = mockedRequestQueue.addExecutor.mock.calls[0][1]
+
+    await expect(
+      executor({ packageString: '@example/unavailable@1.0.0' })
+    ).rejects.toMatchObject({
+      name: 'BuildServiceUnavailableError',
+      originalError: {
+        operation: 'PACKAGE_BUILD_STATS',
+        reason: 'BUILD_SERVICE_UNREACHABLE',
+        url,
+      },
+    })
+  })
+
+  it('returns a retryable response without caching the failure', async () => {
+    const ctx = {
+      query: {},
+      state: {
+        id: 'build-service-unavailable-test',
+        resolved: { packageString: '@example/unavailable@1.0.0' },
+      },
+    }
+    const error = new CustomError(
+      'BuildServiceUnavailableError',
+      { reason: 'BUILD_SERVICE_UNREACHABLE' },
+      undefined
+    )
+
+    await errorMiddleware(ctx as never, async () => {
+      throw error
+    })
+
+    expect(ctx).toMatchObject({
+      status: 503,
+      cacheControl: { maxAge: 0 },
+      body: {
+        error: {
+          code: 'BuildServiceUnavailableError',
+          message:
+            'The build service is temporarily unavailable. Please try again in a few minutes.',
+        },
+      },
+    })
+    expect(mockedFailureCache.set).not.toHaveBeenCalled()
+  })
+
+  it('continues caching genuine package build failures', async () => {
+    const packageString = '@example/build-error@1.0.0'
+    const ctx = {
+      query: {},
+      state: {
+        id: 'build-error-test',
+        resolved: { packageString },
+      },
+    }
+    const error = new CustomError('BuildError', 'parse failed', undefined)
+
+    await errorMiddleware(ctx as never, async () => {
+      throw error
+    })
+
+    expect(ctx).toMatchObject({
+      status: 422,
+      body: {
+        error: {
+          code: 'BuildError',
+          message: 'Failed to build this package.',
+        },
+      },
+    })
+    expect(mockedFailureCache.set).toHaveBeenCalledWith(
+      packageString,
+      expect.objectContaining({ status: 422 })
+    )
+  })
+})

--- a/server/api/BuildService.ts
+++ b/server/api/BuildService.ts
@@ -90,7 +90,7 @@ export default class BuildService {
     if (axios.isAxiosError(error) && error.request) {
       debug('No response received from build server. Is the server down?')
       throw new CustomError(
-        'BuildError',
+        'BuildServiceUnavailableError',
         {
           operation: operationType,
           reason: 'BUILD_SERVICE_UNREACHABLE',

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -111,6 +111,15 @@ const errorHandler: Middleware = async (ctx, next) => {
     const packageString = ctx.state.resolved.packageString
 
     switch (err.name) {
+      case 'BuildServiceUnavailableError':
+        ctx.cacheControl = { maxAge: 0 }
+        respondWithError(503, {
+          code: 'BuildServiceUnavailableError',
+          message:
+            'The build service is temporarily unavailable. Please try again in a few minutes.',
+        })
+        break
+
       case 'BlocklistedPackageError':
         respondWithError(403, {
           code: 'BlocklistedPackageError',


### PR DESCRIPTION
## Summary
- classify no-response build-service requests as BuildServiceUnavailableError
- return HTTP 503 with a retryable message and disable response caching
- keep genuine package BuildError responses at HTTP 422 and in the failure cache

## Production evidence
On July 27, transient BUILD_SERVICE_UNREACHABLE failures such as @lando-labs/lando-ds-meta@0.59.0 were returned as HTTP 422 and written to the six-hour failure cache. This caused a temporary infrastructure outage to appear as a deterministic package failure.

## Validation
- focused regression suite: 3 tests passed
- remaining non-server Jest suites: 29 tests passed
- production yarn build: passed
- Prettier check: passed

The seven existing errors-cache integration tests require a server on localhost:5000 and were not runnable as standalone Jest tests.