### PR TITLE
Upgrade deduplicated builds to the highest subscriber priority

### DIFF
--- a/__tests__/Queue.test.ts
+++ b/__tests__/Queue.test.ts
@@ -265,3 +265,68 @@ describe('Queue cancellation', () => {
     expect(queue.getRunningJobs()).toHaveLength(0)
   })
 })
+
+describe('Queue priority', () => {
+  const nativeAbortController = global.AbortController
+
+  beforeAll(() => {
+    global.AbortController =
+      AbortController as unknown as typeof global.AbortController
+  })
+
+  afterAll(() => {
+    global.AbortController = nativeAbortController
+  })
+
+  it('upgrades a queued job when a higher-priority subscriber joins it', async () => {
+    const queue = new Queue({ concurrency: 1, aging: false })
+    const executionOrder: string[] = []
+    let releaseBlocker: () => void = () => {}
+    const blocker = new Promise<void>(resolve => {
+      releaseBlocker = resolve
+    })
+
+    queue.addExecutor<string, string>('TEST', async id => {
+      executionOrder.push(id)
+      if (id === 'blocker') {
+        await blocker
+      }
+      return id
+    })
+
+    const blockerResult = queue.process<string, string>(
+      'blocker',
+      'TEST',
+      'blocker'
+    )
+    const firstSharedResult = queue.process<string, string>(
+      'shared',
+      'TEST',
+      'shared',
+      { priority: Queue.priority.LOW }
+    )
+    const mediumResult = queue.process<string, string>(
+      'medium',
+      'TEST',
+      'medium',
+      { priority: Queue.priority.MEDIUM }
+    )
+    const secondSharedResult = queue.process<string, string>(
+      'shared',
+      'TEST',
+      'shared',
+      { priority: Queue.priority.HIGH }
+    )
+
+    releaseBlocker()
+
+    await Promise.all([
+      blockerResult,
+      firstSharedResult,
+      mediumResult,
+      secondSharedResult,
+    ])
+
+    expect(executionOrder).toEqual(['blocker', 'shared', 'medium'])
+  })
+})

--- a/__tests__/request-priority.test.ts
+++ b/__tests__/request-priority.test.ts
@@ -1,0 +1,31 @@
+import type { Context } from 'koa'
+
+import Queue from '../server/Queue'
+import { getRequestPriority } from '../utils/server.utils'
+
+function contextFor(client?: string): Context {
+  return {
+    headers: client ? { 'x-bundlephobia-user': client } : {},
+  } as unknown as Context
+}
+
+describe('request priority', () => {
+  it('prioritizes website requests over MCP and public API requests', () => {
+    expect(getRequestPriority(contextFor('bundlephobia website'))).toBe(
+      Queue.priority.HIGH
+    )
+    expect(getRequestPriority(contextFor('bundlephobia mcp tool'))).toBe(
+      Queue.priority.MEDIUM
+    )
+    expect(getRequestPriority(contextFor())).toBe(Queue.priority.LOW)
+    expect(getRequestPriority(contextFor('unknown api client'))).toBe(
+      Queue.priority.LOW
+    )
+  })
+
+  it('keeps Yarn requests at low priority', () => {
+    expect(getRequestPriority(contextFor('yarn website'))).toBe(
+      Queue.priority.LOW
+    )
+  })
+})

--- a/server/Queue.ts
+++ b/server/Queue.ts
@@ -389,6 +389,12 @@ class Queue {
 
       if (this.hasJob(id, type)) {
         log('job id %s already present, adding callbacks', id)
+        const existingJob = this.jobs.find(
+          queuedJob => queuedJob.id === id && queuedJob.type === type
+        )
+        if (existingJob) {
+          existingJob.priority = Math.max(existingJob.priority, priority)
+        }
         this.addListenersToJob(id, type, {
           resolve: successListener as (value: never) => void,
           reject: failureListener,

--- a/utils/server.utils.ts
+++ b/utils/server.utils.ts
@@ -58,9 +58,10 @@ export function getRequestPriority(ctx: Context): number {
   switch (client) {
     case 'bundlephobia website':
       return Queue.priority.HIGH
-    case 'yarn website':
-      return Queue.priority.LOW
-    default:
+    case 'bundlephobia mcp tool':
       return Queue.priority.MEDIUM
+    case 'yarn website':
+    default:
+      return Queue.priority.LOW
   }
 }


### PR DESCRIPTION
## Summary
- upgrade an existing deduplicated queue job when a higher-priority subscriber joins
- explicitly classify website requests as high, MCP calls as medium, and public/unknown/Yarn traffic as low using the existing priority levels
- cover execution ordering and request classification with focused tests

## Why
If a public API request queued a package first, a later website request for the same package only subscribed to that low-priority job. The shared job could remain behind unrelated work even though an interactive user was waiting for it.

## Verification
- `yarn test __tests__/Queue.test.ts __tests__/request-priority.test.ts --runInBand --watchman=false`
- `yarn lint`
- Prettier check for all changed files
- Full Jest run passed 10 unit suites; the existing `errors-cache` integration suite expected a server on `127.0.0.1:5000` and failed with `ECONNREFUSED`