### PR TITLE
fix: show concise install error details

### DIFF
--- a/__tests__/build-service-unavailable.test.ts
+++ b/__tests__/build-service-unavailable.test.ts
@@ -96,6 +96,28 @@ describe('build service unavailability', () => {
     expect(serializeError({ toJSON: () => serialized })).toBe(serialized)
   })
 
+  it('summarizes install failures without exposing package manager output', () => {
+    const originalError = {
+      exitCode: 128,
+      signal: null,
+      stderr: 'full package manager output',
+    }
+    const error = {
+      originalError,
+      toJSON: () => ({
+        name: 'InstallError',
+        originalError,
+        extra: undefined,
+      }),
+    }
+
+    expect(serializeError(error)).toEqual({
+      name: 'InstallError',
+      originalError: 'Package manager exited with code 128.',
+      extra: undefined,
+    })
+  })
+
   it('identifies a structured internal build-service error', async () => {
     const responseBody = serializeError(
       Object.assign(new Error('disk full'), { code: 'ENOSPC' })
@@ -175,6 +197,50 @@ describe('build service unavailability', () => {
         },
       },
     })
+    expect(mockedFailureCache.set).not.toHaveBeenCalled()
+  })
+
+  it('returns the short install error summary', async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+    const ctx = {
+      query: {},
+      state: {
+        id: 'install-error-test',
+        resolved: { packageString: '@example/install-error@1.0.0' },
+      },
+    }
+    const error = new CustomError(
+      'InstallError',
+      'Package manager exited with code 128.',
+      undefined
+    )
+
+    await errorMiddleware(ctx as never, async () => {
+      throw error
+    })
+
+    const responseError = (
+      ctx as unknown as {
+        body: {
+          error: {
+            details: { originalError: string }
+          }
+        }
+      }
+    ).body.error
+    const detail = responseError.details.originalError
+
+    expect(ctx).toMatchObject({
+      status: 500,
+      cacheControl: { maxAge: 0 },
+      body: {
+        error: {
+          code: 'InstallError',
+          message: 'Installing the package failed.',
+        },
+      },
+    })
+    expect(detail).toBe('Package manager exited with code 128.')
     expect(mockedFailureCache.set).not.toHaveBeenCalled()
   })
 

--- a/build-service/serializeError.js
+++ b/build-service/serializeError.js
@@ -2,6 +2,19 @@ function getErrorMessage(error) {
   return error instanceof Error ? error.message : String(error)
 }
 
+function getInstallErrorSummary(error) {
+  if (!error || typeof error !== 'object') {
+    return undefined
+  }
+  if (typeof error.signal === 'string') {
+    return `Package installation was terminated by ${error.signal}.`
+  }
+  if (typeof error.exitCode === 'number') {
+    return `Package manager exited with code ${error.exitCode}.`
+  }
+  return undefined
+}
+
 export default function serializeError(error) {
   if (
     error &&
@@ -14,6 +27,12 @@ export default function serializeError(error) {
       typeof serialized === 'object' &&
       typeof serialized.name === 'string'
     ) {
+      if (serialized.name === 'InstallError') {
+        return {
+          ...serialized,
+          originalError: getInstallErrorSummary(error.originalError),
+        }
+      }
       return serialized
     }
   }

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -176,6 +176,9 @@ const errorHandler: Middleware = async (ctx, next) => {
         respondWithError(500, {
           code: 'InstallError',
           message: 'Installing the package failed.',
+          details: {
+            originalError: err.originalError,
+          },
         })
         ctx.cacheControl = {
           maxAge: 0,


### PR DESCRIPTION
## Summary
- summarize installer failures at the build-service boundary using structured exitCode or signal data
- pass only that short summary to the existing InstallError Details UI
- keep full package-manager stdout and stderr in server logs
- preserve the existing HTTP 500 and no-cache behavior

## Example
A package-manager failure with exitCode 128 is exposed as:

    Package manager exited with code 128.

Full npm, Bun, Yarn, or Git output is not included in the public response. No output parsing or redaction regexes are used.

## Validation
- serializer and middleware regression tests
- related unit suites: 36 tests passed
- build-service syntax check passed
- Prettier check passed
- production yarn build passed