### PR TITLE
Add unobtrusive EthicalAds placement to homepage

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import Script from 'next/script'
 
 import Analytics from '../client/analytics'
 import { AutocompleteInput } from '../client/components/AutocompleteInput'
@@ -95,6 +96,16 @@ const Logo = () => (
   </svg>
 )
 
+const loadEthicalAd = () => {
+  const ethicalads = (
+    window as typeof window & {
+      ethicalads?: { load: () => void }
+    }
+  ).ethicalads
+
+  ethicalads?.load()
+}
+
 const Home = () => {
   const router = useRouter()
 
@@ -114,6 +125,12 @@ const Home = () => {
       <MetaTags
         title="Bundlephobia | Size of npm dependencies"
         canonicalPath=""
+      />
+      <Script
+        id="ethicalads-client"
+        src="https://media.ethicalads.io/media/client/ethicalads.min.js"
+        strategy="afterInteractive"
+        onReady={loadEthicalAd}
       />
       <div className="homepage__container">
         <PageNav minimal={true} />
@@ -143,6 +160,14 @@ const Home = () => {
               <sup>beta</sup>
             </Link>
           </div>
+          <div
+            id="homepage-text"
+            className="homepage__ethical-ad flat adaptive-css"
+            data-ea-publisher="bundlephobiacom"
+            data-ea-type="text"
+            data-ea-manual="true"
+            data-ea-verbosity="quiet"
+          />
         </div>
       </div>
     </Layout>

--- a/pages/index.scss
+++ b/pages/index.scss
@@ -97,7 +97,6 @@
 
 .homepage__scan-link {
   margin-top: 4vh;
-  margin-bottom: 14vh;
   letter-spacing: 0.5px;
 
   a {
@@ -113,7 +112,39 @@
   }
 
   @media screen and (max-width: 40em) {
-    margin-bottom: 20vh;
+    margin-top: 3vh;
+  }
+}
+
+.homepage__ethical-ad {
+  --ea-bgcolor: transparent;
+  --ea-bgcolor-dark: transparent;
+  --ea-font-family: #{$font-family-body};
+  --ea-font-size: 12px;
+
+  width: min(32rem, 100%);
+  min-height: 102px;
+  margin-top: 5vh;
+  margin-bottom: 5vh;
+  color: var(--color-text-muted);
+
+  &.loaded {
+    .ea-content {
+      margin: 0;
+      padding: $global-spacing;
+      text-align: center;
+    }
+
+    .ea-callout {
+      margin: $global-spacing * 0.5 0 0;
+      padding: 0;
+      text-align: center;
+    }
+  }
+
+  @media screen and (max-width: 40em) {
+    margin-top: 4vh;
+    margin-bottom: 3vh;
   }
 }
 


### PR DESCRIPTION
## Summary

- load the EthicalAds client on the homepage after the page becomes interactive
- add a single text-only, flat placement for `bundlephobiacom`
- manually reload the placement when the homepage remounts during Next.js navigation
- reserve placement height and use transparent, theme-adaptive styling to avoid layout shift and visual interruption

## Why text-only

EthicalAds recommends showing one ad at page load. A text-only placement beneath the secondary scan link was the least intrusive option in desktop, mobile, light, and dark comparisons. Sticky, fixed, and image variants were intentionally excluded.

## Verification

- `yarn lint` (passes with existing unrelated warnings)
- `yarn build`
- confirmed the client initializes and requests `text-v1` for publisher `bundlephobiacom`
- confirmed `/scan` → `/` client-side navigation recreates exactly one placement and requests a fresh ad
- confirmed the publisher returns a valid decision when requested for `https://bundlephobia.com/`
- checked desktop, mobile, light, and dark layouts
- measured unchanged positions for the logo, scan link, and reserved ad slot before and after ad content loads

Docs: https://ethical-ad-client.readthedocs.io/en/stable/