### PR TITLE
Limit oversized package build errors

### DIFF
--- a/__tests__/build-service-unavailable.test.ts
+++ b/__tests__/build-service-unavailable.test.ts
@@ -3,7 +3,9 @@ import axios from 'axios'
 
 import serializeError from '../build-service/serializeError'
 import CustomError from '../server/CustomError'
-import BuildService from '../server/api/BuildService'
+import BuildService, {
+  MAX_BUILD_SERVICE_RESPONSE_BYTES,
+} from '../server/api/BuildService'
 import { failureCache, pool, requestQueue } from '../server/init'
 import errorMiddleware from '../server/middlewares/results/error.middleware'
 
@@ -101,7 +103,30 @@ describe('build service unavailability', () => {
       extra: undefined,
     }
 
-    expect(serializeError({ toJSON: () => serialized })).toBe(serialized)
+    expect(serializeError({ toJSON: () => serialized })).toEqual(serialized)
+  })
+
+  it('preserves custom error details containing circular data', () => {
+    const originalError: { message: string; self?: unknown } = {
+      message: 'the useful build error',
+    }
+    originalError.self = originalError
+
+    expect(
+      serializeError({
+        toJSON: () => ({
+          name: 'BuildError',
+          originalError,
+          extra: undefined,
+        }),
+      })
+    ).toEqual({
+      name: 'BuildError',
+      originalError: {
+        message: 'the useful build error',
+        self: '[Circular]',
+      },
+    })
   })
 
   it('identifies a structured internal build-service error', async () => {
@@ -158,6 +183,7 @@ describe('build service unavailability', () => {
     expect(axios.get).toHaveBeenCalledWith(
       'http://127.0.0.1:7002/size?p=%40example%2Fcancelled%401.0.0',
       expect.objectContaining({
+        maxContentLength: MAX_BUILD_SERVICE_RESPONSE_BYTES,
         signal: controller.signal,
       })
     )

--- a/__tests__/error-middleware.test.ts
+++ b/__tests__/error-middleware.test.ts
@@ -7,11 +7,16 @@ jest.mock('../server/Logger', () => ({
   default: { error: jest.fn() },
 }))
 
+import { failureCache } from '../server/init'
+import CustomError from '../server/CustomError'
 import errorHandler from '../server/middlewares/results/error.middleware'
 
 describe('build API error middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('preserves client HTTP errors before package resolution', async () => {
-    const consoleError = jest.spyOn(console, 'error').mockImplementation()
     const error = Object.assign(
       new Error('package query parameter is required'),
       {
@@ -39,7 +44,31 @@ describe('build API error middleware', () => {
         message: 'package query parameter is required',
       },
     })
-    expect(consoleError).toHaveBeenCalledWith(error)
-    consoleError.mockRestore()
+  })
+
+  it('caches build errors under the package resolved downstream', async () => {
+    const packageString = '@example/build-error@1.0.0'
+    const ctx = {
+      body: undefined,
+      cacheControl: undefined,
+      query: {},
+      state: { id: 'request-id' } as {
+        id: string
+        resolved?: { packageString: string }
+      },
+      status: undefined,
+    }
+    const error = new CustomError('BuildError', 'compiler failed', undefined)
+
+    await errorHandler(ctx as never, async () => {
+      ctx.state.resolved = { packageString }
+      throw error
+    })
+
+    const responseBody = ctx.body
+    expect(failureCache.set).toHaveBeenCalledWith(packageString, {
+      status: 422,
+      body: responseBody,
+    })
   })
 })

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -108,10 +108,10 @@ describe('resolveBuildError', () => {
     }
   )
 
-  it('omits an object that cannot be serialized', () => {
+  it('handles circular error details', () => {
     const circular: { self?: unknown } = {}
     circular.self = circular
 
-    expect(resolveDetails(circular)).toBeNull()
+    expect(resolveDetails(circular)).toContain('[Circular]')
   })
 })

--- a/build-service/index.js
+++ b/build-service/index.js
@@ -11,6 +11,16 @@ import serializeError from './serializeError.js'
 
 const fastify = Fastify()
 
+function sendBuildError(res, packageString, error) {
+  const serialized = serializeError(error)
+  console.error('PACKAGE_BUILD_FAILED', {
+    packageString,
+    name: serialized.name,
+    originalError: serialized.originalError,
+  })
+  return res.code(500).send(serialized)
+}
+
 if (process.env.AMPLITUDE_API_KEY) {
   const client = Amplitude.init(process.env.AMPLITUDE_API_KEY)
 
@@ -37,8 +47,7 @@ fastify.get('/size', async (req, res) => {
     })
     return res.code(200).send(result)
   } catch (err) {
-    console.log(err)
-    return res.code(500).send(serializeError(err))
+    return sendBuildError(res, packageString, err)
   }
 })
 
@@ -51,8 +60,7 @@ fastify.get('/exports-sizes', async (req, res) => {
     })
     return res.code(200).send(result)
   } catch (err) {
-    console.log(err)
-    return res.code(500).send(serializeError(err))
+    return sendBuildError(res, packageString, err)
   }
 })
 
@@ -65,8 +73,7 @@ fastify.get('/exports', async (req, res) => {
     })
     return res.code(200).send(result)
   } catch (err) {
-    console.log(err)
-    return res.code(500).send(serializeError(err))
+    return sendBuildError(res, packageString, err)
   }
 })
 

--- a/build-service/package.json
+++ b/build-service/package.json
@@ -9,7 +9,9 @@
     "dotenv-defaults": "^2.0.2",
     "fastify": "^4.25.2",
     "now-logs": "^0.0.7",
-    "package-build-stats": "9.1.0"
+    "package-build-stats": "9.1.0",
+    "safe-stable-stringify": "^2.5.0",
+    "truncate": "^3.0.0"
   },
   "engines": {
     "node": ">= 9.x.x",

--- a/build-service/serializeError.js
+++ b/build-service/serializeError.js
@@ -1,5 +1,28 @@
-function getErrorMessage(error) {
-  return error instanceof Error ? error.message : String(error)
+import { configure } from 'safe-stable-stringify'
+import truncate from 'truncate'
+
+const MAX_ERROR_MESSAGE_LENGTH = 16_000
+const stringifyError = configure({
+  deterministic: false,
+  maximumBreadth: 20,
+  maximumDepth: 4,
+})
+
+function serializeValue(value) {
+  const serialized = stringifyError(value, (_key, item) => {
+    if (item instanceof Error) {
+      return {
+        name: item.name,
+        message: item.message,
+        ...(typeof item.code === 'string' ? { code: item.code } : {}),
+      }
+    }
+    return typeof item === 'string'
+      ? truncate(item, MAX_ERROR_MESSAGE_LENGTH)
+      : item
+  })
+
+  return serialized === undefined ? undefined : JSON.parse(serialized)
 }
 
 export default function serializeError(error) {
@@ -8,12 +31,8 @@ export default function serializeError(error) {
     typeof error === 'object' &&
     typeof error.toJSON === 'function'
   ) {
-    const serialized = error.toJSON()
-    if (
-      serialized &&
-      typeof serialized === 'object' &&
-      typeof serialized.name === 'string'
-    ) {
+    const serialized = serializeValue(error)
+    if (serialized && typeof serialized.name === 'string') {
       return serialized
     }
   }
@@ -21,7 +40,10 @@ export default function serializeError(error) {
   return {
     name: 'BuildServiceError',
     originalError: {
-      message: getErrorMessage(error),
+      message: truncate(
+        error instanceof Error ? error.message : String(error),
+        MAX_ERROR_MESSAGE_LENGTH
+      ),
       ...(typeof error?.code === 'string' ? { code: error.code } : {}),
     },
     extra: { retryable: true },

--- a/build-service/yarn.lock
+++ b/build-service/yarn.lock
@@ -2726,6 +2726,8 @@ __metadata:
     fastify: "npm:^4.25.2"
     now-logs: "npm:^0.0.7"
     package-build-stats: "npm:9.1.0"
+    safe-stable-stringify: "npm:^2.5.0"
+    truncate: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -8507,7 +8509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-stable-stringify@npm:^2.3.1":
+"safe-stable-stringify@npm:^2.3.1, safe-stable-stringify@npm:^2.5.0":
   version: 2.5.0
   resolution: "safe-stable-stringify@npm:2.5.0"
   checksum: 2697fa186c17c38c3ca5309637b4ac6de2f1c3d282da27cd5e1e3c88eca0fb1f9aea568a6aabdf284111592c8782b94ee07176f17126031be72ab1313ed46c5c
@@ -9489,6 +9491,13 @@ __metadata:
   dependencies:
     utf8-byte-length: "npm:^1.0.1"
   checksum: 366e47a0e22cc271d37eb4e62820453fb877784b55b37218842758b7aa1d402eedd0f8833cfb5d6f7a6cae1535d84289bd5e32c4ee962d2a86962fb7038a6983
+  languageName: node
+  linkType: hard
+
+"truncate@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "truncate@npm:3.0.0"
+  checksum: 9e3c5b4a6bb7626197c7f396f621ba2426b8e1854f1b17e331ccd1fb6a8df7ca38c76d496fee716c7f5765f2b3180e8164a7c7e38425f668b922b72093e8c381
   languageName: node
   linkType: hard
 

--- a/index.ts
+++ b/index.ts
@@ -24,11 +24,11 @@ import remoteMcpClient from './server/mcp/remoteClient'
 import limit from './server/middlewares/rateLimit.middleware'
 import exportsMiddlware from './server/middlewares/exports.middleware'
 import exportsSizesMiddlware from './server/middlewares/exportsSizes.middleware'
+import blockBlacklistMiddleware from './server/middlewares/results/blockBlacklist.middleware'
 import resolvePackageMiddleware from './server/middlewares/results/resolvePackage.middleware'
 import cachedResponseMiddleware from './server/middlewares/results/cachedResponse.middleware'
 import buildMiddleware from './server/middlewares/results/build.middleware'
 import errorMiddleware from './server/middlewares/results/error.middleware'
-import blockBlacklistMiddleware from './server/middlewares/results/blockBlacklist.middleware'
 import requestLoggerMiddleware from './server/middlewares/requestLogger.middleware'
 import similarPackagesMiddleware from './server/middlewares/similar-packages/similarPackages.middleware'
 import generateImgMiddleware from './server/middlewares/generateImg.middleware'
@@ -134,8 +134,8 @@ app.prepare().then(() => {
       }),
     }),
     errorMiddleware,
-    resolvePackageMiddleware,
     blockBlacklistMiddleware,
+    resolvePackageMiddleware,
     cachedResponseMiddleware,
     buildMissRateLimit({
       durationMs: 1000 * 60 * 5,
@@ -148,8 +148,8 @@ app.prepare().then(() => {
   router.get(
     '/api/exports',
     errorMiddleware,
-    resolvePackageMiddleware,
     blockBlacklistMiddleware,
+    resolvePackageMiddleware,
     exportsMiddlware
   )
 
@@ -164,8 +164,8 @@ app.prepare().then(() => {
       }),
     }),
     errorMiddleware,
-    resolvePackageMiddleware,
     blockBlacklistMiddleware,
+    resolvePackageMiddleware,
     cachedResponseMiddleware,
     buildMissRateLimit({
       durationMs: 1000 * 60 * 5,

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-flip-move": "^3.0.5",
     "react-sidebar": "^3.0.2",
     "remark": "^9.0.0",
+    "safe-stable-stringify": "^2.5.0",
     "sass": "^1.70.0",
     "semver": "^7.6.3",
     "stream-chain": "^3.3.2",

--- a/server/api/BuildService.ts
+++ b/server/api/BuildService.ts
@@ -7,6 +7,7 @@ import config from '../config'
 import { pool, requestQueue } from '../init'
 
 const debug = createDebug('bp:build')
+export const MAX_BUILD_SERVICE_RESPONSE_BYTES = 8 * 1024 * 1024
 
 const OperationType = {
   PACKAGE_BUILD_STATS: 'PACKAGE_BUILD_STATS',
@@ -56,7 +57,10 @@ export default class BuildService {
                 `${process.env.BUILD_SERVICE_ENDPOINT}${
                   operation.endpoint
                 }?p=${encodeURIComponent(packageString)}`,
-                { signal }
+                {
+                  signal,
+                  maxContentLength: MAX_BUILD_SERVICE_RESPONSE_BYTES,
+                }
               )
               return response.data
             } catch (error) {

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -2,12 +2,14 @@ import type { Middleware } from 'koa'
 import now from 'performance-now'
 import createDebug from 'debug'
 
+import { toErrorDetail } from '../../../utils'
 import config from '../../config'
 import { failureCache } from '../../init'
 import logger from '../../Logger'
 import { isJobCancelledError } from '../../Queue'
 
 const debug = createDebug('bp:error')
+const MAX_ERROR_LIST_ITEMS = 20
 
 interface ErrorResponseBody {
   error: {
@@ -41,6 +43,12 @@ function isClientHttpError(error: Error): error is ClientHttpError {
 }
 
 function formatSentence(values: string[]): string {
+  const omittedCount = values.length - MAX_ERROR_LIST_ITEMS
+  values = values.slice(0, MAX_ERROR_LIST_ITEMS)
+  if (omittedCount > 0) {
+    values.push(`${omittedCount} more`)
+  }
+
   if (values.length === 0) {
     return ''
   }
@@ -53,10 +61,23 @@ function formatSentence(values: string[]): string {
   return `${values.slice(0, -1).join(', ')}, and ${values[values.length - 1]}`
 }
 
+function getErrorDetails(originalError: unknown) {
+  const detail = toErrorDetail(originalError)
+  return detail ? { originalError: detail } : undefined
+}
+
 const errorHandler: Middleware = async (ctx, next) => {
   const { force } = ctx.query
   const start = now()
-  const packageString = ctx.state.resolved?.packageString
+  let packageString = ctx.state.resolved?.packageString
+
+  const cacheFailure = (status: number, body: unknown) => {
+    if (!packageString) {
+      return
+    }
+    debug('saved %s to failure cache', packageString)
+    failureCache.set(packageString, { status, body })
+  }
 
   const respondWithError = (
     status: number,
@@ -91,6 +112,7 @@ const errorHandler: Middleware = async (ctx, next) => {
   try {
     await next()
   } catch (error) {
+    packageString = ctx.state.resolved?.packageString
     ctx.cacheControl = {
       maxAge: force ? 0 : config.CACHE.SIZE_API_ERROR,
     }
@@ -117,8 +139,6 @@ const errorHandler: Middleware = async (ctx, next) => {
       return
     }
 
-    console.error(error)
-
     if (!(error instanceof Error)) {
       const errObj = error as Record<string, unknown> | null
       if (errObj && errObj.code === 'JOB_EXPIRED') {
@@ -141,7 +161,10 @@ const errorHandler: Middleware = async (ctx, next) => {
         return
       }
 
-      respondWithError(500, { code: 'UnknownError', details: error })
+      respondWithError(500, {
+        code: 'UnknownError',
+        details: getErrorDetails(error),
+      })
       return
     }
 
@@ -243,8 +266,7 @@ const errorHandler: Middleware = async (ctx, next) => {
         }
 
         respondWithError(status, body.error)
-        debug('saved %s to failure cache', packageString)
-        failureCache.set(packageString, { status, body })
+        cacheFailure(status, body)
         break
       }
 
@@ -262,7 +284,7 @@ const errorHandler: Middleware = async (ctx, next) => {
               `but does not specify ${
                 missingModulesList.length > 1 ? 'them' : 'it'
               } either as a dependency or a peer dependency`,
-            details: err,
+            details: getErrorDetails(err.originalError) ?? {},
           },
         }
 
@@ -271,8 +293,7 @@ const errorHandler: Middleware = async (ctx, next) => {
         }
 
         respondWithError(status, body.error)
-        debug('saved %s to failure cache', packageString)
-        failureCache.set(packageString, { status, body })
+        cacheFailure(status, body)
         break
       }
 
@@ -287,7 +308,7 @@ const errorHandler: Middleware = async (ctx, next) => {
                 err.extra?.filePath ?? 'unknown file'
               }</code> can be minified using <a href="https://try.terser.org/" target="_blank">terser</a>.`,
             details: {
-              originalError: JSON.stringify(err.originalError, null, 2),
+              ...getErrorDetails(err.originalError),
             },
           },
         }
@@ -297,24 +318,22 @@ const errorHandler: Middleware = async (ctx, next) => {
         }
 
         respondWithError(status, body.error)
-        debug('saved %s to failure cache', packageString)
-        failureCache.set(packageString, { status, body })
+        cacheFailure(status, body)
         break
       }
 
       case 'BuildError':
       default: {
         const status = 422
+        const details = getErrorDetails(err.originalError) ?? {}
         const errorJSON = {
           code: 'BuildError',
           message: 'Failed to build this package.',
-          details: err,
+          details,
         }
         respondWithError(status, errorJSON)
-        debug('saved %s to failure cache', packageString)
-        failureCache.set(packageString, {
-          status,
-          body: { error: errorJSON },
+        cacheFailure(status, {
+          error: errorJSON,
         })
         break
       }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,6 @@
+import { configure } from 'safe-stable-stringify'
+import truncate from 'truncate'
+
 export interface FormattedValue {
   unit: 'B' | 'kB' | 'MB' | 'μs' | 'ms' | 's'
   size: number
@@ -77,17 +80,24 @@ export function zeroToN(n: number): number[] {
   return Array.from(Array(n).keys())
 }
 
-function toErrorDetail(originalError: unknown): string | null {
+const MAX_ERROR_DETAIL_LENGTH = 12_000
+const stringifyError = configure({ maximumBreadth: 20, maximumDepth: 4 })
+
+export function toErrorDetail(originalError: unknown): string | null {
   if (originalError == null) {
     return null
   }
 
   if (typeof originalError === 'string') {
-    return originalError.trim() ? originalError : null
+    return originalError.trim()
+      ? truncate(originalError, MAX_ERROR_DETAIL_LENGTH)
+      : null
   }
 
   if (originalError instanceof Error) {
-    return originalError.message || null
+    return originalError.message
+      ? truncate(originalError.message, MAX_ERROR_DETAIL_LENGTH)
+      : null
   }
 
   if (Array.isArray(originalError)) {
@@ -95,18 +105,17 @@ function toErrorDetail(originalError: unknown): string | null {
       .map(toErrorDetail)
       .filter((detail): detail is string => detail !== null)
 
-    return details.length ? details.join('\n\n') : null
+    return details.length
+      ? truncate(details.join('\n\n'), MAX_ERROR_DETAIL_LENGTH)
+      : null
   }
 
   if (typeof originalError === 'object') {
-    try {
-      return JSON.stringify(originalError, null, 2)
-    } catch {
-      return null
-    }
+    const serialized = stringifyError(originalError, null, 2)
+    return serialized ? truncate(serialized, MAX_ERROR_DETAIL_LENGTH) : null
   }
 
-  return String(originalError)
+  return truncate(String(originalError), MAX_ERROR_DETAIL_LENGTH)
 }
 
 function isBuildErrorResponse(value: unknown): value is BuildErrorResponse {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7794,6 +7794,8 @@ __metadata:
     fastify: "npm:^4.25.2"
     now-logs: "npm:^0.0.7"
     package-build-stats: "npm:9.1.0"
+    safe-stable-stringify: "npm:^2.5.0"
+    truncate: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7935,6 +7937,7 @@ __metadata:
     react-flip-move: "npm:^3.0.5"
     react-sidebar: "npm:^3.0.2"
     remark: "npm:^9.0.0"
+    safe-stable-stringify: "npm:^2.5.0"
     sass: "npm:^1.70.0"
     sass-loader: "npm:^10.5.2"
     semver: "npm:^7.6.3"
@@ -21665,6 +21668,13 @@ __metadata:
   version: 2.4.3
   resolution: "safe-stable-stringify@npm:2.4.3"
   checksum: 81dede06b8f2ae794efd868b1e281e3c9000e57b39801c6c162267eb9efda17bd7a9eafa7379e1f1cacd528d4ced7c80d7460ad26f62ada7c9e01dec61b2e768
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Scenario

Large build/install errors could be copied from the worker into logs, the HTTP response, main's logs, the failure cache, and the UI. Blocklisted packages such as `next` also loaded complete npm metadata before being rejected.

## Changes

- reject blocklisted packages before registry metadata resolution, with the order shown directly in each route
- use `safe-stable-stringify` for circular-safe error serialization with depth and item limits
- retain useful custom error messages while truncating unusually large strings
- cap build-service responses at 8 MiB
- send only the error detail needed by the UI and failure cache
- cache failures under the package key populated during downstream resolution

`safe-stable-stringify` is used instead of a custom recursive serializer. Unlike `serialize-error`, it does not leave circular handling in custom `toJSON()` implementations.

## Focused tests

- custom error messages survive circular serialization
- failures use the package key resolved downstream
- build-service requests configure the response-size limit

## Verification

- 28 focused Jest tests passed
- production `yarn build` passed
- build-service JavaScript syntax checks passed
- GitHub CI passed on the previous revision and will rerun for this update
