### PR TITLE
Prevent disconnected clients from cancelling shared builds

### DIFF
--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -19,7 +19,10 @@ describe('Queue cancellation', () => {
 
     queue.cancel('job-2', 'TEST')
 
-    await expect(p2).rejects.toThrow('JOB_CANCELLED')
+    await expect(p2).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+      name: 'JobCancelledError',
+    })
     expect(queue.getReadyJobs().length).toBe(0)
 
     resolveFirstJob()
@@ -42,7 +45,10 @@ describe('Queue cancellation', () => {
     queue.cancel('job-1', 'TEST')
 
     expect(mockCancel).toHaveBeenCalledTimes(1)
-    await expect(p1).rejects.toThrow('JOB_CANCELLED')
+    await expect(p1).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+      name: 'JobCancelledError',
+    })
     expect(queue.getRunningJobs().length).toBe(1)
   })
 
@@ -64,7 +70,10 @@ describe('Queue cancellation', () => {
 
     queue.cancel('job-1', 'TEST')
 
-    await expect(p1).rejects.toThrow('JOB_CANCELLED')
+    await expect(p1).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+      name: 'JobCancelledError',
+    })
     expect(executor).toHaveBeenCalledTimes(1)
     expect(queue.getRunningJobs().length).toBe(1)
     expect(queue.getReadyJobs().length).toBe(1)

--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -1,3 +1,5 @@
+import AbortController from 'abort-controller'
+
 import Queue from '../server/Queue'
 
 describe('Queue cancellation', () => {
@@ -82,5 +84,114 @@ describe('Queue cancellation', () => {
     await p2
 
     expect(executor).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps shared work running when one subscriber aborts', async () => {
+    const queue = new Queue({ concurrency: 1 })
+    const firstSubscriber = new AbortController()
+    const secondSubscriber = new AbortController()
+    const cancelExecutor = jest.fn()
+    let resolveJob: (value: string) => void = () => {}
+    const jobPromise = new Promise<string>(resolve => {
+      resolveJob = resolve
+    }) as Promise<string> & { cancel?: () => void }
+    jobPromise.cancel = cancelExecutor
+
+    queue.addExecutor('TEST', () => jobPromise)
+
+    const firstResult = queue.process<string, object>(
+      'shared-job',
+      'TEST',
+      {},
+      {
+        signal: firstSubscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+    const secondResult = queue.process<string, object>(
+      'shared-job',
+      'TEST',
+      {},
+      {
+        signal: secondSubscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+
+    firstSubscriber.abort()
+
+    await expect(firstResult).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+    })
+    expect(cancelExecutor).not.toHaveBeenCalled()
+
+    resolveJob('result')
+
+    await expect(secondResult).resolves.toBe('result')
+    expect(cancelExecutor).not.toHaveBeenCalled()
+  })
+
+  it('cancels shared work after its final subscriber aborts', async () => {
+    const queue = new Queue({ concurrency: 1 })
+    const firstSubscriber = new AbortController()
+    const secondSubscriber = new AbortController()
+    const cancelExecutor = jest.fn()
+    const jobPromise = new Promise(() => {}) as Promise<never> & {
+      cancel?: () => void
+    }
+    jobPromise.cancel = cancelExecutor
+
+    queue.addExecutor('TEST', () => jobPromise)
+
+    const firstResult = queue.process(
+      'shared-job',
+      'TEST',
+      {},
+      {
+        signal: firstSubscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+    const secondResult = queue.process(
+      'shared-job',
+      'TEST',
+      {},
+      {
+        signal: secondSubscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+
+    firstSubscriber.abort()
+    await expect(firstResult).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+    })
+    expect(cancelExecutor).not.toHaveBeenCalled()
+
+    secondSubscriber.abort()
+    await expect(secondResult).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+    })
+    expect(cancelExecutor).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not enqueue work for an already aborted subscriber', async () => {
+    const queue = new Queue({ concurrency: 1 })
+    const subscriber = new AbortController()
+    const executor = jest.fn()
+    subscriber.abort()
+    queue.addExecutor('TEST', executor)
+
+    const result = queue.process(
+      'job',
+      'TEST',
+      {},
+      {
+        signal: subscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+
+    await expect(result).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+    })
+    expect(executor).not.toHaveBeenCalled()
+    expect(queue.getReadyJobs()).toHaveLength(0)
+    expect(queue.getRunningJobs()).toHaveLength(0)
   })
 })

--- a/__tests__/build-cancellation.test.ts
+++ b/__tests__/build-cancellation.test.ts
@@ -1,0 +1,151 @@
+import AbortController from 'abort-controller'
+import { EventEmitter } from 'events'
+
+const mockGetPackageBuildStats = jest.fn()
+
+jest.mock('../server/api/BuildService', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    getPackageBuildStats: (...args: unknown[]) =>
+      mockGetPackageBuildStats(...args),
+  })),
+}))
+
+jest.mock('../utils/cache.utils', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    setPackageSize: jest.fn(),
+  })),
+}))
+
+jest.mock('../utils/firebase.utils', () => ({
+  __esModule: true,
+  default: { setRecentSearch: jest.fn() },
+}))
+
+jest.mock('../server/Logger', () => ({
+  __esModule: true,
+  default: { info: jest.fn() },
+}))
+
+import logger from '../server/Logger'
+import { JobCancelledError } from '../server/Queue'
+import buildMiddleware from '../server/middlewares/results/build.middleware'
+
+function createContext() {
+  const request = new EventEmitter()
+  const response = Object.assign(new EventEmitter(), {
+    writableEnded: false,
+  })
+  return {
+    context: {
+      body: undefined,
+      cacheControl: undefined,
+      headers: {},
+      query: {},
+      req: request,
+      res: response,
+      state: {
+        id: 'request-id',
+        resolved: {
+          description: 'description',
+          name: 'example',
+          packageString: 'example@1.0.0',
+          repository: undefined,
+          scoped: false,
+          version: '1.0.0',
+        },
+      },
+    },
+    request,
+    response,
+  }
+}
+
+describe('build request cancellation', () => {
+  const nativeAbortController = global.AbortController
+
+  beforeAll(() => {
+    global.AbortController =
+      AbortController as unknown as typeof global.AbortController
+  })
+
+  afterAll(() => {
+    global.AbortController = nativeAbortController
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('aborts a build only when the response closes prematurely', async () => {
+    let buildSignal: AbortSignal | undefined
+    mockGetPackageBuildStats.mockImplementation(
+      (_packageString, _priority, signal: AbortSignal) => {
+        buildSignal = signal
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => reject(new JobCancelledError()),
+            { once: true }
+          )
+        })
+      }
+    )
+    const { context, request, response } = createContext()
+
+    const result = buildMiddleware(context as never, jest.fn())
+
+    request.emit('close')
+    expect(buildSignal?.aborted).toBe(false)
+
+    response.emit('close')
+
+    await expect(result).rejects.toMatchObject({ code: 'JOB_CANCELLED' })
+    expect(buildSignal?.aborted).toBe(true)
+    expect(logger.info).toHaveBeenCalledWith(
+      'BUILD_ABORTED',
+      expect.objectContaining({
+        packageString: 'example@1.0.0',
+        requestId: 'request-id',
+      }),
+      'BUILD_ABORTED: client closed connection for package example@1.0.0'
+    )
+  })
+
+  it('does not abort after the response has ended normally', async () => {
+    let buildSignal: AbortSignal | undefined
+    let resolveBuild: (result: { size: number }) => void = () => {}
+    mockGetPackageBuildStats.mockImplementation(
+      (_packageString, _priority, signal: AbortSignal) => {
+        buildSignal = signal
+        return new Promise(resolve => {
+          resolveBuild = resolve
+        })
+      }
+    )
+    const { context, response } = createContext()
+
+    const result = buildMiddleware(context as never, jest.fn())
+
+    response.writableEnded = true
+    response.emit('close')
+    expect(buildSignal?.aborted).toBe(false)
+
+    resolveBuild({ size: 123 })
+    await result
+
+    expect(context.body).toEqual(
+      expect.objectContaining({
+        name: 'example',
+        size: 123,
+        version: '1.0.0',
+      })
+    )
+    expect(logger.info).not.toHaveBeenCalledWith(
+      'BUILD_ABORTED',
+      expect.anything(),
+      expect.anything()
+    )
+  })
+})

--- a/__tests__/cancellation-error.test.ts
+++ b/__tests__/cancellation-error.test.ts
@@ -1,0 +1,52 @@
+jest.mock('../server/init', () => ({
+  failureCache: { set: jest.fn() },
+}))
+
+jest.mock('../server/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), info: jest.fn() },
+}))
+
+import { failureCache } from '../server/init'
+import logger from '../server/Logger'
+import { JobCancelledError } from '../server/Queue'
+import errorHandler from '../server/middlewares/results/error.middleware'
+
+describe('build cancellation errors', () => {
+  it('returns a non-cacheable client error without recording a build failure', async () => {
+    const ctx = {
+      body: undefined,
+      cacheControl: undefined,
+      query: {},
+      state: {
+        id: 'request-id',
+        resolved: { packageString: 'example@1.0.0' },
+      },
+      status: undefined,
+    }
+
+    await errorHandler(ctx as never, async () => {
+      throw new JobCancelledError()
+    })
+
+    expect(ctx.status).toBe(408)
+    expect(ctx.cacheControl).toEqual({ maxAge: 0 })
+    expect(ctx.body).toEqual({
+      error: {
+        code: 'BuildCancelledError',
+        message:
+          'The package build was cancelled because the client disconnected.',
+      },
+    })
+    expect(failureCache.set).not.toHaveBeenCalled()
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(
+      'BUILD_CANCELLED',
+      expect.objectContaining({
+        packageString: 'example@1.0.0',
+        requestId: 'request-id',
+      }),
+      'BUILD_CANCELLED example@1.0.0'
+    )
+  })
+})

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -60,6 +60,7 @@ interface ProcessOptions<TResult> {
   maxAge?: number
   onSuccess?: (result: TResult) => void
   onFailure?: (error: unknown) => void
+  signal?: AbortSignal
 }
 
 class Queue {
@@ -287,14 +288,69 @@ class Queue {
       maxAge = this.options.maxAge,
       onSuccess = () => {},
       onFailure = () => {},
+      signal,
     } = options
 
     this.pruneQueue()
 
     return new Promise<TResult>((resolve, reject) => {
+      let settled = false
+      const resolveSubscriber = (result: TResult) => {
+        if (settled) return
+        settled = true
+        signal?.removeEventListener('abort', cancelSubscriber)
+        resolve(result)
+        onSuccess(result)
+      }
+      const rejectSubscriber = (error: unknown) => {
+        if (settled) return
+        settled = true
+        signal?.removeEventListener('abort', cancelSubscriber)
+        reject(error)
+        onFailure(error)
+      }
+      const successListener = resolveSubscriber as (result: unknown) => void
+      const failureListener = rejectSubscriber
+      const cancelSubscriber = () => {
+        const job = this.jobs.find(
+          queuedJob => queuedJob.id === id && queuedJob.type === type
+        )
+        if (!job || settled) return
+
+        job.successListeners = job.successListeners.filter(
+          listener => listener !== successListener
+        )
+        job.failureListeners = job.failureListeners.filter(
+          listener => listener !== failureListener
+        )
+
+        const error = new JobCancelledError()
+        rejectSubscriber(error)
+
+        if (job.failureListeners.length === 0) {
+          log('cancelling orphaned job %s (%s)', id, job.status.toString())
+          if (job.status === JobStatus.PROCESSING) {
+            job.cancel?.()
+          } else {
+            this.removeJob(id, type)
+            this.executeNextJobIfPossible()
+          }
+        }
+      }
+
+      if (signal?.aborted) {
+        rejectSubscriber(new JobCancelledError())
+        return
+      }
+
+      signal?.addEventListener('abort', cancelSubscriber, { once: true })
+
       if (this.hasJob(id, type)) {
         log('job id %s already present, adding callbacks', id)
-        this.addListenersToJob(id, type, { resolve, reject })
+        this.addListenersToJob(id, type, {
+          resolve: successListener as (value: never) => void,
+          reject: failureListener,
+        })
         return
       }
 
@@ -306,11 +362,8 @@ class Queue {
         addedTime: new Date(),
         status: JobStatus.READY,
         params: jobParams,
-        successListeners: [
-          resolve as unknown as (result: unknown) => void,
-          onSuccess as (result: unknown) => void,
-        ],
-        failureListeners: [reject, onFailure],
+        successListeners: [successListener],
+        failureListeners: [failureListener],
       })
 
       this.executeNextJobIfPossible()

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -15,6 +15,23 @@ const JobPriority = {
 
 type JobType = string
 
+export class JobCancelledError extends Error {
+  readonly code = 'JOB_CANCELLED'
+
+  constructor() {
+    super('JOB_CANCELLED')
+    this.name = 'JobCancelledError'
+  }
+}
+
+export function isJobCancelledError(
+  error: unknown
+): error is JobCancelledError {
+  return (
+    error instanceof Error && 'code' in error && error.code === 'JOB_CANCELLED'
+  )
+}
+
 type QueueExecutor<TParams = unknown, TResult = unknown> = (
   params: TParams
 ) => TResult | Promise<TResult>
@@ -144,7 +161,7 @@ class Queue {
         }
       }
       job.failureListeners.forEach(listener => {
-        listener(new Error('JOB_CANCELLED'))
+        listener(new JobCancelledError())
       })
       if (job.status === JobStatus.READY) {
         this.removeJob(id, type)

--- a/server/api/BuildService.ts
+++ b/server/api/BuildService.ts
@@ -111,18 +111,15 @@ export default class BuildService {
 
   async getPackageBuildStats<T>(
     packageString: string,
-    priority: number
+    priority: number,
+    signal?: AbortSignal
   ): Promise<T> {
     return requestQueue.process<T, BuildServiceJobParams>(
       packageString,
       OperationType.PACKAGE_BUILD_STATS,
       { packageString },
-      { priority }
+      { priority, signal }
     )
-  }
-
-  cancelPackageBuildStats(packageString: string): void {
-    requestQueue.cancel(packageString, OperationType.PACKAGE_BUILD_STATS)
   }
 
   async getPackageExports<T>(

--- a/server/middlewares/results/build.middleware.ts
+++ b/server/middlewares/results/build.middleware.ts
@@ -23,8 +23,11 @@ const buildMiddleware: Middleware = async ctx => {
     typeof packageQuery === 'string' ? packageQuery : packageQuery?.join('/')
 
   const buildStart = now()
+  const abortController = new AbortController()
 
   const onAborted = () => {
+    if (ctx.res.writableEnded) return
+
     logger.info(
       'BUILD_ABORTED',
       {
@@ -33,19 +36,20 @@ const buildMiddleware: Middleware = async ctx => {
       },
       `BUILD_ABORTED: client closed connection for package ${packageString}`
     )
-    buildService.cancelPackageBuildStats(packageString)
+    abortController.abort()
   }
 
-  ctx.req.on('close', onAborted)
+  ctx.res.on('close', onAborted)
 
   let result: PackageBuildResult
   try {
     result = await buildService.getPackageBuildStats<PackageBuildResult>(
       packageString,
-      priority
+      priority,
+      abortController.signal
     )
   } finally {
-    ctx.req.off('close', onAborted)
+    ctx.res.off('close', onAborted)
   }
 
   const buildEnd = now()

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -5,6 +5,7 @@ import createDebug from 'debug'
 import config from '../../config'
 import { failureCache } from '../../init'
 import logger from '../../Logger'
+import { isJobCancelledError } from '../../Queue'
 
 const debug = createDebug('bp:error')
 
@@ -90,10 +91,33 @@ const errorHandler: Middleware = async (ctx, next) => {
   try {
     await next()
   } catch (error) {
-    console.error(error)
     ctx.cacheControl = {
       maxAge: force ? 0 : config.CACHE.SIZE_API_ERROR,
     }
+
+    if (isJobCancelledError(error)) {
+      ctx.cacheControl = { maxAge: 0 }
+      ctx.status = 408
+      ctx.body = {
+        error: {
+          code: 'BuildCancelledError',
+          message:
+            'The package build was cancelled because the client disconnected.',
+        },
+      } satisfies ErrorResponseBody
+      logger.info(
+        'BUILD_CANCELLED',
+        {
+          requestId: ctx.state.id,
+          time: now() - start,
+          ...ctx.state.resolved,
+        },
+        packageString ? `BUILD_CANCELLED ${packageString}` : 'BUILD_CANCELLED'
+      )
+      return
+    }
+
+    console.error(error)
 
     if (!(error instanceof Error)) {
       const errObj = error as Record<string, unknown> | null


### PR DESCRIPTION
## What changed
- detect premature client disconnects from the response lifecycle instead of treating the completed request stream as a disconnect
- attach an `AbortSignal` to each queue subscriber so disconnecting one client detaches only that waiter
- cancel an orphaned underlying build only after its final subscriber disconnects
- classify genuine cancellation as a typed, non-cacheable 408 response
- log cancellation separately as `BUILD_CANCELLED` and never write it to the failure cache

This avoids automatic retries and duplicate builds: connected subscribers continue waiting on the original deduplicated build.

## Verification
- focused cancellation and error suite: 5 suites, 26 tests passed
- full unit run: 8 suites and 45 tests passed; the existing `errors-cache` integration suite requires a server on `127.0.0.1:5000` and was unavailable locally
- `yarn lint` passed with existing unrelated page warnings
- `yarn tsc --noEmit` reaches only the existing implicit-any errors in `__tests__/memory-diagnostics.test.ts`