### PR TITLE
fix: preserve build service errors

### DIFF
--- a/__tests__/build-service-unavailable.test.ts
+++ b/__tests__/build-service-unavailable.test.ts
@@ -1,5 +1,6 @@
 import axios from 'axios'
 
+import serializeError from '../build-service/serializeError'
 import CustomError from '../server/CustomError'
 import BuildService from '../server/api/BuildService'
 import { failureCache, requestQueue } from '../server/init'
@@ -72,6 +73,47 @@ describe('build service unavailability', () => {
     })
   })
 
+  it('serializes native errors into the build-service error contract', () => {
+    const error = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+
+    expect(serializeError(error)).toEqual({
+      name: 'BuildServiceError',
+      originalError: {
+        message: 'disk full',
+        code: 'ENOSPC',
+      },
+      extra: { retryable: true },
+    })
+  })
+
+  it('preserves structured package build errors', () => {
+    const serialized = {
+      name: 'EntryPointError',
+      originalError: 'No package entry point',
+      extra: undefined,
+    }
+
+    expect(serializeError({ toJSON: () => serialized })).toBe(serialized)
+  })
+
+  it('identifies a structured internal build-service error', async () => {
+    const responseBody = serializeError(
+      Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    )
+    const responseError = Object.assign(new Error('Request failed'), {
+      isAxiosError: true,
+      response: { data: responseBody },
+    })
+    jest.spyOn(axios, 'get').mockRejectedValue(responseError)
+
+    new BuildService()
+    const executor = mockedRequestQueue.addExecutor.mock.calls[0][1]
+
+    await expect(
+      executor({ packageString: '@example/internal-error@1.0.0' })
+    ).rejects.toMatchObject(responseBody)
+  })
+
   it('returns a retryable response without caching the failure', async () => {
     const ctx = {
       query: {},
@@ -98,6 +140,38 @@ describe('build service unavailability', () => {
           code: 'BuildServiceUnavailableError',
           message:
             'The build service is temporarily unavailable. Please try again in a few minutes.',
+        },
+      },
+    })
+    expect(mockedFailureCache.set).not.toHaveBeenCalled()
+  })
+
+  it('does not cache internal build-service errors', async () => {
+    const ctx = {
+      query: {},
+      state: {
+        id: 'build-service-error-test',
+        resolved: { packageString: '@example/internal-error@1.0.0' },
+      },
+    }
+    const error = new CustomError(
+      'BuildServiceError',
+      { message: 'disk full', code: 'ENOSPC' },
+      { retryable: true }
+    )
+
+    await errorMiddleware(ctx as never, async () => {
+      throw error
+    })
+
+    expect(ctx).toMatchObject({
+      status: 503,
+      cacheControl: { maxAge: 0 },
+      body: {
+        error: {
+          code: 'BuildServiceError',
+          message:
+            'The build service encountered a temporary error. Please try again in a few minutes.',
         },
       },
     })

--- a/build-service/index.js
+++ b/build-service/index.js
@@ -7,6 +7,7 @@ import {
   eventQueue,
 } from 'package-build-stats'
 import Amplitude from '@amplitude/node'
+import serializeError from './serializeError.js'
 
 const fastify = Fastify()
 
@@ -37,8 +38,7 @@ fastify.get('/size', async (req, res) => {
     return res.code(200).send(result)
   } catch (err) {
     console.log(err)
-    const errorToSend = 'toJSON' in err ? err.toJSON() : err
-    return res.code(500).send(errorToSend)
+    return res.code(500).send(serializeError(err))
   }
 })
 
@@ -52,8 +52,7 @@ fastify.get('/exports-sizes', async (req, res) => {
     return res.code(200).send(result)
   } catch (err) {
     console.log(err)
-    const errorToSend = 'toJSON' in err ? err.toJSON() : err
-    return res.code(500).send(errorToSend)
+    return res.code(500).send(serializeError(err))
   }
 })
 
@@ -67,8 +66,7 @@ fastify.get('/exports', async (req, res) => {
     return res.code(200).send(result)
   } catch (err) {
     console.log(err)
-    const errorToSend = 'toJSON' in err ? err.toJSON() : err
-    return res.code(500).send(errorToSend)
+    return res.code(500).send(serializeError(err))
   }
 })
 

--- a/build-service/serializeError.js
+++ b/build-service/serializeError.js
@@ -1,0 +1,29 @@
+function getErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export default function serializeError(error) {
+  if (
+    error &&
+    typeof error === 'object' &&
+    typeof error.toJSON === 'function'
+  ) {
+    const serialized = error.toJSON()
+    if (
+      serialized &&
+      typeof serialized === 'object' &&
+      typeof serialized.name === 'string'
+    ) {
+      return serialized
+    }
+  }
+
+  return {
+    name: 'BuildServiceError',
+    originalError: {
+      message: getErrorMessage(error),
+      ...(typeof error?.code === 'string' ? { code: error.code } : {}),
+    },
+    extra: { retryable: true },
+  }
+}

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -111,6 +111,15 @@ const errorHandler: Middleware = async (ctx, next) => {
     const packageString = ctx.state.resolved.packageString
 
     switch (err.name) {
+      case 'BuildServiceError':
+        ctx.cacheControl = { maxAge: 0 }
+        respondWithError(503, {
+          code: 'BuildServiceError',
+          message:
+            'The build service encountered a temporary error. Please try again in a few minutes.',
+        })
+        break
+
       case 'BuildServiceUnavailableError':
         ctx.cacheControl = { maxAge: 0 }
         respondWithError(503, {


### PR DESCRIPTION
## Summary
- serialize native build-service errors into the name/originalError/extra contract expected by main
- preserve existing structured package-build-stats errors
- return unexpected build-service failures as non-cacheable HTTP 503 responses
- use the same serializer for size, exports, and export-size endpoints

## Reproduction
A native Error with message disk full and code ENOSPC currently becomes this Fastify response:

    {statusCode: 500, code: ENOSPC, error: Internal Server Error, message: disk full}

That response does not match the contract consumed by BuildService.handleError. Main discards its message and code, maps it to generic BuildError, returns HTTP 422, and writes the package to failureCache. The original handover described the wire value as an empty object; the exact Fastify replay showed the more precise contract mismatch above, with the same incorrect cached-422 outcome.

After this change the build service sends BuildServiceError with preserved internal message/code, and main returns a sanitized HTTP 503 with max-age 0 and no failure-cache entry.

## Validation
- exact Fastify inject reproduction before and after the fix
- focused error-contract suite: 7 tests passed
- related unit suites: 34 tests passed
- build-service syntax checks passed
- production yarn build passed