### PR TITLE
Sequence package result navigation before fetching

### DIFF
--- a/pages/package/[...packageString]/ResultPage.tsx
+++ b/pages/package/[...packageString]/ResultPage.tsx
@@ -265,12 +265,18 @@ class ResultPage extends PureComponent<ResultPageProps, ResultPageState> {
         if (!this.isActiveSearch(requestId)) return
 
         this.activeQuery = normalizedQuery
-        if (getPackageStringFromRouter(this.props.router) !== normalizedQuery) {
-          Router.push(`/package/${normalizedQuery}`)
-        }
-        Analytics.pageView('package result')
-        this.fetchResults(normalizedQuery, requestId)
-        this.fetchHistory(normalizedQuery, requestId)
+        const navigation =
+          getPackageStringFromRouter(this.props.router) !== normalizedQuery
+            ? Router.push(`/package/${normalizedQuery}`)
+            : Promise.resolve(true)
+
+        navigation.then(() => {
+          if (!this.isActiveSearch(requestId)) return
+
+          Analytics.pageView('package result')
+          this.fetchResults(normalizedQuery, requestId)
+          this.fetchHistory(normalizedQuery, requestId)
+        })
       }
     )
   }


### PR DESCRIPTION
## Summary
- wait for an intentional package-route navigation before starting result and history requests
- prevent canonical version replacement from racing the original route transition
- keep stale-search request guards intact

## Why
The broader package matrix found that successful shorthand, tag, and semver-range searches rendered correctly but logged `Loading initial props cancelled` while canonicalizing the resolved version.

## Verification
- 15/15 Playwright CLI result-page cases reached the correct terminal UI and canonical URL
- covered exact versions, omitted versions, dist-tags, semver ranges, scoped packages, prereleases, missing packages, missing versions, and build errors
- zero page exceptions and zero unexpected console errors
- focused Jest regression: pass
- Next lint: pass with existing warnings
- Next production build: pass