### PR TITLE
Add a smaller deep-equality recommendation

### DIFF
--- a/server/middlewares/similar-packages/fixtures.ts
+++ b/server/middlewares/similar-packages/fixtures.ts
@@ -108,7 +108,13 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'compare', weight: Weight.NORMAL },
       { tag: 'isequal', weight: Weight.HIGH },
     ],
-    similar: ['dequal', 'fast-deep-equal', 'deep-eql', 'deep-equal'],
+    similar: [
+      'dequal',
+      'fast-deep-equal',
+      '@gilbarbara/deep-equal',
+      'deep-eql',
+      'deep-equal',
+    ],
   },
   'drag-and-drop': {
     name: 'Drag & Drop Libraries',
@@ -526,14 +532,7 @@ const categories: Record<string, CategoryDefinition> = {
       { tag: 'check', weight: Weight.SMALL },
       { tag: 'structure', weight: Weight.MID },
     ],
-    similar: [
-      '@sinclair/typebox',
-      'valibot',
-      'ajv',
-      'jsonschema',
-      'yup',
-      'zod',
-    ],
+    similar: ['@sinclair/typebox', 'valibot', 'ajv', 'yup', 'zod'],
   },
   'querystring-parser': {
     name: 'Query String Parsers',


### PR DESCRIPTION
## Summary

- add `@gilbarbara/deep-equal` as a smaller zero-dependency alternative
- retain `deep-equal` because its substantial adoption remains valuable
- complete the earlier TypeBox replacement by removing `jsonschema`

`@gilbarbara/deep-equal` solves the same browser/Node deep-comparison job, has a recent release and substantial npm usage, and has zero dependencies. This adds it alongside—not instead of—the highly downloaded `deep-equal` package.

## Verification

- `git diff --check`
- `YARN_ENABLE_SCRIPTS=false yarn install --immutable`
- `yarn test:recommendations` (11/11 passed)
- pre-commit lint/format hook passed; existing unrelated Next.js warnings remain

Closes #740
Refs #829