### PR TITLE
Capture authoritative main memory restart metrics

### DIFF
--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -29,6 +29,13 @@ describe('Queue cancellation', () => {
 
     expect(queue.getReadyJobs().length).toBe(1)
     expect(queue.getRunningJobs().length).toBe(1)
+    expect(queue.getDiagnostics()).toEqual({
+      total: 2,
+      ready: 1,
+      running: 1,
+      successListeners: 2,
+      failureListeners: 2,
+    })
 
     queue.cancel('job-2', 'TEST')
 

--- a/__tests__/memory-diagnostics.test.ts
+++ b/__tests__/memory-diagnostics.test.ts
@@ -4,6 +4,7 @@ const path = require('path')
 
 const {
   createMemoryDiagnostics,
+  createRuntimeMetrics,
   getStartupEnvironment,
   parseBytes,
 } = require('../scripts/memory-diagnostics.cjs')
@@ -39,7 +40,7 @@ describe('memory diagnostics', () => {
     )
     const report = {
       excludeEnv: false,
-      writeReport: filename => fs.writeFileSync(filename, '{}'),
+      writeReport: (filename: string) => fs.writeFileSync(filename, '{}'),
     }
     const writeHeapSnapshot = filename => fs.writeFileSync(filename, 'snapshot')
     const diagnostics = createMemoryDiagnostics({
@@ -95,6 +96,88 @@ describe('memory diagnostics', () => {
 
     expect(diagnostics.check()).toBe(false)
     expect(writeHeapSnapshot).not.toHaveBeenCalled()
+    diagnostics.stop()
+  })
+
+  test('captures a lightweight runtime timeline without a heap snapshot', () => {
+    const runtimeMetrics = createRuntimeMetrics()
+    runtimeMetrics.recordRequestStart()
+    runtimeMetrics.recordRequestComplete({
+      route: '/api/size',
+      status: 200,
+      durationMs: 25,
+    })
+    runtimeMetrics.registerProvider('main', () => ({
+      queue: { ready: 2, running: 4 },
+    }))
+    const writeHeapSnapshot = jest.fn()
+    const report = {
+      excludeEnv: false,
+      writeReport: (filename: string) => fs.writeFileSync(filename, '{}'),
+    }
+    const diagnostics = createMemoryDiagnostics({
+      service: 'main',
+      thresholdBytes: 100,
+      outputRoot,
+      intervalMs: 60_000,
+      captureHeapSnapshot: false,
+      memoryUsage: () => ({
+        rss: 101,
+        heapTotal: 20,
+        heapUsed: 10,
+        external: 5,
+        arrayBuffers: 3,
+      }),
+      heapStatistics: () => ({ malloced_memory: 7 }),
+      activeResourcesInfo: () => ['TCPSocketWrap', 'TCPSocketWrap'],
+      runtimeMetrics,
+      report,
+      writeHeapSnapshot,
+      now: () => Date.parse('2026-07-31T00:00:00Z'),
+      pid: 456,
+      logger: { error: jest.fn() },
+    })
+
+    expect(diagnostics.check()).toBe(true)
+    expect(writeHeapSnapshot).not.toHaveBeenCalled()
+    expect(
+      fs.existsSync(path.join(outputRoot, 'main', 'latest.heapsnapshot'))
+    ).toBe(false)
+
+    const metadata = JSON.parse(
+      fs.readFileSync(
+        path.join(outputRoot, 'main', 'latest.metadata.json'),
+        'utf8'
+      )
+    )
+    expect(metadata.heapSnapshotCaptured).toBe(false)
+
+    const capturedTimeline = JSON.parse(
+      fs.readFileSync(
+        path.join(outputRoot, 'main', 'latest.timeline.json'),
+        'utf8'
+      )
+    )
+    expect(capturedTimeline.samples).toHaveLength(1)
+    expect(capturedTimeline.samples[0]).toMatchObject({
+      memory: { rss: 101, external: 5, arrayBuffers: 3 },
+      heap: { malloced_memory: 7 },
+      activeResources: { TCPSocketWrap: 2 },
+      runtime: {
+        requests: {
+          active: 0,
+          started: 1,
+          completed: 1,
+          meanDurationMs: 25,
+          maxDurationMs: 25,
+          routes: { '/api/size': 1 },
+          statuses: { '200': 1 },
+        },
+        providers: {
+          main: { queue: { ready: 2, running: 4 } },
+        },
+      },
+    })
     diagnostics.stop()
   })
 

--- a/__tests__/request-memory-metrics.test.ts
+++ b/__tests__/request-memory-metrics.test.ts
@@ -1,0 +1,45 @@
+import requestLoggerMiddleware from '../server/middlewares/requestLogger.middleware'
+import {
+  recordRequestComplete,
+  recordRequestStart,
+} from '../server/MemoryDiagnostics'
+
+jest.mock('../server/MemoryDiagnostics', () => ({
+  recordRequestStart: jest.fn(),
+  recordRequestComplete: jest.fn(),
+}))
+
+const mockRecordRequestStart = recordRequestStart as jest.MockedFunction<
+  typeof recordRequestStart
+>
+const mockRecordRequestComplete = recordRequestComplete as jest.MockedFunction<
+  typeof recordRequestComplete
+>
+
+describe('request memory metrics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('records normalized request metrics without swallowing errors', async () => {
+    const error = new Error('request failed')
+    const context = {
+      path: '/package/example',
+      request: { url: '/package/example' },
+      response: { status: 500 },
+    }
+
+    await expect(
+      requestLoggerMiddleware(context as never, async () => {
+        throw error
+      })
+    ).rejects.toBe(error)
+
+    expect(mockRecordRequestStart).toHaveBeenCalledTimes(1)
+    expect(mockRecordRequestComplete).toHaveBeenCalledWith({
+      route: '/package/*',
+      status: 500,
+      durationMs: expect.any(Number),
+    })
+  })
+})

--- a/process.yml
+++ b/process.yml
@@ -19,6 +19,7 @@ apps:
       MEMORY_DIAGNOSTICS_SERVICE: main
       MEMORY_DIAGNOSTICS_RSS_THRESHOLD: 425M
       MEMORY_DIAGNOSTICS_DIR: /var/cache/bundlephobia/diagnostics
+      MEMORY_DIAGNOSTICS_HEAP_SNAPSHOT: 'false'
 
   - script: ./build-service/index.js
     name: build-service

--- a/scripts/memory-diagnostics.cjs
+++ b/scripts/memory-diagnostics.cjs
@@ -1,11 +1,90 @@
 const fs = require('fs')
 const path = require('path')
 const v8 = require('v8')
+const {
+  PerformanceObserver,
+  monitorEventLoopDelay,
+  performance,
+} = require('perf_hooks')
 
 const GIB = 1024 ** 3
 const DEFAULT_INTERVAL_MS = 3000
 const DEFAULT_COOLDOWN_MS = 10 * 60 * 1000
 const DEFAULT_MIN_FREE_BYTES = 8 * GIB
+const DEFAULT_TIMELINE_SAMPLES = 120
+
+function createRuntimeMetrics() {
+  let activeRequests = 0
+  let intervalStarted = 0
+  let intervalCompleted = 0
+  let intervalDurationMs = 0
+  let intervalMaxDurationMs = 0
+  let intervalRoutes = Object.create(null)
+  let intervalStatuses = Object.create(null)
+  const providers = new Map()
+
+  function increment(record, key) {
+    record[key] = (record[key] || 0) + 1
+  }
+
+  return {
+    recordRequestStart() {
+      activeRequests += 1
+      intervalStarted += 1
+    },
+
+    recordRequestComplete({ route, status, durationMs }) {
+      activeRequests = Math.max(activeRequests - 1, 0)
+      intervalCompleted += 1
+      intervalDurationMs += durationMs
+      intervalMaxDurationMs = Math.max(intervalMaxDurationMs, durationMs)
+      increment(intervalRoutes, route)
+      increment(intervalStatuses, String(status))
+    },
+
+    registerProvider(name, provider) {
+      providers.set(name, provider)
+      return () => providers.delete(name)
+    },
+
+    takeSnapshot() {
+      const providerValues = {}
+      for (const [name, provider] of providers) {
+        try {
+          providerValues[name] = provider()
+        } catch (error) {
+          providerValues[name] = {
+            error: error instanceof Error ? error.message : String(error),
+          }
+        }
+      }
+
+      const snapshot = {
+        requests: {
+          active: activeRequests,
+          started: intervalStarted,
+          completed: intervalCompleted,
+          meanDurationMs:
+            intervalCompleted > 0 ? intervalDurationMs / intervalCompleted : 0,
+          maxDurationMs: intervalMaxDurationMs,
+          routes: intervalRoutes,
+          statuses: intervalStatuses,
+        },
+        providers: providerValues,
+      }
+
+      intervalStarted = 0
+      intervalCompleted = 0
+      intervalDurationMs = 0
+      intervalMaxDurationMs = 0
+      intervalRoutes = Object.create(null)
+      intervalStatuses = Object.create(null)
+      return snapshot
+    },
+  }
+}
+
+const runtimeMetrics = createRuntimeMetrics()
 
 function parseBytes(value) {
   const match = /^(\d+)([KMG])?$/i.exec(String(value || '').trim())
@@ -30,8 +109,17 @@ function createMemoryDiagnostics(options) {
     intervalMs = DEFAULT_INTERVAL_MS,
     cooldownMs = DEFAULT_COOLDOWN_MS,
     minFreeBytes = DEFAULT_MIN_FREE_BYTES,
+    captureHeapSnapshot = true,
+    timelineSamples = DEFAULT_TIMELINE_SAMPLES,
     fsImpl = fs,
     memoryUsage = process.memoryUsage,
+    heapStatistics = v8.getHeapStatistics,
+    heapSpaceStatistics = v8.getHeapSpaceStatistics,
+    heapCodeStatistics = v8.getHeapCodeStatistics,
+    activeResourcesInfo = process.getActiveResourcesInfo,
+    resourceUsage = process.resourceUsage,
+    cpuUsage = process.cpuUsage,
+    runtimeMetrics: metrics = runtimeMetrics,
     report = process.report,
     writeHeapSnapshot = v8.writeHeapSnapshot,
     now = Date.now,
@@ -44,9 +132,77 @@ function createMemoryDiagnostics(options) {
     service.replace(/[^a-z0-9_-]/gi, '_')
   )
   const latestSnapshot = path.join(serviceDirectory, 'latest.heapsnapshot')
+  const latestMetadata = path.join(serviceDirectory, 'latest.metadata.json')
+  const latestTimeline = path.join(serviceDirectory, 'latest.timeline.json')
   const lockDirectory = path.join(outputRoot, '.capture.lock')
   const lockOwner = path.join(lockDirectory, 'pid')
   let handled = false
+  const timeline = []
+  const gcInterval = { count: 0, durationMs: 0, kinds: Object.create(null) }
+  let previousEventLoopUtilization = performance.eventLoopUtilization()
+  let previousCpuUsage = cpuUsage()
+  const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 })
+  eventLoopDelay.enable()
+  const gcObserver = new PerformanceObserver(list => {
+    for (const entry of list.getEntries()) {
+      const kind = String(entry.detail?.kind ?? 'unknown')
+      gcInterval.count += 1
+      gcInterval.durationMs += entry.duration
+      gcInterval.kinds[kind] = (gcInterval.kinds[kind] || 0) + 1
+    }
+  })
+  gcObserver.observe({ entryTypes: ['gc'] })
+
+  function histogramMilliseconds(value) {
+    return Number.isFinite(value) ? value / 1e6 : 0
+  }
+
+  function collectSample(memory = memoryUsage()) {
+    const currentEventLoopUtilization = performance.eventLoopUtilization(
+      previousEventLoopUtilization
+    )
+    previousEventLoopUtilization = performance.eventLoopUtilization()
+    const currentCpuUsage = cpuUsage(previousCpuUsage)
+    previousCpuUsage = cpuUsage()
+    const resources = {}
+    for (const resource of activeResourcesInfo()) {
+      resources[resource] = (resources[resource] || 0) + 1
+    }
+
+    const sample = {
+      capturedAt: new Date(now()).toISOString(),
+      memory,
+      heap: heapStatistics(),
+      heapSpaces: heapSpaceStatistics(),
+      heapCode: heapCodeStatistics(),
+      cpu: currentCpuUsage,
+      resources: resourceUsage(),
+      gc: {
+        count: gcInterval.count,
+        durationMs: gcInterval.durationMs,
+        kinds: gcInterval.kinds,
+      },
+      eventLoop: {
+        utilization: currentEventLoopUtilization.utilization,
+        delayMeanMs: histogramMilliseconds(eventLoopDelay.mean),
+        delayMaxMs: histogramMilliseconds(eventLoopDelay.max),
+        delayP95Ms: histogramMilliseconds(eventLoopDelay.percentile(95)),
+        delayP99Ms: histogramMilliseconds(eventLoopDelay.percentile(99)),
+      },
+      activeResources: resources,
+      runtime: metrics.takeSnapshot(),
+    }
+
+    timeline.push(sample)
+    if (timeline.length > timelineSamples) {
+      timeline.shift()
+    }
+    gcInterval.count = 0
+    gcInterval.durationMs = 0
+    gcInterval.kinds = Object.create(null)
+    eventLoopDelay.reset()
+    return sample
+  }
 
   function releaseLock() {
     fsImpl.rmSync(lockDirectory, { recursive: true, force: true })
@@ -96,6 +252,7 @@ function createMemoryDiagnostics(options) {
 
   function check() {
     const memory = memoryUsage()
+    collectSample(memory)
     if (handled || memory.rss < thresholdBytes) {
       return false
     }
@@ -103,7 +260,6 @@ function createMemoryDiagnostics(options) {
     if (!acquireLock()) {
       return false
     }
-    handled = true
     removeIncompleteCaptures()
 
     const suffix = `${now()}-${pid}`
@@ -119,19 +275,29 @@ function createMemoryDiagnostics(options) {
       serviceDirectory,
       `.latest-${suffix}.metadata.json`
     )
+    const temporaryTimeline = path.join(
+      serviceDirectory,
+      `.latest-${suffix}.timeline.json`
+    )
 
     try {
       if (
+        captureHeapSnapshot &&
         fsImpl.existsSync(latestSnapshot) &&
         now() - fsImpl.statSync(latestSnapshot).mtimeMs < cooldownMs
       ) {
         return false
       }
 
-      const requiredFreeBytes = Math.max(minFreeBytes, thresholdBytes * 3)
-      if (getAvailableBytes(serviceDirectory, fsImpl) < requiredFreeBytes) {
+      const requiredFreeBytes = captureHeapSnapshot
+        ? Math.max(minFreeBytes, thresholdBytes * 3)
+        : 0
+      if (
+        requiredFreeBytes > 0 &&
+        getAvailableBytes(serviceDirectory, fsImpl) < requiredFreeBytes
+      ) {
         logger.error(
-          `[memory-diagnostics] Skipping ${service} heap snapshot: insufficient free disk space`
+          `[memory-diagnostics] Skipping ${service} capture: insufficient free disk space`
         )
         return false
       }
@@ -139,6 +305,7 @@ function createMemoryDiagnostics(options) {
       logger.error(
         `[memory-diagnostics] Capturing ${service} at ${memory.rss} bytes RSS`
       )
+      handled = true
 
       if (report) {
         report.excludeEnv = true
@@ -160,6 +327,7 @@ function createMemoryDiagnostics(options) {
             capturedAt: new Date(now()).toISOString(),
             memory,
             smapsRollup,
+            heapSnapshotCaptured: captureHeapSnapshot,
           },
           null,
           2
@@ -167,19 +335,25 @@ function createMemoryDiagnostics(options) {
         { mode: 0o600 }
       )
 
-      writeHeapSnapshot(temporarySnapshot)
-      fsImpl.renameSync(temporarySnapshot, latestSnapshot)
+      fsImpl.writeFileSync(
+        temporaryTimeline,
+        JSON.stringify({ service, pid, samples: timeline }, null, 2),
+        { mode: 0o600 }
+      )
+
+      if (captureHeapSnapshot) {
+        writeHeapSnapshot(temporarySnapshot)
+        fsImpl.renameSync(temporarySnapshot, latestSnapshot)
+      }
       if (report) {
         fsImpl.renameSync(
           temporaryReport,
           path.join(serviceDirectory, 'latest.report.json')
         )
       }
-      fsImpl.renameSync(
-        temporaryMetadata,
-        path.join(serviceDirectory, 'latest.metadata.json')
-      )
-      logger.error(`[memory-diagnostics] Captured ${service} heap snapshot`)
+      fsImpl.renameSync(temporaryMetadata, latestMetadata)
+      fsImpl.renameSync(temporaryTimeline, latestTimeline)
+      logger.error(`[memory-diagnostics] Captured ${service} diagnostics`)
       return true
     } catch (error) {
       logger.error(
@@ -191,6 +365,7 @@ function createMemoryDiagnostics(options) {
         temporarySnapshot,
         temporaryReport,
         temporaryMetadata,
+        temporaryTimeline,
       ]) {
         try {
           fsImpl.rmSync(filename, { force: true })
@@ -202,7 +377,14 @@ function createMemoryDiagnostics(options) {
 
   const timer = setInterval(check, intervalMs)
   timer.unref()
-  return { check, stop: () => clearInterval(timer) }
+  return {
+    check,
+    stop: () => {
+      clearInterval(timer)
+      gcObserver.disconnect()
+      eventLoopDelay.disable()
+    },
+  }
 }
 
 function getStartupEnvironment(environment = process.env) {
@@ -225,6 +407,8 @@ function startFromEnvironment() {
     thresholdBytes: parseBytes(threshold),
     outputRoot:
       environment.MEMORY_DIAGNOSTICS_DIR || path.resolve('diagnostics'),
+    captureHeapSnapshot:
+      environment.MEMORY_DIAGNOSTICS_HEAP_SNAPSHOT !== 'false',
   })
   return true
 }
@@ -233,7 +417,13 @@ startFromEnvironment()
 
 module.exports = {
   createMemoryDiagnostics,
+  createRuntimeMetrics,
   getAvailableBytes,
   getStartupEnvironment,
   parseBytes,
+  recordRequestStart: () => runtimeMetrics.recordRequestStart(),
+  recordRequestComplete: request =>
+    runtimeMetrics.recordRequestComplete(request),
+  registerMetricsProvider: (name, provider) =>
+    runtimeMetrics.registerProvider(name, provider),
 }

--- a/server/MemoryDiagnostics.ts
+++ b/server/MemoryDiagnostics.ts
@@ -1,0 +1,22 @@
+interface RequestMetric {
+  route: string
+  status: number
+  durationMs: number
+}
+
+interface MemoryDiagnosticsModule {
+  recordRequestStart(): void
+  recordRequestComplete(request: RequestMetric): void
+  registerMetricsProvider(name: string, provider: () => unknown): () => boolean
+}
+
+const diagnostics =
+  require('../scripts/memory-diagnostics.cjs') as MemoryDiagnosticsModule
+
+export const recordRequestStart = () => diagnostics.recordRequestStart()
+export const recordRequestComplete = (request: RequestMetric) =>
+  diagnostics.recordRequestComplete(request)
+export const registerMetricsProvider = (
+  name: string,
+  provider: () => unknown
+) => diagnostics.registerMetricsProvider(name, provider)

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -85,6 +85,37 @@ class Queue {
     }
   }
 
+  getDiagnostics(): {
+    total: number
+    ready: number
+    running: number
+    successListeners: number
+    failureListeners: number
+  } {
+    let ready = 0
+    let running = 0
+    let successListeners = 0
+    let failureListeners = 0
+
+    for (const job of this.jobs) {
+      if (job.status === JobStatus.READY) {
+        ready += 1
+      } else if (job.status === JobStatus.PROCESSING) {
+        running += 1
+      }
+      successListeners += job.successListeners.length
+      failureListeners += job.failureListeners.length
+    }
+
+    return {
+      total: this.jobs.length,
+      ready,
+      running,
+      successListeners,
+      failureListeners,
+    }
+  }
+
   addExecutor<TParams, TResult>(
     jobType: JobType,
     handler: QueueExecutor<TParams, TResult>

--- a/server/init.ts
+++ b/server/init.ts
@@ -4,6 +4,7 @@ import logger from './Logger'
 import Queue from './Queue'
 import config from './config'
 import type { FailureCacheEntry } from './types'
+import { registerMetricsProvider } from './MemoryDiagnostics'
 
 interface WorkerPoolExecution extends Promise<unknown> {
   cancel?: () => void
@@ -20,6 +21,7 @@ interface WorkerpoolModule {
 }
 
 interface LruCacheInstance<K, V> {
+  itemCount: number
   get(key: K): V | undefined
   set(key: K, value: V): this
   del?(key: K): void
@@ -51,5 +53,10 @@ const pool = workerpool.pool('./server/worker.js', {
 if (process.env.BUILD_SERVICE_ENDPOINT) {
   pool.terminate()
 }
+
+registerMetricsProvider('main', () => ({
+  queue: requestQueue.getDiagnostics(),
+  failureCacheEntries: failureCache.itemCount,
+}))
 
 export { debug, failureCache, logger, pool, requestQueue }

--- a/server/middlewares/requestLogger.middleware.ts
+++ b/server/middlewares/requestLogger.middleware.ts
@@ -2,40 +2,76 @@ import type { Middleware } from 'koa'
 import now from 'performance-now'
 
 import logger from '../Logger'
+import { recordRequestComplete, recordRequestStart } from '../MemoryDiagnostics'
+
+const API_ROUTES = new Set([
+  '/api/exports',
+  '/api/exports-sizes',
+  '/api/mcp/call-tool',
+  '/api/mcp/tools',
+  '/api/package-history',
+  '/api/recent',
+  '/api/similar-packages',
+  '/api/size',
+  '/api/stats-image',
+])
+
+function normalizeRoute(path: string): string {
+  if (path.startsWith('/api/')) {
+    return API_ROUTES.has(path) ? path : '/api/*'
+  }
+  if (path.startsWith('/package/')) {
+    return '/package/*'
+  }
+  if (path.startsWith('/_next/')) {
+    return '/_next/*'
+  }
+  if (path.startsWith('/-/search')) {
+    return '/-/search'
+  }
+  return path === '/' ? '/' : 'other'
+}
 
 const requestLoggerMiddleware: Middleware = async (ctx, next) => {
-  if (!ctx.request.url.includes('/api/')) {
-    await next()
-    return
-  }
-
   const requestStart = now()
-  await next()
-  const requestEnd = now()
-  const time = requestEnd - requestStart
+  recordRequestStart()
 
-  logger.info(
-    'REQUEST',
-    {
-      url: ctx.request.url,
-      type: ctx.request.type,
-      query: ctx.request.query,
-      headers: ctx.request.headers,
-      ip:
-        ctx.request.header['x-koaip'] ||
-        ctx.request.header['cf-connecting-ip'] ||
-        ctx.ip,
-      requestId: ctx.state.id,
-      method: ctx.request.method,
-      origin: ctx.request.origin,
-      hostname: ctx.request.hostname,
+  try {
+    await next()
+  } finally {
+    const requestEnd = now()
+    const time = requestEnd - requestStart
+    recordRequestComplete({
+      route: normalizeRoute(ctx.path),
       status: ctx.response.status,
-      time,
-    },
-    `REQUEST: ${ctx.response.status} ${(time / 1000).toFixed(2)}s ${
-      ctx.req.method
-    } ${ctx.request.url}`
-  )
+      durationMs: time,
+    })
+
+    if (ctx.request.url.includes('/api/')) {
+      logger.info(
+        'REQUEST',
+        {
+          url: ctx.request.url,
+          type: ctx.request.type,
+          query: ctx.request.query,
+          headers: ctx.request.headers,
+          ip:
+            ctx.request.header['x-koaip'] ||
+            ctx.request.header['cf-connecting-ip'] ||
+            ctx.ip,
+          requestId: ctx.state.id,
+          method: ctx.request.method,
+          origin: ctx.request.origin,
+          hostname: ctx.request.hostname,
+          status: ctx.response.status,
+          time,
+        },
+        `REQUEST: ${ctx.response.status} ${(time / 1000).toFixed(2)}s ${
+          ctx.req.method
+        } ${ctx.request.url}`
+      )
+    }
+  }
 }
 
 export default requestLoggerMiddleware


### PR DESCRIPTION
## What changed
- keep a bounded six-minute, three-second runtime timeline with RSS, V8 heap spaces, external and ArrayBuffer memory, GC, CPU, event-loop, active-resource, and OS resource metrics
- record normalized request/status metrics plus queue depth, running work, listener counts, and failure-cache size
- atomically capture the timeline, smaps rollup, metadata, and a Node diagnostic report at 425 MiB RSS
- disable automatic heap snapshots for main only because capture itself pushed RSS near 1 GiB and triggered PM2 reloads; build and cache diagnostics retain heap snapshots
- preserve request error propagation and avoid user/package high-cardinality labels

## Verification
- 13 focused tests pass
- production build passes
- Prettier check passes
- 10,000 synthetic samples kept the JS heap bounded at roughly 6.0 to 6.7 MiB
- full Jest run: 49 pass; seven existing errors-cache integration tests require a server on 127.0.0.1:5000 and fail with ECONNREFUSED when run standalone

## Production follow-up
After merge and deploy, inspect /var/cache/bundlephobia/diagnostics/main/latest.timeline.json, latest.metadata.json, and latest.report.json after the next 425 MiB crossing or PM2 reload.