### PR TITLE
Replace EthicalAds with Carbon Ads

### DIFF
--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
-import Script from 'next/script'
 
 import Analytics from '../client/analytics'
 import { AutocompleteInput } from '../client/components/AutocompleteInput'
@@ -96,16 +95,6 @@ const Logo = () => (
   </svg>
 )
 
-const loadEthicalAd = () => {
-  const ethicalads = (
-    window as typeof window & {
-      ethicalads?: { load: () => void }
-    }
-  ).ethicalads
-
-  ethicalads?.load()
-}
-
 const Home = () => {
   const router = useRouter()
 
@@ -125,12 +114,6 @@ const Home = () => {
       <MetaTags
         title="Bundlephobia | Size of npm dependencies"
         canonicalPath=""
-      />
-      <Script
-        id="ethicalads-client"
-        src="https://media.ethicalads.io/media/client/ethicalads.min.js"
-        strategy="afterInteractive"
-        onReady={loadEthicalAd}
       />
       <div className="homepage__container">
         <PageNav minimal={true} />
@@ -160,14 +143,14 @@ const Home = () => {
               <sup>beta</sup>
             </Link>
           </div>
-          <div
-            id="homepage-text"
-            className="homepage__ethical-ad flat adaptive-css"
-            data-ea-publisher="bundlephobiacom"
-            data-ea-type="text"
-            data-ea-manual="true"
-            data-ea-verbosity="quiet"
-          />
+          <div className="homepage__carbon-ad">
+            <script
+              async
+              type="text/javascript"
+              src="//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=responsive"
+              id="_carbonads_js"
+            />
+          </div>
         </div>
       </div>
     </Layout>

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -147,7 +147,7 @@ const Home = () => {
             <script
               async
               type="text/javascript"
-              src="//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=responsive"
+              src="//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=cover"
               id="_carbonads_js"
             />
           </div>

--- a/pages/index.scss
+++ b/pages/index.scss
@@ -117,6 +117,9 @@
 }
 
 .homepage__carbon-ad {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   position: fixed;
   right: $global-spacing * 2;
   bottom: $global-spacing * 2;
@@ -124,13 +127,6 @@
   min-height: 280px;
   margin: 0;
   z-index: 1;
-
-  @media screen and (max-width: 70em) {
-    position: static;
-    width: min(32rem, 100%);
-    margin-top: 4vh;
-    margin-bottom: 3vh;
-  }
 }
 
 // Adapt the silver pocket element in the logo for dark mode

--- a/pages/index.scss
+++ b/pages/index.scss
@@ -14,6 +14,18 @@
   align-items: center;
   max-width: 100%;
   height: calc(100vh - 90px);
+
+  // Preserve the vertical position created by the former inline ad slot.
+  &::after {
+    content: '';
+    flex: 0 0 calc(102px + 10vh);
+  }
+
+  @media screen and (max-width: 40em) {
+    &::after {
+      flex-basis: calc(102px + 7vh);
+    }
+  }
 }
 
 .homepage__tagline {
@@ -120,7 +132,7 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  position: fixed;
+  position: absolute;
   right: $global-spacing * 2;
   bottom: $global-spacing * 2;
   width: min($global-spacing * 36, calc(100vw - #{$global-spacing * 4}));

--- a/pages/index.scss
+++ b/pages/index.scss
@@ -117,12 +117,17 @@
 }
 
 .homepage__carbon-ad {
-  width: min(32rem, 100%);
+  position: fixed;
+  right: $global-spacing * 2;
+  bottom: $global-spacing * 2;
+  width: min($global-spacing * 36, calc(100vw - #{$global-spacing * 4}));
   min-height: 280px;
-  margin-top: 5vh;
-  margin-bottom: 5vh;
+  margin: 0;
+  z-index: 1;
 
-  @media screen and (max-width: 40em) {
+  @media screen and (max-width: 70em) {
+    position: static;
+    width: min(32rem, 100%);
     margin-top: 4vh;
     margin-bottom: 3vh;
   }

--- a/pages/index.scss
+++ b/pages/index.scss
@@ -118,7 +118,7 @@
 
 .homepage__carbon-ad {
   width: min(32rem, 100%);
-  min-height: 155px;
+  min-height: 280px;
   margin-top: 5vh;
   margin-bottom: 5vh;
 

--- a/pages/index.scss
+++ b/pages/index.scss
@@ -116,31 +116,11 @@
   }
 }
 
-.homepage__ethical-ad {
-  --ea-bgcolor: transparent;
-  --ea-bgcolor-dark: transparent;
-  --ea-font-family: #{$font-family-body};
-  --ea-font-size: 12px;
-
+.homepage__carbon-ad {
   width: min(32rem, 100%);
-  min-height: 102px;
+  min-height: 155px;
   margin-top: 5vh;
   margin-bottom: 5vh;
-  color: var(--color-text-muted);
-
-  &.loaded {
-    .ea-content {
-      margin: 0;
-      padding: $global-spacing;
-      text-align: center;
-    }
-
-    .ea-callout {
-      margin: $global-spacing * 0.5 0 0;
-      padding: 0;
-      text-align: center;
-    }
-  }
 
   @media screen and (max-width: 40em) {
     margin-top: 4vh;


### PR DESCRIPTION
## Summary

- replace the homepage EthicalAds client and placement with the supplied Carbon Cover tag
- reserve the recommended 280px container height and bottom-align the injected creative
- anchor the ad absolutely 20px from the homepage bottom-right so it scrolls with the page rather than floating in the viewport
- preserve the former inline ad footprint with a nonvisual flex spacer, keeping the logo, search bar, and scan link at their existing production coordinates
- remove EthicalAds-specific loading code and CSS overrides

## Verification

- `yarn lint` passes with existing repository warnings
- Playwright at 1280x720 confirms exact production/local coordinates for the logo, search bar, and scan link
- Playwright at 390x844 confirms the mobile coordinates match production within 0.016px
- the injected `#carbonads` creative ends 20px from the right and bottom edges at initial load
- scrolling 200px moves the absolutely positioned ad upward by 200px, confirming it is not viewport-fixed

## Test suite note

`yarn test --runInBand --watchman=false` currently reports 69 passing tests and 9 failures across 3 unrelated backend suites. The failures are in build-service performance timing and package-build fixture expectations; this PR changes only the homepage component and stylesheet.