### PR TITLE
Prune stale package recommendations

### DIFF
--- a/server/middlewares/similar-packages/fixtures.ts
+++ b/server/middlewares/similar-packages/fixtures.ts
@@ -143,15 +143,14 @@ const categories: Record<string, CategoryDefinition> = {
     ],
   },
   'excel-parsers': {
-    name: 'Excel File Readers, Manipulators & Writers',
+    name: 'Excel file readers',
     tags: [
-      { tag: 'excel', weight: Weight.MAX },
-      { tag: 'read', weight: Weight.SMALL },
-      { tag: 'write', weight: Weight.SMALL },
-      { tag: 'manipulate', weight: Weight.SMALL },
-      { tag: 'parse', weight: Weight.SMALL },
+      { tag: 'excel', weight: Weight.HIGH },
+      { tag: 'read', weight: Weight.NORMAL },
+      { tag: 'parse', weight: Weight.NORMAL },
+      { tag: 'import', weight: Weight.MID },
     ],
-    similar: ['read-excel-file', 'xlsx', 'exceljs', 'node-xlsx', 'excel4node'],
+    similar: ['read-excel-file', 'xlsx', 'exceljs'],
   },
   'full-text-search': {
     name: 'Text search',
@@ -325,13 +324,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'palette', weight: Weight.HIGH },
       { tag: 'pixels', weight: Weight.MID },
     ],
-    similar: [
-      'extract-colors',
-      'img-color-extractor',
-      'color-thief-browser',
-      'colority',
-      'node-vibrant',
-    ],
+    similar: ['extract-colors', 'node-vibrant'],
   },
   'immutable-data-structures': {
     name: 'Immutable Data',
@@ -345,13 +338,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'freeze', weight: Weight.MID },
       { tag: 'cursor', weight: Weight.MID },
     ],
-    similar: [
-      'immer',
-      'immutable',
-      'seamless-immutable',
-      'immutability-helper',
-      'baobab',
-    ],
+    similar: ['immer', 'immutable', 'immutability-helper'],
   },
   'lazy-load-content': {
     name: 'Lazy Loading Content',
@@ -375,7 +362,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'abstract syntax tree', weight: Weight.MID },
       { tag: 'md', weight: Weight.HIGH },
     ],
-    similar: ['marked', 'markdown-it', 'showdown', 'remarkable', 'snarkdown'],
+    similar: ['marked', 'markdown-it', 'showdown'],
   },
   memoization: {
     name: 'Memoization',
@@ -457,17 +444,11 @@ const categories: Record<string, CategoryDefinition> = {
   'react-animation': {
     name: 'React based animation',
     tags: [
-      { tag: 'react', weight: Weight.NORMAL },
       { tag: 'animation', weight: Weight.HIGH },
       { tag: 'transform', weight: Weight.NORMAL },
       { tag: 'motion', weight: Weight.NORMAL },
     ],
-    similar: [
-      'react-spring',
-      'framer-motion',
-      'react-transition-group',
-      'react-motion',
-    ],
+    similar: ['react-spring', 'framer-motion'],
   },
   'react-autocomplete': {
     name: 'React based autocomplete components',
@@ -477,13 +458,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'autosuggest', weight: Weight.NORMAL },
       { tag: 'typeahead', weight: Weight.NORMAL },
     ],
-    similar: [
-      'react-autosuggest',
-      'downshift',
-      'react-autowhatever',
-      'react-autocomplete',
-      'react-select',
-    ],
+    similar: ['react-autosuggest', 'downshift', 'react-select'],
   },
   'react-head-meta': {
     name: 'React based meta tags management',
@@ -540,7 +515,7 @@ const categories: Record<string, CategoryDefinition> = {
     ],
   },
   'schema-validation': {
-    name: 'JSON schema validation',
+    name: 'Runtime schema validation',
     tags: [
       { tag: 'JSON', weight: Weight.MID },
       { tag: 'object', weight: Weight.MID },
@@ -625,8 +600,8 @@ const categories: Record<string, CategoryDefinition> = {
       'embla-carousel',
       'keen-slider',
       'swiper',
+      '@glidejs/glide',
       'slick-carousel',
-      'tiny-slider',
     ],
   },
   templating: {


### PR DESCRIPTION
## Summary

- keep one verified replacement: Glide for tiny-slider; both are browser carousel libraries
- remove the proposed ExcellentExport replacement because it is a browser table exporter while excel4node is a Node XLSX generator
- narrow Excel recommendations to cross-environment readers: read-excel-file, SheetJS, and ExcelJS
- keep the existing Immutable Data category while pruning archived seamless-immutable and stale Baobab
- narrow React animation to animation engines and retain only cross-environment image palette extractors
- remove stale or archived entries from autocomplete and Markdown parsing

The final change adds one package and removes fourteen.

## Same-purpose and environment audit

These are alternative libraries, not API-compatible drop-ins. Acceptance means the same primary job and an overlapping runtime or framework environment.

| Earlier batch area | Result |
| --- | --- |
| ofetch, wretch, and xior HTTP clients | Same HTTP-client job and supported runtime; valid |
| MiniSearch, Classix, Tempo, and dequal | Same utility job and JavaScript runtimes; valid |
| Valibot and TypeBox | Same runtime data-validation job; category renamed from JSON schema validation to Runtime schema validation |
| Lexical, Milkdown, and Tiptap | Browser rich-text editor foundations; valid |
| OGL, PlayCanvas, AG Charts, DOM capture, input masking, and carousels | Same browser-facing job within each category; valid |
| React Helmet Async, React Hookz, Informed, i18n, and state libraries | Same React or JavaScript application environment within each category; valid |
| graphql-request | Same GraphQL-client job and browser/Node environment; valid |
| PDFme | Same PDF-generation job with browser support shared by the category; valid |
| Phone and related libraries | Same phone parsing, validation, and formatting job; valid |
| read-excel-file | Valid only in a reader-focused category; category narrowed and Node-only reader/writer entries removed |
| Immer | Valid within the existing Immutable Data category; the category is retained |
| React Transition Group | Not an animation engine replacement; removed |
| ExcellentExport | Not a replacement for excel4node; removed and #593 remains open |

## Verification

- node --test .github/scripts/*.test.mjs (11 tests pass)
- live recommendation quality check passes Glide
- yarn lint passes with existing unrelated warnings
- pre-commit lint and staged-file checks pass

Closes #586