### PR TITLE
Avoid loading full npm packuments for version resolution

### DIFF
--- a/__tests__/error-middleware.test.ts
+++ b/__tests__/error-middleware.test.ts
@@ -71,4 +71,29 @@ describe('build API error middleware', () => {
       body: responseBody,
     })
   })
+
+  it('labels a single mismatch suggestion as the latest version', async () => {
+    const ctx = {
+      body: undefined,
+      cacheControl: undefined,
+      query: {},
+      state: { id: 'request-id' },
+      status: undefined,
+    }
+
+    await errorHandler(ctx as never, async () => {
+      throw new CustomError('PackageVersionMismatchError', null, {
+        suggestedVersion: '19.1.1',
+      })
+    })
+
+    expect(ctx.status).toBe(404)
+    expect(ctx.body).toMatchObject({
+      error: {
+        code: 'PackageVersionMismatchError',
+        message:
+          'This package has not been published with this particular version. The latest version is `<code>19.1.1</code>`.',
+      },
+    })
+  })
 })

--- a/__tests__/server-utils.test.ts
+++ b/__tests__/server-utils.test.ts
@@ -1,0 +1,66 @@
+const registryFetch = require('npm-registry-fetch')
+const pacote = require('pacote')
+
+jest.mock('npm-registry-fetch', () => ({ json: jest.fn() }))
+jest.mock('pacote', () => ({ manifest: jest.fn() }))
+
+import { resolvePackage } from '../utils/server.utils'
+
+describe('resolvePackage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it.each([
+    ['next', '/next/latest'],
+    ['next@15.0.0', '/next/15.0.0'],
+    ['next@canary', '/next/canary'],
+    ['@babel/core', '/@babel%2fcore/latest'],
+  ])('fetches one manifest for %s', async (packageString, expectedPath) => {
+    registryFetch.json.mockResolvedValue({ name: 'next', version: '15.0.0' })
+
+    await expect(resolvePackage(packageString)).resolves.toEqual({
+      name: 'next',
+      version: '15.0.0',
+    })
+    expect(registryFetch.json).toHaveBeenCalledWith(expectedPath)
+    expect(pacote.manifest).not.toHaveBeenCalled()
+  })
+
+  it('uses abbreviated metadata only to resolve a semver range', async () => {
+    pacote.manifest.mockResolvedValue({ name: 'next', version: '15.5.9' })
+    registryFetch.json.mockResolvedValue({
+      name: 'next',
+      version: '15.5.9',
+      repository: { url: 'https://github.com/vercel/next.js' },
+    })
+
+    await resolvePackage('next@^15.0.0')
+
+    expect(pacote.manifest).toHaveBeenCalledWith('next@^15.0.0', {
+      fullMetadata: false,
+    })
+    expect(registryFetch.json).toHaveBeenCalledWith('/next/15.5.9')
+  })
+
+  it('reports a missing version when the package itself exists', async () => {
+    registryFetch.json
+      .mockRejectedValueOnce({ code: 'E404' })
+      .mockResolvedValueOnce({ name: 'react', version: '19.1.1' })
+
+    await expect(resolvePackage('react@99.0.0')).rejects.toMatchObject({
+      name: 'PackageVersionMismatchError',
+      extra: { validVersions: ['19.1.1'] },
+    })
+  })
+
+  it('reports a package that does not exist', async () => {
+    registryFetch.json.mockRejectedValue({ code: 'E404' })
+
+    await expect(
+      resolvePackage('definitely-not-a-real-package')
+    ).rejects.toMatchObject({
+      name: 'PackageNotFoundError',
+    })
+  })
+})

--- a/__tests__/server-utils.test.ts
+++ b/__tests__/server-utils.test.ts
@@ -14,8 +14,10 @@ describe('resolvePackage', () => {
   it.each([
     ['next', '/next/latest'],
     ['next@15.0.0', '/next/15.0.0'],
+    ['next@v15.0.0', '/next/15.0.0'],
     ['next@canary', '/next/canary'],
     ['@babel/core', '/@babel%2fcore/latest'],
+    ['next-alias@npm:next@15.0.0', '/next/15.0.0'],
   ])('fetches one manifest for %s', async (packageString, expectedPath) => {
     registryFetch.json.mockResolvedValue({ name: 'next', version: '15.0.0' })
 
@@ -43,6 +45,31 @@ describe('resolvePackage', () => {
     expect(registryFetch.json).toHaveBeenCalledWith('/next/15.5.9')
   })
 
+  it('uses abbreviated metadata to resolve an aliased semver range', async () => {
+    pacote.manifest.mockResolvedValue({ name: 'react', version: '18.3.1' })
+    registryFetch.json.mockResolvedValue({ name: 'react', version: '18.3.1' })
+
+    await resolvePackage('legacy-react@npm:react@^18')
+
+    expect(pacote.manifest).toHaveBeenCalledWith('legacy-react@npm:react@^18', {
+      fullMetadata: false,
+    })
+    expect(registryFetch.json).toHaveBeenCalledWith('/react/18.3.1')
+  })
+
+  it('preserves Pacote resolution for non-registry specs', async () => {
+    pacote.manifest.mockResolvedValue({ name: 'react', version: '18.2.0' })
+
+    await expect(resolvePackage('github:facebook/react')).resolves.toEqual({
+      name: 'react',
+      version: '18.2.0',
+    })
+    expect(pacote.manifest).toHaveBeenCalledWith('github:facebook/react', {
+      fullMetadata: true,
+    })
+    expect(registryFetch.json).not.toHaveBeenCalled()
+  })
+
   it('reports a missing version when the package itself exists', async () => {
     registryFetch.json
       .mockRejectedValueOnce({ code: 'E404' })
@@ -50,7 +77,7 @@ describe('resolvePackage', () => {
 
     await expect(resolvePackage('react@99.0.0')).rejects.toMatchObject({
       name: 'PackageVersionMismatchError',
-      extra: { validVersions: ['19.1.1'] },
+      extra: { suggestedVersion: '19.1.1' },
     })
   })
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@types/koa-static": "^4.0.4",
     "@types/node": "^24.0.0",
     "@types/node-fetch": "^2.6.13",
+    "@types/npm-package-arg": "6.1.4",
     "@types/progress-stream": "^2",
     "@types/react": "18.2.48",
     "@types/react-autocomplete": "1.8.10",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "next": "^13.5.6",
     "node-fetch": "^2.7.0",
     "normalize.css": "^8.0.1",
+    "npm-package-arg": "^8.1.5",
     "npm-registry-fetch": "^11.0.0",
     "p-queue": "^3.2.0",
     "package-build-stats": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "next": "^13.5.6",
     "node-fetch": "^2.7.0",
     "normalize.css": "^8.0.1",
+    "npm-registry-fetch": "^11.0.0",
     "p-queue": "^3.2.0",
     "package-build-stats": "9.1.0",
     "pacote": "^11.3.5",

--- a/server/middlewares/results/error.middleware.ts
+++ b/server/middlewares/results/error.middleware.ts
@@ -24,6 +24,7 @@ interface BuildErrorShape extends Error {
   extra?: {
     reason?: string
     validVersions?: string[]
+    suggestedVersion?: string
     missingModules?: string[]
     filePath?: string
   }
@@ -227,6 +228,14 @@ const errorHandler: Middleware = async (ctx, next) => {
         break
 
       case 'PackageVersionMismatchError': {
+        if (err.extra?.suggestedVersion) {
+          respondWithError(404, {
+            code: 'PackageVersionMismatchError',
+            message: `This package has not been published with this particular version. The latest version is \`<code>${err.extra.suggestedVersion}</code>\`.`,
+          })
+          break
+        }
+
         const validVersions = formatSentence(
           (err.extra?.validVersions ?? []).map(
             version => `\`<code>${version}</code>\``

--- a/utils/server.utils.ts
+++ b/utils/server.utils.ts
@@ -1,6 +1,7 @@
 import 'dotenv-defaults/config'
 
 import type { Context } from 'koa'
+import parsePackageSpec from 'npm-package-arg'
 import semver from 'semver'
 
 import CustomError from '../server/CustomError'
@@ -15,22 +16,21 @@ interface PacoteModule {
 
 const pacote = require('pacote') as PacoteModule
 
-interface PackageSpec {
-  type: string
-  name?: string
-  escapedName?: string
-  fetchSpec?: string | null
-  subSpec?: PackageSpec
-}
-
-interface RegistryPackageSpec extends PackageSpec {
-  type: 'range' | 'tag' | 'version'
+type RegistryPackageSpec = parsePackageSpec.RegistryResult & {
   escapedName: string
 }
 
-const parsePackageSpec = require('npm-package-arg') as (
-  spec: string
-) => PackageSpec
+function isAliasPackageSpec(
+  spec: parsePackageSpec.Result
+): spec is parsePackageSpec.AliasResult {
+  return spec.type === 'alias'
+}
+
+function isRegistryPackageSpec(
+  spec: parsePackageSpec.Result
+): spec is RegistryPackageSpec {
+  return spec.registry && Boolean(spec.escapedName)
+}
 
 interface NpmRegistryFetchModule {
   json(path: string): Promise<ResolvedPackageManifest>
@@ -70,17 +70,13 @@ function registryPackageSpec(
   packageString: string
 ): RegistryPackageSpec | null {
   const parsed = parsePackageSpec(packageString)
-  const target = parsed.type === 'alias' ? parsed.subSpec : parsed
+  const target = isAliasPackageSpec(parsed) ? parsed.subSpec : parsed
 
-  if (
-    !target ||
-    !['range', 'tag', 'version'].includes(target.type) ||
-    !target.escapedName
-  ) {
+  if (!isRegistryPackageSpec(target)) {
     return null
   }
 
-  return target as RegistryPackageSpec
+  return target
 }
 
 export async function resolvePackage(

--- a/utils/server.utils.ts
+++ b/utils/server.utils.ts
@@ -5,7 +5,6 @@ import semver from 'semver'
 
 import CustomError from '../server/CustomError'
 import Queue from '../server/Queue'
-import { parsePackageString } from './common.utils'
 
 interface PacoteModule {
   manifest(
@@ -15,6 +14,23 @@ interface PacoteModule {
 }
 
 const pacote = require('pacote') as PacoteModule
+
+interface PackageSpec {
+  type: string
+  name?: string
+  escapedName?: string
+  fetchSpec?: string | null
+  subSpec?: PackageSpec
+}
+
+interface RegistryPackageSpec extends PackageSpec {
+  type: 'range' | 'tag' | 'version'
+  escapedName: string
+}
+
+const parsePackageSpec = require('npm-package-arg') as (
+  spec: string
+) => PackageSpec
 
 interface NpmRegistryFetchModule {
   json(path: string): Promise<ResolvedPackageManifest>
@@ -50,18 +66,47 @@ async function fetchVersionManifest(name: string, version: string) {
   return registryFetch.json(registryManifestPath(name, version))
 }
 
+function registryPackageSpec(
+  packageString: string
+): RegistryPackageSpec | null {
+  const parsed = parsePackageSpec(packageString)
+  const target = parsed.type === 'alias' ? parsed.subSpec : parsed
+
+  if (
+    !target ||
+    !['range', 'tag', 'version'].includes(target.type) ||
+    !target.escapedName
+  ) {
+    return null
+  }
+
+  return target as RegistryPackageSpec
+}
+
 export async function resolvePackage(
   packageString: string
 ): Promise<ResolvedPackageManifest> {
-  const { name, version } = parsePackageString(packageString)
-  const requestedVersion = version ?? 'latest'
+  let requestedVersion = 'latest'
+  let packageName: string | undefined
 
   try {
-    if (
-      !semver.validRange(requestedVersion) ||
-      semver.valid(requestedVersion)
-    ) {
-      return await fetchVersionManifest(name, requestedVersion)
+    const packageSpec = registryPackageSpec(packageString)
+
+    if (!packageSpec) {
+      return await pacote.manifest(packageString, { fullMetadata: true })
+    }
+
+    const targetName = packageSpec.escapedName
+    packageName = targetName
+    requestedVersion = packageSpec.fetchSpec || 'latest'
+
+    if (packageSpec.type === 'version') {
+      requestedVersion = semver.clean(requestedVersion) ?? requestedVersion
+      return await fetchVersionManifest(targetName, requestedVersion)
+    }
+
+    if (packageSpec.type === 'tag') {
+      return await fetchVersionManifest(targetName, requestedVersion)
     }
 
     const manifest = await pacote.manifest(packageString, {
@@ -80,11 +125,11 @@ export async function resolvePackage(
       })
     }
 
-    if (requestedVersion !== 'latest' && isNotFound(error)) {
+    if (packageName && requestedVersion !== 'latest' && isNotFound(error)) {
       try {
-        const latest = await fetchVersionManifest(name, 'latest')
+        const latest = await fetchVersionManifest(packageName, 'latest')
         throw new CustomError('PackageVersionMismatchError', null, {
-          validVersions: [latest.version],
+          suggestedVersion: latest.version,
         })
       } catch (latestError) {
         if (latestError instanceof CustomError) {

--- a/utils/server.utils.ts
+++ b/utils/server.utils.ts
@@ -1,9 +1,11 @@
 import 'dotenv-defaults/config'
 
 import type { Context } from 'koa'
+import semver from 'semver'
 
 import CustomError from '../server/CustomError'
 import Queue from '../server/Queue'
+import { parsePackageString } from './common.utils'
 
 interface PacoteModule {
   manifest(
@@ -14,9 +16,16 @@ interface PacoteModule {
 
 const pacote = require('pacote') as PacoteModule
 
+interface NpmRegistryFetchModule {
+  json(path: string): Promise<ResolvedPackageManifest>
+}
+
+const registryFetch = require('npm-registry-fetch') as NpmRegistryFetchModule
+
 interface PacoteManifestError {
   code?: string
   distTags?: Record<string, string>
+  statusCode?: number
   versions?: string[]
 }
 
@@ -28,14 +37,37 @@ export interface ResolvedPackageManifest {
   [key: string]: unknown
 }
 
+function registryManifestPath(name: string, version: string): string {
+  return `/${name.replace('/', '%2f')}/${encodeURIComponent(version)}`
+}
+
+function isNotFound(error: unknown): boolean {
+  const registryError = error as PacoteManifestError
+  return registryError.code === 'E404' || registryError.statusCode === 404
+}
+
+async function fetchVersionManifest(name: string, version: string) {
+  return registryFetch.json(registryManifestPath(name, version))
+}
+
 export async function resolvePackage(
   packageString: string
 ): Promise<ResolvedPackageManifest> {
+  const { name, version } = parsePackageString(packageString)
+  const requestedVersion = version ?? 'latest'
+
   try {
+    if (
+      !semver.validRange(requestedVersion) ||
+      semver.valid(requestedVersion)
+    ) {
+      return await fetchVersionManifest(name, requestedVersion)
+    }
+
     const manifest = await pacote.manifest(packageString, {
-      fullMetadata: true,
+      fullMetadata: false,
     })
-    return manifest as ResolvedPackageManifest
+    return await fetchVersionManifest(manifest.name, manifest.version)
   } catch (error) {
     const pacoteError = error as PacoteManifestError
 
@@ -46,6 +78,22 @@ export async function resolvePackage(
           ...(pacoteError.versions ?? []),
         ],
       })
+    }
+
+    if (requestedVersion !== 'latest' && isNotFound(error)) {
+      try {
+        const latest = await fetchVersionManifest(name, 'latest')
+        throw new CustomError('PackageVersionMismatchError', null, {
+          validVersions: [latest.version],
+        })
+      } catch (latestError) {
+        if (latestError instanceof CustomError) {
+          throw latestError
+        }
+        if (!isNotFound(latestError)) {
+          throw new CustomError('PackageNotFoundError', latestError, undefined)
+        }
+      }
     }
 
     throw new CustomError('PackageNotFoundError', error, undefined)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7916,6 +7916,7 @@ __metadata:
     node-fetch: "npm:^2.7.0"
     nodemon: "npm:^2.0.22"
     normalize.css: "npm:^8.0.1"
+    npm-registry-fetch: "npm:^11.0.0"
     p-queue: "npm:^3.2.0"
     package-build-stats: "npm:9.1.0"
     pacote: "npm:^11.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5657,6 +5657,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/npm-package-arg@npm:6.1.4":
+  version: 6.1.4
+  resolution: "@types/npm-package-arg@npm:6.1.4"
+  checksum: aa881ce030580fcf7fa64c0e47171a7b2d6053253b6ee14c4fa1d779017a797f4865939cdcbd4095d8afc82b78c16532e67caea7aa7561a9c2a669a695121b36
+  languageName: node
+  linkType: hard
+
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
@@ -7851,6 +7858,7 @@ __metadata:
     "@types/koa__router": "npm:^12.0.4"
     "@types/node": "npm:^24.0.0"
     "@types/node-fetch": "npm:^2.6.13"
+    "@types/npm-package-arg": "npm:6.1.4"
     "@types/progress-stream": "npm:^2"
     "@types/react": "npm:18.2.48"
     "@types/react-autocomplete": "npm:1.8.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7916,6 +7916,7 @@ __metadata:
     node-fetch: "npm:^2.7.0"
     nodemon: "npm:^2.0.22"
     normalize.css: "npm:^8.0.1"
+    npm-package-arg: "npm:^8.1.5"
     npm-registry-fetch: "npm:^11.0.0"
     p-queue: "npm:^3.2.0"
     package-build-stats: "npm:9.1.0"
@@ -18128,7 +18129,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-package-arg@npm:^8.0.0, npm-package-arg@npm:^8.0.1, npm-package-arg@npm:^8.1.2":
+"npm-package-arg@npm:^8.0.0, npm-package-arg@npm:^8.0.1, npm-package-arg@npm:^8.1.2, npm-package-arg@npm:^8.1.5":
   version: 8.1.5
   resolution: "npm-package-arg@npm:8.1.5"
   dependencies:


### PR DESCRIPTION
## What changed

- parse npm package specifications with npm-package-arg instead of hand-written version heuristics
- resolve latest, exact versions, dist-tags, normalized v-prefixed versions, aliases, and scoped packages through the npm registry single-version endpoint
- retain Pacote selection semantics for semver ranges with abbreviated metadata, then fetch only the selected version metadata
- preserve the original full-metadata Pacote path for Git, URL, file, and other non-registry specifications
- preserve PackageNotFoundError and PackageVersionMismatchError behavior without a manually maintained blocklist

## Why

A next packument contains thousands of versions and is tens of megabytes decoded. The normal Bundlephobia request only needs one version plus its repository and description. The registry single-version endpoint returns those fields in a few kilobytes.

A production read-only probe resolved next latest, next canary, and scoped @babel/core in 67-86 ms. The first lookup increased RSS by about 5 MiB and subsequent lookups did not measurably increase it.

## Compatibility

A production parity matrix compared the old full-metadata Pacote path with this resolver for latest, exact versions, v-prefixed versions, tags, scoped packages, prereleases, semver ranges, and exact/ranged npm aliases. Name, resolved version, description, and repository matched in every case. Non-registry specifications continue to use the old Pacote path.

Invalid exact versions still return PackageVersionMismatchError, but now accurately label the single returned suggestion as the latest version rather than calling it a complete list of valid versions.

## Verification

- 14 focused resolver and error-middleware tests passed
- ESLint passed for all changed TypeScript files
- yarn build passed
- immutable Yarn install passed
- production registry and Pacote parity probes passed

The existing errors-cache integration suite requires a local server on port 5000 and is not runnable standalone.