### PR TITLE
Capture heap diagnostics before PM2 memory restarts

### DIFF
--- a/__tests__/memory-diagnostics.test.ts
+++ b/__tests__/memory-diagnostics.test.ts
@@ -1,0 +1,99 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const {
+  createMemoryDiagnostics,
+  parseBytes,
+} = require('../scripts/memory-diagnostics.cjs')
+
+describe('memory diagnostics', () => {
+  let outputRoot
+
+  beforeEach(() => {
+    outputRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'bundlephobia-memory-diagnostics-')
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(outputRoot, { recursive: true, force: true })
+  })
+
+  test('parses PM2-style byte values', () => {
+    expect(parseBytes('425M')).toBe(425 * 1024 ** 2)
+    expect(parseBytes('1G')).toBe(1024 ** 3)
+    expect(() => parseBytes('425MB')).toThrow('Invalid byte value')
+  })
+
+  test('keeps one completed snapshot and skips captures during cooldown', () => {
+    fs.mkdirSync(path.join(outputRoot, 'build-service'))
+    fs.writeFileSync(
+      path.join(
+        outputRoot,
+        'build-service',
+        '.latest-interrupted.heapsnapshot'
+      ),
+      'partial'
+    )
+    const report = {
+      excludeEnv: false,
+      writeReport: filename => fs.writeFileSync(filename, '{}'),
+    }
+    const writeHeapSnapshot = filename => fs.writeFileSync(filename, 'snapshot')
+    const diagnostics = createMemoryDiagnostics({
+      service: 'build-service',
+      thresholdBytes: 100,
+      outputRoot,
+      intervalMs: 60_000,
+      minFreeBytes: 0,
+      memoryUsage: () => ({ rss: 101, heapUsed: 10 }),
+      report,
+      writeHeapSnapshot,
+      now: () => Date.parse('2026-07-28T00:00:00Z'),
+      pid: 123,
+      logger: { error: jest.fn() },
+    })
+
+    expect(diagnostics.check()).toBe(true)
+    expect(report.excludeEnv).toBe(true)
+    expect(
+      fs.existsSync(
+        path.join(
+          outputRoot,
+          'build-service',
+          '.latest-interrupted.heapsnapshot'
+        )
+      )
+    ).toBe(false)
+    expect(
+      fs.readFileSync(
+        path.join(outputRoot, 'build-service', 'latest.heapsnapshot'),
+        'utf8'
+      )
+    ).toBe('snapshot')
+    expect(diagnostics.check()).toBe(false)
+    expect(
+      fs
+        .readdirSync(path.join(outputRoot, 'build-service'))
+        .filter(filename => filename.endsWith('.heapsnapshot'))
+    ).toEqual(['latest.heapsnapshot'])
+    diagnostics.stop()
+  })
+
+  test('does not capture below the configured RSS threshold', () => {
+    const writeHeapSnapshot = jest.fn()
+    const diagnostics = createMemoryDiagnostics({
+      service: 'main',
+      thresholdBytes: 100,
+      outputRoot,
+      intervalMs: 60_000,
+      memoryUsage: () => ({ rss: 99 }),
+      writeHeapSnapshot,
+    })
+
+    expect(diagnostics.check()).toBe(false)
+    expect(writeHeapSnapshot).not.toHaveBeenCalled()
+    diagnostics.stop()
+  })
+})

--- a/process.yml
+++ b/process.yml
@@ -2,6 +2,8 @@ apps:
   - script: './index.js'
     args: '--project tsconfig.server.json ./index.ts'
     name: main
+    node_args:
+      - --require=./scripts/memory-diagnostics.cjs
     instances: 1
     max_memory_restart: 500M
     error_file: logs/index.log
@@ -14,9 +16,14 @@ apps:
       PORT: 5400
       CACHE_SERVICE_ENDPOINT: http://localhost:7001
       BUILD_SERVICE_ENDPOINT: http://localhost:7002
+      MEMORY_DIAGNOSTICS_SERVICE: main
+      MEMORY_DIAGNOSTICS_RSS_THRESHOLD: 425M
+      MEMORY_DIAGNOSTICS_DIR: /var/cache/bundlephobia/diagnostics
 
   - script: ./build-service/index.js
     name: build-service
+    node_args:
+      - --require=./scripts/memory-diagnostics.cjs
     instances: 3
     max_memory_restart: 1000M
     exec_mode: cluster
@@ -26,9 +33,14 @@ apps:
     env:
       NODE_ENV: production
       DEBUG: 'bp:*'
+      MEMORY_DIAGNOSTICS_SERVICE: build-service
+      MEMORY_DIAGNOSTICS_RSS_THRESHOLD: 850M
+      MEMORY_DIAGNOSTICS_DIR: /var/cache/bundlephobia/diagnostics
 
   - script: ./cache-service/index.js
     name: cache-service
+    node_args:
+      - --require=./scripts/memory-diagnostics.cjs
     instances: 1
     max_memory_restart: 200M
     exec_mode: cluster
@@ -38,3 +50,6 @@ apps:
     env:
       NODE_ENV: production
       DEBUG: 'bp:*'
+      MEMORY_DIAGNOSTICS_SERVICE: cache-service
+      MEMORY_DIAGNOSTICS_RSS_THRESHOLD: 170M
+      MEMORY_DIAGNOSTICS_DIR: /var/cache/bundlephobia/diagnostics

--- a/scripts/memory-diagnostics.cjs
+++ b/scripts/memory-diagnostics.cjs
@@ -1,0 +1,229 @@
+const fs = require('fs')
+const path = require('path')
+const v8 = require('v8')
+
+const GIB = 1024 ** 3
+const DEFAULT_INTERVAL_MS = 3000
+const DEFAULT_COOLDOWN_MS = 10 * 60 * 1000
+const DEFAULT_MIN_FREE_BYTES = 8 * GIB
+
+function parseBytes(value) {
+  const match = /^(\d+)([KMG])?$/i.exec(String(value || '').trim())
+  if (!match) {
+    throw new Error(`Invalid byte value: ${value}`)
+  }
+
+  const units = { K: 1024, M: 1024 ** 2, G: GIB }
+  return Number(match[1]) * (units[match[2]?.toUpperCase()] || 1)
+}
+
+function getAvailableBytes(directory, fsImpl = fs) {
+  const stats = fsImpl.statfsSync(directory, { bigint: true })
+  return Number(stats.bavail * stats.bsize)
+}
+
+function createMemoryDiagnostics(options) {
+  const {
+    service,
+    thresholdBytes,
+    outputRoot,
+    intervalMs = DEFAULT_INTERVAL_MS,
+    cooldownMs = DEFAULT_COOLDOWN_MS,
+    minFreeBytes = DEFAULT_MIN_FREE_BYTES,
+    fsImpl = fs,
+    memoryUsage = process.memoryUsage,
+    report = process.report,
+    writeHeapSnapshot = v8.writeHeapSnapshot,
+    now = Date.now,
+    pid = process.pid,
+    logger = console,
+  } = options
+
+  const serviceDirectory = path.join(
+    outputRoot,
+    service.replace(/[^a-z0-9_-]/gi, '_')
+  )
+  const latestSnapshot = path.join(serviceDirectory, 'latest.heapsnapshot')
+  const lockDirectory = path.join(outputRoot, '.capture.lock')
+  const lockOwner = path.join(lockDirectory, 'pid')
+  let handled = false
+
+  function releaseLock() {
+    fsImpl.rmSync(lockDirectory, { recursive: true, force: true })
+  }
+
+  function acquireLock() {
+    try {
+      fsImpl.mkdirSync(lockDirectory)
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error
+      }
+
+      try {
+        const ownerPid = Number(fsImpl.readFileSync(lockOwner, 'utf8'))
+        if (!Number.isInteger(ownerPid) || ownerPid < 1) {
+          throw new Error('Invalid lock owner')
+        }
+        process.kill(ownerPid, 0)
+        return false
+      } catch (lockError) {
+        if (lockError.code === 'EPERM') {
+          return false
+        }
+        fsImpl.rmSync(lockDirectory, { recursive: true, force: true })
+        fsImpl.mkdirSync(lockDirectory)
+      }
+    }
+
+    fsImpl.writeFileSync(lockOwner, String(pid), { mode: 0o600 })
+    return true
+  }
+
+  function removeIncompleteCaptures() {
+    for (const filename of fsImpl.readdirSync(serviceDirectory)) {
+      if (filename.startsWith('.latest-')) {
+        fsImpl.rmSync(path.join(serviceDirectory, filename), { force: true })
+      }
+    }
+  }
+
+  fsImpl.mkdirSync(serviceDirectory, { recursive: true, mode: 0o700 })
+  if (acquireLock()) {
+    removeIncompleteCaptures()
+    releaseLock()
+  }
+
+  function check() {
+    const memory = memoryUsage()
+    if (handled || memory.rss < thresholdBytes) {
+      return false
+    }
+
+    if (!acquireLock()) {
+      return false
+    }
+    handled = true
+    removeIncompleteCaptures()
+
+    const suffix = `${now()}-${pid}`
+    const temporarySnapshot = path.join(
+      serviceDirectory,
+      `.latest-${suffix}.heapsnapshot`
+    )
+    const temporaryReport = path.join(
+      serviceDirectory,
+      `.latest-${suffix}.report.json`
+    )
+    const temporaryMetadata = path.join(
+      serviceDirectory,
+      `.latest-${suffix}.metadata.json`
+    )
+
+    try {
+      if (
+        fsImpl.existsSync(latestSnapshot) &&
+        now() - fsImpl.statSync(latestSnapshot).mtimeMs < cooldownMs
+      ) {
+        return false
+      }
+
+      const requiredFreeBytes = Math.max(minFreeBytes, thresholdBytes * 3)
+      if (getAvailableBytes(serviceDirectory, fsImpl) < requiredFreeBytes) {
+        logger.error(
+          `[memory-diagnostics] Skipping ${service} heap snapshot: insufficient free disk space`
+        )
+        return false
+      }
+
+      logger.error(
+        `[memory-diagnostics] Capturing ${service} at ${memory.rss} bytes RSS`
+      )
+
+      if (report) {
+        report.excludeEnv = true
+        report.writeReport(temporaryReport)
+        fsImpl.chmodSync(temporaryReport, 0o600)
+      }
+
+      let smapsRollup
+      try {
+        smapsRollup = fsImpl.readFileSync('/proc/self/smaps_rollup', 'utf8')
+      } catch {}
+
+      fsImpl.writeFileSync(
+        temporaryMetadata,
+        JSON.stringify(
+          {
+            service,
+            pid,
+            capturedAt: new Date(now()).toISOString(),
+            memory,
+            smapsRollup,
+          },
+          null,
+          2
+        ),
+        { mode: 0o600 }
+      )
+
+      writeHeapSnapshot(temporarySnapshot)
+      fsImpl.renameSync(temporarySnapshot, latestSnapshot)
+      if (report) {
+        fsImpl.renameSync(
+          temporaryReport,
+          path.join(serviceDirectory, 'latest.report.json')
+        )
+      }
+      fsImpl.renameSync(
+        temporaryMetadata,
+        path.join(serviceDirectory, 'latest.metadata.json')
+      )
+      logger.error(`[memory-diagnostics] Captured ${service} heap snapshot`)
+      return true
+    } catch (error) {
+      logger.error(
+        `[memory-diagnostics] Failed to capture ${service}: ${error.message}`
+      )
+      return false
+    } finally {
+      for (const filename of [
+        temporarySnapshot,
+        temporaryReport,
+        temporaryMetadata,
+      ]) {
+        try {
+          fsImpl.rmSync(filename, { force: true })
+        } catch {}
+      }
+      releaseLock()
+    }
+  }
+
+  const timer = setInterval(check, intervalMs)
+  timer.unref()
+  return { check, stop: () => clearInterval(timer) }
+}
+
+function startFromEnvironment() {
+  const service = process.env.MEMORY_DIAGNOSTICS_SERVICE
+  const threshold = process.env.MEMORY_DIAGNOSTICS_RSS_THRESHOLD
+  if (!service || !threshold) {
+    return
+  }
+
+  createMemoryDiagnostics({
+    service,
+    thresholdBytes: parseBytes(threshold),
+    outputRoot:
+      process.env.MEMORY_DIAGNOSTICS_DIR || path.resolve('diagnostics'),
+  })
+}
+
+startFromEnvironment()
+
+module.exports = {
+  createMemoryDiagnostics,
+  getAvailableBytes,
+  parseBytes,
+}


### PR DESCRIPTION
## Summary
- preload one shared memory diagnostic for main, build-service, and cache-service
- capture one latest heap snapshot, diagnostic report, and RSS metadata per service before the existing PM2 memory limit
- serialize captures across workers and require sufficient free disk space so diagnostics do not compound an incident

## Thresholds
- main: 425 MiB (PM2 restart: 500 MiB)
- build-service: 850 MiB (PM2 restart: 1,000 MiB)
- cache-service: 170 MiB (PM2 restart: 200 MiB)

Files are retained under `/var/cache/bundlephobia/diagnostics/<service>/latest.*`; environment variables are excluded from Node diagnostic reports and files are mode 0600.

## Validation
- `node_modules/.bin/jest __tests__/memory-diagnostics.test.ts --runInBand --watchman=false`
- `corepack yarn lint`
- `corepack yarn build`
- real Node 24 heap/report smoke capture

The full Jest invocation also reaches the existing `errors-cache` integration suite, whose seven requests fail with `ECONNREFUSED` when no local server is running; all other suites pass.