### PR TITLE
Fix unhandled recent-search request failures

### DIFF
--- a/__tests__/layout-recent-searches.test.ts
+++ b/__tests__/layout-recent-searches.test.ts
@@ -1,0 +1,25 @@
+import API from '../client/api'
+import Layout from '../client/components/Layout/Layout'
+
+jest.mock('../client/assets/heart.svg', () => () => null)
+jest.mock('../client/assets/digital-ocean-logo.svg', () => () => null)
+
+describe('Layout recent searches', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('does not leave a rejected recent-search request unhandled', async () => {
+    jest
+      .spyOn(API, 'getRecentSearches')
+      .mockRejectedValue({ error: { code: 'ServiceUnavailableError' } })
+
+    const layout = new Layout({})
+    const setState = jest.spyOn(layout, 'setState')
+    layout.componentDidMount()
+
+    await new Promise(resolve => setImmediate(resolve))
+
+    expect(setState).not.toHaveBeenCalled()
+  })
+})

--- a/client/components/Layout/Layout.tsx
+++ b/client/components/Layout/Layout.tsx
@@ -19,11 +19,13 @@ export default class Layout extends Component<LayoutProps, LayoutState> {
   }
 
   componentDidMount() {
-    API.getRecentSearches(5).then(searches => {
-      this.setState({
-        recentSearches: Object.keys(searches),
+    API.getRecentSearches(5)
+      .then(searches => {
+        this.setState({
+          recentSearches: Object.keys(searches),
+        })
       })
-    })
+      .catch(() => undefined)
   }
 
   render() {


### PR DESCRIPTION
## Summary
- handle failures from the optional footer recent-search request
- keep the footer empty when that endpoint is temporarily unavailable
- add a regression test for the non-Error rejection captured by Sentry (BUNDLEPHOBIA-3468)

## Reproduction
On the parent commit, the focused test fails with the structured ServiceUnavailableError object as an unhandled rejection when /api/recent returns 503.

## Verification
- focused regression test passes
- production build passes
- lint passes with existing warnings

## Notes
The full Jest run remains blocked by pre-existing integration/environment failures: errors-cache expects a server on port 5000, and existing build-duration tests fail because performance is unavailable / the expected header is missing.