### PR TITLE
Simplify package recommendation form

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-package-recommendation.yml
+++ b/.github/ISSUE_TEMPLATE/2-package-recommendation.yml
@@ -23,8 +23,8 @@ body:
   - type: input
     id: category
     attributes:
-      label: Bundlephobia category
-      description: Which existing category should contain this package? Propose a concise category name if none fits.
+      label: Package category name
+      description: Use a category name from [the supported package categories](https://github.com/pastelsky/bundlephobia/blob/bundlephobia/server/middlewares/similar-packages/fixtures.ts), or propose a concise name if none fits.
       placeholder: 'For example: General purpose date-time utilities'
     validations:
       required: true
@@ -35,15 +35,6 @@ body:
       label: Alternative npm packages
       description: Enter exact npm package names, separated by commas. The automation compares their minified and gzipped sizes.
       placeholder: 'For example: moment, luxon'
-    validations:
-      required: true
-
-  - type: textarea
-    id: overlap
-    attributes:
-      label: Functional overlap
-      description: Describe the concrete use cases that both packages support. Links to documentation or comparisons are helpful.
-      placeholder: 'Both packages can...'
     validations:
       required: true
 
@@ -74,6 +65,4 @@ body:
       label: Submission checklist
       options:
         - label: I searched existing recommendations and issues for duplicates.
-          required: true
-        - label: I understand that automated checks provide evidence but do not guarantee acceptance.
           required: true

--- a/.github/scripts/recommendation-quality.mjs
+++ b/.github/scripts/recommendation-quality.mjs
@@ -30,7 +30,6 @@ export function extractIssueFormAnswers(body = '') {
       answers.get('Alternative npm packages') ??
       answers.get('Alternative package or category') ??
       cleanIssueAnswer(legacyAlternative?.[1]),
-    overlap: answers.get('Functional overlap') ?? '',
     advantage: answers.get('Why is this a better alternative?') ?? '',
   }
 }
@@ -221,9 +220,6 @@ export function evaluateRecommendation(signals, answers = {}) {
     notes.push(
       `No activity was found in the last ${RECENT_ACTIVITY_DAYS} days and the latest release is not a stable 1.x-or-newer version.`
     )
-  }
-  if (answers.overlap !== undefined && answers.overlap.trim().length < 40) {
-    notes.push('The functional-overlap explanation needs more detail.')
   }
   if (answers.advantage !== undefined && answers.advantage.trim().length < 40) {
     notes.push('The relative-advantage explanation needs more detail.')

--- a/.github/scripts/recommendation-quality.test.mjs
+++ b/.github/scripts/recommendation-quality.test.mjs
@@ -19,17 +19,13 @@ test('extracts required answers from a GitHub issue form body', () => {
 
 date-fns
 
-### Bundlephobia category
+### Package category name
 
 General purpose date-time utilities
 
 ### Alternative npm packages
 
 moment
-
-### Functional overlap
-
-Both packages parse, format, and manipulate dates in browser applications.
 
 ### Why is this a better alternative?
 
@@ -144,10 +140,7 @@ test('collects objective npm and GitHub quality signals', async () => {
 })
 
 test('blocks authoritative failures but keeps incomplete signals advisory', () => {
-  const missing = evaluateRecommendation(
-    { exists: false },
-    { overlap: '', advantage: '' }
-  )
+  const missing = evaluateRecommendation({ exists: false }, { advantage: '' })
   assert.equal(missing.status, 'invalid')
   assert.equal(missing.errors.length, 1)
 
@@ -160,7 +153,6 @@ test('blocks authoritative failures but keeps incomplete signals advisory', () =
       activeOrStable: true,
     },
     {
-      overlap: 'Same thing',
       advantage: 'Smaller',
     }
   )

--- a/.github/scripts/triage-package-recommendation.mjs
+++ b/.github/scripts/triage-package-recommendation.mjs
@@ -220,7 +220,7 @@ ${
     ? `### Follow-up needed\n\n${findings
         .map(finding => `- ${finding}`)
         .join('\n')}`
-    : 'The objective checks passed. A maintainer still needs to verify functional overlap and whether this improves the category.'
+    : 'The objective checks passed. A maintainer still needs to verify category fit and whether this improves the recommendations.'
 }
 
 _Thresholds: at least 1,000 weekly npm downloads or 100 GitHub stars; maintenance is indicated by activity in the last two years or a stable 1.x-or-newer release. These are triage signals, not automatic acceptance._`


### PR DESCRIPTION
## Summary

- rename the recommendation form field to `Package category name`
- link contributors directly to the supported categories in `fixtures.ts`
- remove the separate functional-overlap question and its evaluator warning
- remove the automated-checks acknowledgement from the submission checklist

## Verification

- `node --test .github/scripts/*.test.mjs` (11 tests pass)
- Prettier check passes for all changed files
- pre-commit lint and staged-file checks pass with existing unrelated warnings
