### PR TITLE
Refresh curated package recommendations

### DIFF
--- a/server/middlewares/similar-packages/fixtures.ts
+++ b/server/middlewares/similar-packages/fixtures.ts
@@ -25,7 +25,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'construct', weight: Weight.MID },
       { tag: 'conditional', weight: Weight.MID },
     ],
-    similar: ['clsx', 'classnames', 'classcat', 'merge-class-names'],
+    similar: ['clsx', 'classnames', 'classcat', 'classix'],
   },
   clipboard: {
     name: 'Clipboard Utilities',
@@ -145,7 +145,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'fuzzy', weight: Weight.NORMAL },
       { tag: 'text', weight: Weight.NORMAL },
     ],
-    similar: ['flexsearch', 'lunr', 'wade', 'js-search', 'fuse.js'],
+    similar: ['minisearch', 'flexsearch', 'fuse.js', 'lunr'],
   },
   'fetch-polyfill': {
     name: 'Fetch polyfills',
@@ -176,7 +176,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'webgl', weight: Weight.MAX },
       { tag: 'gl', weight: Weight.HIGH },
     ],
-    similar: ['three', 'babylonjs'],
+    similar: ['ogl', 'three', 'babylonjs'],
   },
   'general-purpose-animation': {
     name: 'General purpose animation libraries',
@@ -268,7 +268,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'xhr', weight: Weight.NORMAL },
       { tag: 'node node.js', weight: Weight.NORMAL },
     ],
-    similar: ['got', 'phin', 'axios', 'node-fetch', 'superagent'],
+    similar: ['wretch', 'ofetch', 'axios', 'got'],
   },
   'browser-http-request': {
     name: 'HTTP client libraries for Browser',
@@ -493,7 +493,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'check', weight: Weight.SMALL },
       { tag: 'structure', weight: Weight.MID },
     ],
-    similar: ['jsonschema', 'joi', 'ajv', 'superstruct', 'yup', 'zod'],
+    similar: ['jsonschema', 'valibot', 'ajv', 'superstruct', 'yup', 'zod'],
   },
   'querystring-parser': {
     name: 'Query String Parsers',
@@ -518,7 +518,7 @@ const categories: Record<string, CategoryDefinition> = {
         weight: Weight.NORMAL,
       },
     ],
-    similar: ['slate', 'quill', 'draft-js', 'medium-editor', 'froala-editor'],
+    similar: ['lexical', 'slate', 'quill', 'froala-editor'],
   },
   'site-tour': {
     name: 'Site Tours',


### PR DESCRIPTION
## Summary

- add smaller, actively maintained recommendations: `ofetch`, `wretch`, `minisearch`, `classix`, `valibot`, `lexical`, and `ogl`
- remove deprecated, archived, stale, or heavier/redundant alternatives: `phin`, `node-fetch`, `superagent`, `wade`, `js-search`, `merge-class-names`, `joi`, `draft-js`, and `medium-editor`
- keep each affected category focused at three to six packages without adding UI-only truncation

## Selection notes

- `ofetch` and `wretch` are 3.9 kB and 1.8 kB gzip respectively; `phin` is deprecated, while `node-fetch` and `superagent` are redundant in the refreshed four-package shortlist
- `minisearch` is active, 5.8 kB gzip, and replaces the 2017-era `wade` plus stale `js-search`
- `classix` replaces archived `merge-class-names`
- `valibot` is active, modular, and 14.7 kB gzip; it replaces 53.8 kB `joi`
- `lexical` replaces archived Draft.js and the 2017-era MediumEditor
- `ogl` adds a maintained 34.2 kB minimal WebGL option alongside Three.js and Babylon.js
- `io-ts` was evaluated but not added because its measured size excludes the required `fp-ts` peer and its latest package/repository activity is from 2024

## Verification

- `node --test .github/scripts/*.test.mjs` (11 tests pass)
- live recommendation checker passes all seven additions
- all affected categories remain within the six-package cap
- pre-commit lint and staged-file checks pass with existing unrelated warnings

Closes #840
Closes #922
Closes #386
Closes #775
Closes #812
Closes #652
Closes #841
