### PR TITLE
Fix HAProxy Cloudflare client IP validation

### DIFF
--- a/operations/haproxy/haproxy.cfg
+++ b/operations/haproxy/haproxy.cfg
@@ -30,7 +30,7 @@ frontend bundlephobia_http
     bind :80
 
     acl request_from_cloudflare src -f /etc/haproxy/cloudflare-networks.lst
-    acl valid_cloudflare_client_ip req.hdr(CF-Connecting-IP) -m ip
+    acl valid_cloudflare_client_ip req.hdr_ip(CF-Connecting-IP) -m found
 
     http-request set-var(txn.client_ip) src
     http-request set-var(txn.client_ip) req.hdr_ip(CF-Connecting-IP) if request_from_cloudflare valid_cloudflare_client_ip


### PR DESCRIPTION
## Summary
- parse `CF-Connecting-IP` as an IP before checking that it is present
- ensure HAProxy rate-limit tables use the actual client address instead of the Cloudflare edge address

## Verification
- HAProxy 3.4.3 configuration validation passes
- live stick-table lookup recorded the requesting host public IP
- direct requests continue to use their socket source address