### PR TITLE
fix: keep canceled builds in queue accounting

### DIFF
--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -43,6 +43,35 @@ describe('Queue cancellation', () => {
 
     expect(mockCancel).toHaveBeenCalledTimes(1)
     await expect(p1).rejects.toThrow('JOB_CANCELLED')
-    expect(queue.getRunningJobs().length).toBe(0)
+    expect(queue.getRunningJobs().length).toBe(1)
+  })
+
+  it('keeps canceled work counted until its executor settles', async () => {
+    const queue = new Queue({ concurrency: 1 })
+
+    let resolveFirstJob: any
+    const firstJobPromise = new Promise(resolve => {
+      resolveFirstJob = resolve
+    })
+    const executor = jest
+      .fn()
+      .mockReturnValueOnce(firstJobPromise)
+      .mockResolvedValueOnce(undefined)
+    queue.addExecutor('TEST', executor)
+
+    const p1 = queue.process('job-1', 'TEST', {})
+    const p2 = queue.process('job-2', 'TEST', {})
+
+    queue.cancel('job-1', 'TEST')
+
+    await expect(p1).rejects.toThrow('JOB_CANCELLED')
+    expect(executor).toHaveBeenCalledTimes(1)
+    expect(queue.getRunningJobs().length).toBe(1)
+    expect(queue.getReadyJobs().length).toBe(1)
+
+    resolveFirstJob()
+    await p2
+
+    expect(executor).toHaveBeenCalledTimes(2)
   })
 })

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -146,8 +146,10 @@ class Queue {
       job.failureListeners.forEach(listener => {
         listener(new Error('JOB_CANCELLED'))
       })
-      this.removeJob(id, type)
-      this.executeNextJobIfPossible()
+      if (job.status === JobStatus.READY) {
+        this.removeJob(id, type)
+        this.executeNextJobIfPossible()
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- keep processing jobs in queue accounting after cancellation until their executor actually settles
- continue removing ready jobs immediately when canceled
- prevent a still-running canceled build from freeing capacity for hidden duplicate work

## Scope
This is intentionally a minimal fix. Subscriber-level cancellation and end-to-end Axios abort behavior are not changed here.

## Validation
- Queue regression suite: 3 tests passed
- related unit suites: 30 tests passed
- production yarn build: passed
- Prettier check: passed