### PR TITLE
Add compact tooltip and 2D game recommendation categories

### DIFF
--- a/server/middlewares/similar-packages/fixtures.ts
+++ b/server/middlewares/similar-packages/fixtures.ts
@@ -86,6 +86,17 @@ const categories: Record<string, CategoryDefinition> = {
     ],
     similar: ['js-cookie', 'browser-cookies', 'universal-cookie'],
   },
+  'browser-2d-game-engine': {
+    name: 'Browser 2D game engines',
+    tags: [
+      { tag: 'game engine', weight: Weight.MAX },
+      { tag: '2d', weight: Weight.HIGH },
+      { tag: 'canvas', weight: Weight.NORMAL },
+      { tag: 'webgl', weight: Weight.NORMAL },
+      { tag: 'browser', weight: Weight.NORMAL },
+    ],
+    similar: ['melonjs', 'excalibur', 'phaser'],
+  },
   'date-nlp': {
     name: 'Natural language date-time utilities',
     tags: [
@@ -519,6 +530,16 @@ const categories: Record<string, CategoryDefinition> = {
       'formsy-react',
       'react-hook-form',
     ],
+  },
+  'react-tooltip': {
+    name: 'React tooltip components',
+    tags: [
+      { tag: 'react', weight: Weight.HIGH },
+      { tag: 'tooltip', weight: Weight.MAX },
+      { tag: 'popover', weight: Weight.MID },
+      { tag: 'hover', weight: Weight.NORMAL },
+    ],
+    similar: ['react-tooltip', '@radix-ui/react-tooltip', 'rc-tooltip'],
   },
   'schema-validation': {
     name: 'Runtime schema validation',


### PR DESCRIPTION
## Summary

- add a compact React tooltip category with `react-tooltip`, `@radix-ui/react-tooltip`, and `rc-tooltip`
- add a compact browser 2D game-engine category with `melonjs`, `excalibur`, and `phaser`
- keep each category to three same-purpose packages in the same runtime/framework environment

This is the accepted portion of a 20-issue review batch; the other 18 issues were closed individually with specific quality, category, runtime, duplication, or evidence reasons.

## Verification

- `YARN_ENABLE_SCRIPTS=false yarn install --immutable`
- `yarn test:recommendations` (11/11 passed)
- `git diff --check`
- pre-commit lint/format hook passed; existing unrelated Next.js warnings remain

Closes #745
Closes #769