### PR TITLE
Abort orphaned build-service requests

### DIFF
--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -3,6 +3,17 @@ import AbortController from 'abort-controller'
 import Queue from '../server/Queue'
 
 describe('Queue cancellation', () => {
+  const nativeAbortController = global.AbortController
+
+  beforeAll(() => {
+    global.AbortController =
+      AbortController as unknown as typeof global.AbortController
+  })
+
+  afterAll(() => {
+    global.AbortController = nativeAbortController
+  })
+
   it('cancels a ready job in the queue', async () => {
     const queue = new Queue({ concurrency: 1 })
 
@@ -169,6 +180,58 @@ describe('Queue cancellation', () => {
       code: 'JOB_CANCELLED',
     })
     expect(cancelExecutor).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts a non-cancelable executor after its final subscriber leaves', async () => {
+    const queue = new Queue({ concurrency: 1 })
+    const firstSubscriber = new AbortController()
+    const secondSubscriber = new AbortController()
+    let executorSignal: globalThis.AbortSignal | undefined
+    let rejectExecution: (error: Error) => void = () => {}
+    const execution = new Promise((_resolve, reject) => {
+      rejectExecution = reject
+    })
+
+    queue.addExecutor('TEST', (_params, { signal }) => {
+      executorSignal = signal
+      return execution
+    })
+
+    const firstResult = queue.process(
+      'shared-job',
+      'TEST',
+      {},
+      {
+        signal: firstSubscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+    const secondResult = queue.process(
+      'shared-job',
+      'TEST',
+      {},
+      {
+        signal: secondSubscriber.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+
+    firstSubscriber.abort()
+    await expect(firstResult).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+    })
+    expect(executorSignal?.aborted).toBe(false)
+
+    secondSubscriber.abort()
+    await expect(secondResult).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+    })
+    expect(executorSignal?.aborted).toBe(true)
+    expect(queue.getRunningJobs()).toHaveLength(1)
+
+    rejectExecution(new Error('executor stopped'))
+    await execution.catch(() => {})
+    await Promise.resolve()
+
+    expect(queue.getRunningJobs()).toHaveLength(0)
   })
 
   it('does not enqueue work for an already aborted subscriber', async () => {

--- a/__tests__/build-service-unavailable.test.ts
+++ b/__tests__/build-service-unavailable.test.ts
@@ -1,9 +1,10 @@
+import AbortController from 'abort-controller'
 import axios from 'axios'
 
 import serializeError from '../build-service/serializeError'
 import CustomError from '../server/CustomError'
 import BuildService from '../server/api/BuildService'
-import { failureCache, requestQueue } from '../server/init'
+import { failureCache, pool, requestQueue } from '../server/init'
 import errorMiddleware from '../server/middlewares/results/error.middleware'
 
 jest.mock('../server/init', () => ({
@@ -28,6 +29,7 @@ jest.mock('../server/Logger', () => ({
 }))
 
 const mockedFailureCache = failureCache as jest.Mocked<typeof failureCache>
+const mockedPool = pool as jest.Mocked<typeof pool>
 const mockedRequestQueue = requestQueue as jest.Mocked<typeof requestQueue>
 
 describe('build service unavailability', () => {
@@ -60,9 +62,15 @@ describe('build service unavailability', () => {
 
     new BuildService()
     const executor = mockedRequestQueue.addExecutor.mock.calls[0][1]
+    const controller = new AbortController()
 
     await expect(
-      executor({ packageString: '@example/unavailable@1.0.0' })
+      executor(
+        { packageString: '@example/unavailable@1.0.0' },
+        {
+          signal: controller.signal as unknown as globalThis.AbortSignal,
+        }
+      )
     ).rejects.toMatchObject({
       name: 'BuildServiceUnavailableError',
       originalError: {
@@ -108,10 +116,79 @@ describe('build service unavailability', () => {
 
     new BuildService()
     const executor = mockedRequestQueue.addExecutor.mock.calls[0][1]
+    const controller = new AbortController()
 
     await expect(
-      executor({ packageString: '@example/internal-error@1.0.0' })
+      executor(
+        { packageString: '@example/internal-error@1.0.0' },
+        {
+          signal: controller.signal as unknown as globalThis.AbortSignal,
+        }
+      )
     ).rejects.toMatchObject(responseBody)
+  })
+
+  it('cancels an in-flight build-service request when its job aborts', async () => {
+    const controller = new AbortController()
+    jest.spyOn(axios, 'get').mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener?.(
+          'abort',
+          () => reject(new axios.CanceledError()),
+          { once: true }
+        )
+      })
+    })
+
+    new BuildService()
+    const executor = mockedRequestQueue.addExecutor.mock.calls[0][1]
+    const result = executor(
+      { packageString: '@example/cancelled@1.0.0' },
+      {
+        signal: controller.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+
+    controller.abort()
+
+    await expect(result).rejects.toMatchObject({
+      code: 'JOB_CANCELLED',
+      name: 'JobCancelledError',
+    })
+    expect(axios.get).toHaveBeenCalledWith(
+      'http://127.0.0.1:7002/size?p=%40example%2Fcancelled%401.0.0',
+      expect.objectContaining({
+        signal: controller.signal,
+      })
+    )
+  })
+
+  it('cancels an in-process worker execution when its job aborts', async () => {
+    delete process.env.BUILD_SERVICE_ENDPOINT
+    const controller = new AbortController()
+    let rejectExecution: (error: Error) => void = () => {}
+    const execution = new Promise((_resolve, reject) => {
+      rejectExecution = reject
+    }) as ReturnType<typeof pool.exec>
+    execution.timeout = jest.fn().mockReturnValue(execution)
+    execution.cancel = jest.fn(() => {
+      rejectExecution(new Error('worker execution cancelled'))
+    })
+    mockedPool.exec.mockReturnValue(execution)
+
+    new BuildService()
+    const executor = mockedRequestQueue.addExecutor.mock.calls[0][1]
+    const result = executor(
+      { packageString: '@example/cancelled@1.0.0' },
+      {
+        signal: controller.signal as unknown as globalThis.AbortSignal,
+      }
+    )
+
+    controller.abort()
+
+    await expect(result).rejects.toThrow('worker execution cancelled')
+    expect(execution.cancel).toHaveBeenCalledTimes(1)
   })
 
   it('returns a retryable response without caching the failure', async () => {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/koa__router": "^12.0.4",
     "animejs": "^3.2.2",
     "array-to-sentence": "^2.0.0",
-    "axios": "^0.21.4",
+    "axios": "1.16.1",
     "balloon-css": "^0.4.0",
     "bfj": "^9.0.2",
     "big-json": "^3.2.0",

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -15,6 +15,10 @@ const JobPriority = {
 
 type JobType = string
 
+interface QueueExecutorContext {
+  signal: AbortSignal
+}
+
 export class JobCancelledError extends Error {
   readonly code = 'JOB_CANCELLED'
 
@@ -33,7 +37,8 @@ export function isJobCancelledError(
 }
 
 type QueueExecutor<TParams = unknown, TResult = unknown> = (
-  params: TParams
+  params: TParams,
+  context: QueueExecutorContext
 ) => TResult | Promise<TResult>
 
 interface QueueJob<TParams = unknown, TResult = unknown> {
@@ -46,6 +51,7 @@ interface QueueJob<TParams = unknown, TResult = unknown> {
   params: TParams
   successListeners: Array<(result: TResult) => void>
   failureListeners: Array<(error: unknown) => void>
+  abortController: AbortController
   cancel?: () => void
 }
 
@@ -152,14 +158,17 @@ class Queue {
     this.jobs = this.jobs.filter(job => job.id !== id || job.type !== type)
   }
 
+  cancelJob(job: QueueJob): void {
+    job.abortController.abort()
+    job.cancel?.()
+  }
+
   cancel(id: string, type: JobType): void {
     const job = this.jobs.find(job => job.id === id && job.type === type)
     if (job) {
       log('cancelling job %s (%s)', id, job.status.toString())
       if (job.status === JobStatus.PROCESSING) {
-        if (job.cancel) {
-          job.cancel()
-        }
+        this.cancelJob(job)
       }
       job.failureListeners.forEach(listener => {
         listener(new JobCancelledError())
@@ -228,7 +237,9 @@ class Queue {
 
     try {
       const handler = this.executorMap[nextJob.type]
-      const promiseOrValue = handler.call(this, nextJob.params)
+      const promiseOrValue = handler.call(this, nextJob.params, {
+        signal: nextJob.abortController.signal,
+      })
 
       if (promiseOrValue && typeof promiseOrValue === 'object') {
         const cancelablePromise = promiseOrValue as Promise<unknown> & {
@@ -330,7 +341,7 @@ class Queue {
         if (job.failureListeners.length === 0) {
           log('cancelling orphaned job %s (%s)', id, job.status.toString())
           if (job.status === JobStatus.PROCESSING) {
-            job.cancel?.()
+            this.cancelJob(job)
           } else {
             this.removeJob(id, type)
             this.executeNextJobIfPossible()
@@ -364,6 +375,7 @@ class Queue {
         params: jobParams,
         successListeners: [successListener],
         failureListeners: [failureListener],
+        abortController: new AbortController(),
       })
 
       this.executeNextJobIfPossible()

--- a/server/api/BuildService.ts
+++ b/server/api/BuildService.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import createDebug from 'debug'
 
 import CustomError from '../CustomError'
+import { JobCancelledError } from '../Queue'
 import config from '../config'
 import { pool, requestQueue } from '../init'
 
@@ -23,13 +24,6 @@ interface BuildServerErrorPayload {
   name?: string
   originalError?: unknown
   extra?: unknown
-}
-
-interface PoolLike {
-  exec(
-    method: string,
-    params: unknown[]
-  ): { timeout(ms: number): Promise<unknown> }
 }
 
 export default class BuildService {
@@ -55,23 +49,34 @@ export default class BuildService {
     operations.forEach(operation => {
       requestQueue.addExecutor<BuildServiceJobParams, unknown>(
         operation.type,
-        async ({ packageString }) => {
+        async ({ packageString }, { signal }) => {
           if (process.env.BUILD_SERVICE_ENDPOINT) {
             try {
               const response = await axios.get(
                 `${process.env.BUILD_SERVICE_ENDPOINT}${
                   operation.endpoint
-                }?p=${encodeURIComponent(packageString)}`
+                }?p=${encodeURIComponent(packageString)}`,
+                { signal }
               )
               return response.data
             } catch (error) {
+              if (axios.isCancel(error)) {
+                throw new JobCancelledError()
+              }
               this.handleError(error, operation.type)
             }
           }
 
-          return (pool as PoolLike)
+          const execution = pool
             .exec(operation.methodName, [packageString])
             .timeout(config.WORKER_TIMEOUT)
+          const cancelExecution = () => execution.cancel?.()
+          signal.addEventListener('abort', cancelExecution, { once: true })
+          try {
+            return await execution
+          } finally {
+            signal.removeEventListener('abort', cancelExecution)
+          }
         }
       )
     })

--- a/server/init.ts
+++ b/server/init.ts
@@ -5,11 +5,13 @@ import Queue from './Queue'
 import config from './config'
 import type { FailureCacheEntry } from './types'
 
+interface WorkerPoolExecution extends Promise<unknown> {
+  cancel?: () => void
+  timeout(ms: number): WorkerPoolExecution
+}
+
 interface WorkerPoolLike {
-  exec(
-    method: string,
-    params: unknown[]
-  ): { timeout(ms: number): Promise<unknown> }
+  exec(method: string, params: unknown[]): WorkerPoolExecution
   terminate(): void
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7133,7 +7133,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^0.21.1, axios@npm:^0.21.4":
+"axios@npm:1.16.1":
+  version: 1.16.1
+  resolution: "axios@npm:1.16.1"
+  dependencies:
+    follow-redirects: "npm:^1.16.0"
+    form-data: "npm:^4.0.5"
+    https-proxy-agent: "npm:^5.0.1"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 2f77e37e6552bbff8a772d058fb09500198e9188c6b20dc799d82dbe12a8cb506f6eed4e4e62a9ba612a35cbab496faa26d68f9bff14a53af6d15c3e136391a7
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.21.1":
   version: 0.21.4
   resolution: "axios@npm:0.21.4"
   dependencies:
@@ -7847,7 +7859,7 @@ __metadata:
     animejs: "npm:^3.2.2"
     array-to-sentence: "npm:^2.0.0"
     autoprefixer: "npm:^9.8.8"
-    axios: "npm:^0.21.4"
+    axios: "npm:1.16.1"
     balloon-css: "npm:^0.4.0"
     bfj: "npm:^9.0.2"
     big-json: "npm:^3.2.0"
@@ -12189,6 +12201,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -12252,6 +12274,19 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.5":
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -13261,6 +13296,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -17070,7 +17114,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.18, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34, mime-types@npm:~2.1.35":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.18, mime-types@npm:^2.1.35, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34, mime-types@npm:~2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -20143,6 +20187,13 @@ __metadata:
     forwarded: "npm:0.2.0"
     ipaddr.js: "npm:1.9.1"
   checksum: c3eed999781a35f7fd935f398b6d8920b6fb00bbc14287bc6de78128ccc1a02c89b95b56742bf7cf0362cc333c61d138532049c7dedc7a328ef13343eff81210
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: ed01729fd4d094eab619cd7e17ce3698b3413b31eb102c4904f9875e677cd207392795d5b4adee9cec359dfd31c44d5ad7595a3a3ad51c40250e141512281c58
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What changed
- give each deduplicated queue job a job-level `AbortController`
- abort the executor only after the final subscriber disconnects while preserving queue accounting until it settles
- pass the job signal to Axios and cancel in-process workerpool executions as well
- upgrade Axios from 0.21.4 to the current stable 1.16.1 so the build-service request uses native `AbortSignal` support
- preserve the typed `JobCancelledError` boundary introduced in #1026

This does not retry or start replacement work. Connected subscribers continue waiting on the original shared build; only truly orphaned work is terminated.

## Verification
- focused queue/build cancellation suite: 4 suites, 19 tests passed
- production `yarn build`: passed
- `yarn lint`: passed with existing unrelated page warnings
- full Jest run: 47 tests passed; the 7 existing `errors-cache` integration cases require a server on `127.0.0.1:5000`
- real local HTTP socket check: Axios returned `ERR_CANCELED` and the server observed the request socket close
- standalone `tsc --noEmit` reaches only the existing implicit-any errors in `__tests__/memory-diagnostics.test.ts`