### PR TITLE
Terminate cancelled package build workers

### DIFF
--- a/__tests__/build-service-runner.test.ts
+++ b/__tests__/build-service-runner.test.ts
@@ -1,0 +1,89 @@
+import AbortController from 'abort-controller'
+import { EventEmitter } from 'node:events'
+import { fork } from 'node:child_process'
+
+import runPackageOperation from '../build-service/runPackageOperation'
+
+jest.mock('node:child_process', () => ({
+  fork: jest.fn(),
+}))
+
+const mockedFork = fork as jest.MockedFunction<typeof fork>
+
+function createWorker() {
+  const worker = new EventEmitter() as EventEmitter & {
+    send: jest.Mock
+    kill: jest.Mock
+  }
+  worker.send = jest.fn()
+  worker.kill = jest.fn()
+  return worker
+}
+
+describe('build-service package operation runner', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.clearAllMocks()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('runs an operation in an isolated child process', async () => {
+    const worker = createWorker()
+    mockedFork.mockReturnValue(worker as never)
+
+    const result = runPackageOperation('size', 'example@1.0.0')
+    worker.emit('spawn')
+
+    expect(worker.send).toHaveBeenCalledWith({
+      type: 'run',
+      operation: 'size',
+      packageString: 'example@1.0.0',
+    })
+
+    worker.emit('message', { type: 'result', result: { size: 42 } })
+    await expect(result).resolves.toEqual({ size: 42 })
+  })
+
+  it('gracefully aborts and then force-kills a worker that does not exit', async () => {
+    const worker = createWorker()
+    mockedFork.mockReturnValue(worker as never)
+    const controller = new AbortController()
+
+    const result = runPackageOperation('size', 'example@1.0.0', {
+      signal: controller.signal as unknown as globalThis.AbortSignal,
+    })
+    worker.emit('spawn')
+    controller.abort()
+
+    await expect(result).rejects.toMatchObject({
+      code: 'BUILD_CANCELLED',
+      name: 'BuildOperationCancelledError',
+    })
+    expect(worker.send).toHaveBeenLastCalledWith({ type: 'cancel' })
+    expect(worker.kill).toHaveBeenCalledWith('SIGTERM')
+
+    jest.advanceTimersByTime(2000)
+    expect(worker.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('preserves structured package-build errors', async () => {
+    const worker = createWorker()
+    mockedFork.mockReturnValue(worker as never)
+    const payload = {
+      name: 'EntryPointError',
+      originalError: 'No package entry point',
+    }
+
+    const result = runPackageOperation('size', 'example@1.0.0')
+    worker.emit('spawn')
+    worker.emit('message', { type: 'error', error: payload })
+
+    await expect(result).rejects.toMatchObject({
+      name: 'EntryPointError',
+      payload,
+    })
+  })
+})

--- a/build-service/buildWorker.js
+++ b/build-service/buildWorker.js
@@ -1,0 +1,60 @@
+import {
+  eventQueue,
+  getAllPackageExports,
+  getPackageExportSizes,
+  getPackageStats,
+} from 'package-build-stats'
+import serializeError from './serializeError.js'
+
+const operations = {
+  exports: getAllPackageExports,
+  exportSizes: getPackageExportSizes,
+  size: getPackageStats,
+}
+
+const abortController = new AbortController()
+
+function cancelBuild() {
+  abortController.abort()
+}
+
+process.once('SIGTERM', cancelBuild)
+process.on('message', message => {
+  if (message?.type === 'cancel') {
+    cancelBuild()
+  }
+})
+
+eventQueue.on('*', (event, details) => {
+  process.send?.({ type: 'telemetry', event, details })
+})
+
+process.once('message', async message => {
+  if (message?.type !== 'run') {
+    return
+  }
+
+  const operation = operations[message.operation]
+  if (!operation) {
+    process.send?.({
+      type: 'error',
+      error: serializeError(
+        new Error(`Unknown build operation: ${message.operation}`)
+      ),
+    })
+    process.disconnect?.()
+    return
+  }
+
+  try {
+    const result = await operation(message.packageString, {
+      installTimeout: 60000,
+      signal: abortController.signal,
+    })
+    process.send?.({ type: 'result', result })
+  } catch (error) {
+    process.send?.({ type: 'error', error: serializeError(error) })
+  } finally {
+    process.disconnect?.()
+  }
+})

--- a/build-service/index.js
+++ b/build-service/index.js
@@ -1,73 +1,71 @@
 import 'dotenv-defaults/config.js'
 import Fastify from 'fastify'
-import {
-  getPackageStats,
-  getAllPackageExports,
-  getPackageExportSizes,
-  eventQueue,
-} from 'package-build-stats'
 import Amplitude from '@amplitude/node'
 import serializeError from './serializeError.js'
+import runPackageOperation, {
+  BuildOperationCancelledError,
+} from './runPackageOperation.js'
 
 const fastify = Fastify()
+let amplitudeClient
 
 if (process.env.AMPLITUDE_API_KEY) {
-  const client = Amplitude.init(process.env.AMPLITUDE_API_KEY)
-
-  eventQueue.on('*', (event, details) => {
-    client.logEvent({
-      event_type: event,
-      user_id: 'build-service',
-      event_properties: {
-        ...details,
-      },
-    })
-  })
+  amplitudeClient = Amplitude.init(process.env.AMPLITUDE_API_KEY)
 
   setInterval(() => {
-    client.flush()
+    amplitudeClient.flush()
   }, 5000)
+}
+
+function recordTelemetry(event, details) {
+  amplitudeClient?.logEvent({
+    event_type: event,
+    user_id: 'build-service',
+    event_properties: { ...details },
+  })
+}
+
+async function handleBuild(operation, packageString, res) {
+  const abortController = new AbortController()
+  const cancelDisconnectedBuild = () => {
+    if (!res.raw.writableEnded) {
+      abortController.abort()
+    }
+  }
+  res.raw.once('close', cancelDisconnectedBuild)
+
+  try {
+    const result = await runPackageOperation(operation, packageString, {
+      signal: abortController.signal,
+      onTelemetry: recordTelemetry,
+    })
+    return res.code(200).send(result)
+  } catch (err) {
+    if (err instanceof BuildOperationCancelledError) {
+      return
+    }
+    console.log(err)
+    return res.code(500).send(serializeError(err))
+  } finally {
+    res.raw.removeListener('close', cancelDisconnectedBuild)
+  }
 }
 
 fastify.get('/size', async (req, res) => {
   const packageString = decodeURIComponent(req.query.p)
-  try {
-    const result = await getPackageStats(packageString, {
-      installTimeout: 60000,
-    })
-    return res.code(200).send(result)
-  } catch (err) {
-    console.log(err)
-    return res.code(500).send(serializeError(err))
-  }
+  return handleBuild('size', packageString, res)
 })
 
 fastify.get('/exports-sizes', async (req, res) => {
   const packageString = decodeURIComponent(req.query.p)
 
-  try {
-    const result = await getPackageExportSizes(packageString, {
-      installTimeout: 60000,
-    })
-    return res.code(200).send(result)
-  } catch (err) {
-    console.log(err)
-    return res.code(500).send(serializeError(err))
-  }
+  return handleBuild('exportSizes', packageString, res)
 })
 
 fastify.get('/exports', async (req, res) => {
   const packageString = decodeURIComponent(req.query.p)
 
-  try {
-    const result = await getAllPackageExports(packageString, {
-      installTimeout: 60000,
-    })
-    return res.code(200).send(result)
-  } catch (err) {
-    console.log(err)
-    return res.code(500).send(serializeError(err))
-  }
+  return handleBuild('exports', packageString, res)
 })
 
 fastify

--- a/build-service/package.json
+++ b/build-service/package.json
@@ -9,7 +9,7 @@
     "dotenv-defaults": "^2.0.2",
     "fastify": "^4.25.2",
     "now-logs": "^0.0.7",
-    "package-build-stats": "9.1.0"
+    "package-build-stats": "9.2.0"
   },
   "engines": {
     "node": ">= 9.x.x",

--- a/build-service/runPackageOperation.js
+++ b/build-service/runPackageOperation.js
@@ -1,0 +1,96 @@
+import { fork } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const workerPath = fileURLToPath(new URL('./buildWorker.js', import.meta.url))
+const forceKillDelay = 2000
+
+export class BuildOperationCancelledError extends Error {
+  constructor() {
+    super('Package build was cancelled')
+    this.name = 'BuildOperationCancelledError'
+    this.code = 'BUILD_CANCELLED'
+  }
+}
+
+class RemoteBuildError extends Error {
+  constructor(payload) {
+    super(payload?.name || 'Package build failed')
+    this.name = payload?.name || 'BuildServiceError'
+    this.payload = payload
+  }
+
+  toJSON() {
+    return this.payload
+  }
+}
+
+export default function runPackageOperation(
+  operation,
+  packageString,
+  { signal, onTelemetry } = {}
+) {
+  return new Promise((resolve, reject) => {
+    const worker = fork(workerPath, [], {
+      stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+    })
+    let settled = false
+    let forceKillTimer
+
+    const settle = callback => {
+      if (settled) {
+        return
+      }
+      settled = true
+      signal?.removeEventListener('abort', cancel)
+      callback()
+    }
+
+    const cancel = () => {
+      if (settled) {
+        return
+      }
+
+      worker.send?.({ type: 'cancel' })
+      worker.kill('SIGTERM')
+      forceKillTimer = setTimeout(() => worker.kill('SIGKILL'), forceKillDelay)
+      forceKillTimer.unref()
+      settle(() => reject(new BuildOperationCancelledError()))
+    }
+
+    worker.once('spawn', () => {
+      if (signal?.aborted) {
+        cancel()
+        return
+      }
+      worker.send({ type: 'run', operation, packageString })
+    })
+
+    worker.on('message', message => {
+      if (message?.type === 'telemetry') {
+        onTelemetry?.(message.event, message.details)
+      } else if (message?.type === 'result') {
+        settle(() => resolve(message.result))
+      } else if (message?.type === 'error') {
+        settle(() => reject(new RemoteBuildError(message.error)))
+      }
+    })
+
+    worker.once('error', error => settle(() => reject(error)))
+    worker.once('exit', (code, exitSignal) => {
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer)
+      }
+      settle(() =>
+        reject(
+          new Error(
+            `Build worker exited before responding (${
+              exitSignal || `code ${code}`
+            })`
+          )
+        )
+      )
+    })
+
+    signal?.addEventListener('abort', cancel, { once: true })
+  })
+}

--- a/build-service/yarn.lock
+++ b/build-service/yarn.lock
@@ -2725,7 +2725,7 @@ __metadata:
     dotenv-defaults: "npm:^2.0.2"
     fastify: "npm:^4.25.2"
     now-logs: "npm:^0.0.7"
-    package-build-stats: "npm:9.1.0"
+    package-build-stats: "npm:9.2.0"
   languageName: unknown
   linkType: soft
 
@@ -7326,9 +7326,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-build-stats@npm:9.1.0":
-  version: 9.1.0
-  resolution: "package-build-stats@npm:9.1.0"
+"package-build-stats@npm:9.2.0":
+  version: 9.2.0
+  resolution: "package-build-stats@npm:9.2.0"
   dependencies:
     "@babel/core": "npm:^7.28.5"
     "@rspack/core": "npm:^2.1.4"
@@ -7365,7 +7365,7 @@ __metadata:
     yargs: "npm:^18.0.0"
   bin:
     package-stats: bin/cli.js
-  checksum: d9291d16004d65c9fe57101c8ffa596ae2bee14b37d16738a7ec6976b86e3d842f9703351a9e8efa3fa1c52e172a7a652de1be3316daf92ca3867210c1532316
+  checksum: c7d778f706670dedf4ef32ba2a4c5bf9a51a1fbcea72d24bcc51b9050c056c30af12aa54a3f07f66fd5f5b03fc56aef286868a0a26f12fcbe5f80e664e73d6ac
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node-fetch": "^2.7.0",
     "normalize.css": "^8.0.1",
     "p-queue": "^3.2.0",
-    "package-build-stats": "9.1.0",
+    "package-build-stats": "9.2.0",
     "pacote": "^11.3.5",
     "performance-now": "^2.1.0",
     "progress-stream": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7793,7 +7793,7 @@ __metadata:
     dotenv-defaults: "npm:^2.0.2"
     fastify: "npm:^4.25.2"
     now-logs: "npm:^0.0.7"
-    package-build-stats: "npm:9.1.0"
+    package-build-stats: "npm:9.2.0"
   languageName: unknown
   linkType: soft
 
@@ -7915,7 +7915,7 @@ __metadata:
     nodemon: "npm:^2.0.22"
     normalize.css: "npm:^8.0.1"
     p-queue: "npm:^3.2.0"
-    package-build-stats: "npm:9.1.0"
+    package-build-stats: "npm:9.2.0"
     pacote: "npm:^11.3.5"
     performance-now: "npm:^2.1.0"
     postcss: "npm:^8.4.33"
@@ -19017,9 +19017,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"package-build-stats@npm:9.1.0":
-  version: 9.1.0
-  resolution: "package-build-stats@npm:9.1.0"
+"package-build-stats@npm:9.2.0":
+  version: 9.2.0
+  resolution: "package-build-stats@npm:9.2.0"
   dependencies:
     "@babel/core": "npm:^7.28.5"
     "@rspack/core": "npm:^2.1.4"
@@ -19056,7 +19056,7 @@ __metadata:
     yargs: "npm:^18.0.0"
   bin:
     package-stats: bin/cli.js
-  checksum: a08357b93d671286cfed9b8a34b536b0f3998323de05f8b5d64a01d5230a00551337f1f7c6a456a9fbc200433e9acb654cd0518ba441d4513a65c7d6852e4566
+  checksum: 8eea70e9eef8a15dc98b4c1f7578edd9df240aac36895cd2a8da6da2fb9fe259cdcee9c92d547c3e09af68727159f41626acfae26cca1879413e3cfbbbb08f8c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- run each build-service package operation in an isolated child process
- propagate client disconnects into package-build-stats via AbortSignal
- gracefully cancel installers and analysis, then force-kill an unresponsive active Rspack worker after a bounded grace period
- preserve structured build errors and forward worker telemetry to the existing Amplitude client
- pin published package-build-stats 9.2.0 in both manifests and lockfiles

This completes the cancellation path started in #1027: browser disconnect -> shared queue listener removal -> main-to-build-service Axios abort -> build-service socket close -> package worker cancellation. Shared queue jobs remain alive while another subscriber still needs them.

## Verification
- targeted cancellation/queue/build-service Jest tests
- full `yarn test --runInBand`
- `yarn lint`
- `yarn build`
- real local aborted `next@latest` request; no build worker or package-manager descendant remained
- both installed package-build-stats copies resolve to 9.2.0
- package-build-stats 9.2.0 confirmed on the public npm registry