### PR TITLE
Replace stale package recommendations

### DIFF
--- a/server/middlewares/similar-packages/fixtures.ts
+++ b/server/middlewares/similar-packages/fixtures.ts
@@ -108,13 +108,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'compare', weight: Weight.NORMAL },
       { tag: 'isequal', weight: Weight.HIGH },
     ],
-    similar: [
-      'dequal',
-      'fast-deep-equal',
-      'deep-eql',
-      'deep-equal',
-      'lodash.isequal',
-    ],
+    similar: ['dequal', 'fast-deep-equal', 'deep-eql', 'deep-equal'],
   },
   'drag-and-drop': {
     name: 'Drag & Drop Libraries',
@@ -307,7 +301,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'xhr', weight: Weight.NORMAL },
       { tag: 'browser', weight: Weight.NORMAL },
     ],
-    similar: ['axios', 'ky', 'superagent', 'redaxios', 'unfetch'],
+    similar: ['axios', 'ky', 'xior', 'superagent', 'redaxios'],
   },
   'icu-message-fromatter': {
     name: 'ICU message string formatters',
@@ -468,7 +462,12 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'transform', weight: Weight.NORMAL },
       { tag: 'motion', weight: Weight.NORMAL },
     ],
-    similar: ['react-spring', 'framer-motion', 'react-motion', 'react-move'],
+    similar: [
+      'react-spring',
+      'framer-motion',
+      'react-transition-group',
+      'react-motion',
+    ],
   },
   'react-autocomplete': {
     name: 'React based autocomplete components',
@@ -519,8 +518,8 @@ const categories: Record<string, CategoryDefinition> = {
       'next-intl',
       'react-intl',
       'react-i18next',
+      'next-translate',
       'react-intl-universal',
-      'eo-locale',
       '@lingui/react',
     ],
   },
@@ -535,7 +534,7 @@ const categories: Record<string, CategoryDefinition> = {
     similar: [
       'formik',
       'react-final-form',
-      'react-form',
+      'informed',
       'formsy-react',
       'react-hook-form',
     ],


### PR DESCRIPTION
## Summary

- replace eo-locale with next-translate
- replace react-form with informed
- replace unfetch with xior in the browser HTTP shortlist
- replace react-move with react-transition-group
- remove deprecated lodash.isequal now that dequal covers the same category

This is intentionally replacement-only: four additions, five removals, and one fewer recommendation overall.

## Assessment notes

- every addition exists on npm, is non-deprecated, meets the adoption threshold, and has current release or repository activity
- eo-locale has only 462 weekly downloads and no current repository evidence
- react-form has not published since 2019
- unfetch and react-move have not published since 2022 and 2021 respectively
- lodash.isequal is explicitly deprecated on npm

## Verification

- node --test .github/scripts/*.test.mjs (11 tests pass)
- live recommendation quality check passes all four additions
- yarn lint passes with existing unrelated warnings
- pre-commit lint and staged-file checks pass

Closes #670
Closes #508
Closes #880
Closes #567