### PR TITLE
Fix blank package pages for fast cached builds

### DIFF
--- a/__tests__/build-progress-indicator.test.ts
+++ b/__tests__/build-progress-indicator.test.ts
@@ -1,0 +1,15 @@
+import BuildProgressIndicator from '../client/components/BuildProgressIndicator'
+
+describe('BuildProgressIndicator', () => {
+  it('updates when a fast build completes before progress starts', () => {
+    const onDone = jest.fn()
+    const indicator = new BuildProgressIndicator({
+      isDone: false,
+      onDone,
+    })
+
+    expect(
+      indicator.shouldComponentUpdate({ isDone: true, onDone }, indicator.state)
+    ).toBe(true)
+  })
+})

--- a/client/components/BuildProgressIndicator/BuildProgressIndicator.tsx
+++ b/client/components/BuildProgressIndicator/BuildProgressIndicator.tsx
@@ -51,7 +51,10 @@ export default class BuildProgressIndicator extends Component<
     props: BuildProgressIndicatorProps,
     nextState: BuildProgressIndicatorState
   ) {
-    return this.state.progressText !== nextState.progressText
+    return (
+      this.props.isDone !== props.isDone ||
+      this.state.progressText !== nextState.progressText
+    )
   }
 
   componentWillUnmount() {

--- a/pages/package/[...packageString]/ResultPage.tsx
+++ b/pages/package/[...packageString]/ResultPage.tsx
@@ -159,7 +159,11 @@ class ResultPage extends PureComponent<ResultPageProps, ResultPageState> {
           },
           () => {
             this.activeQuery = newPackageString
-            Router.replace(`/package/${newPackageString}`)
+            if (
+              getPackageStringFromRouter(this.props.router) !== newPackageString
+            ) {
+              Router.replace(`/package/${newPackageString}`)
+            }
           }
         )
 
@@ -261,7 +265,9 @@ class ResultPage extends PureComponent<ResultPageProps, ResultPageState> {
         if (!this.isActiveSearch(requestId)) return
 
         this.activeQuery = normalizedQuery
-        Router.push(`/package/${normalizedQuery}`)
+        if (getPackageStringFromRouter(this.props.router) !== normalizedQuery) {
+          Router.push(`/package/${normalizedQuery}`)
+        }
         Analytics.pageView('package result')
         this.fetchResults(normalizedQuery, requestId)
         this.fetchHistory(normalizedQuery, requestId)


### PR DESCRIPTION
## Summary
- let the progress indicator react when a cached build completes before animation starts
- avoid redundant same-route push/replace calls that cancel Next.js initial props
- add a focused regression test for fast completion

## Verification
- `jest __tests__/build-progress-indicator.test.ts --runInBand`: pass
- `next lint`: pass with existing warnings
- `next build`: pass
- `npx playwright-cli`: `raw-body@4.0.0` renders bundle stats and composition with zero console errors

The broader Jest suite still has pre-existing environment-dependent failures involving the missing `performance` global and tests that expect a build API on port 5000.