### PR TITLE
Add Carbon ad after export analysis

### DIFF
--- a/client/components/CarbonAd/CarbonAd.tsx
+++ b/client/components/CarbonAd/CarbonAd.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+type CarbonAdProps = {
+  className?: string
+}
+
+const CarbonAd = ({ className }: CarbonAdProps) => {
+  const containerRef = React.useRef<HTMLElement>(null)
+
+  React.useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const script = document.createElement('script')
+    script.async = true
+    script.type = 'text/javascript'
+    script.src =
+      '//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=cover'
+    script.id = '_carbonads_js'
+    container.appendChild(script)
+
+    return () => {
+      container.querySelector('#carbonads')?.remove()
+      script.remove()
+    }
+  }, [])
+
+  return (
+    <aside
+      ref={containerRef}
+      className={className}
+      aria-label="Advertisement"
+    />
+  )
+}
+
+export default CarbonAd

--- a/client/components/CarbonAd/index.ts
+++ b/client/components/CarbonAd/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CarbonAd'

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import Analytics from '../client/analytics'
 import { AutocompleteInput } from '../client/components/AutocompleteInput'
 import AutocompleteInputBox from '../client/components/AutocompleteInputBox/AutocompleteInputBox'
+import CarbonAd from '../client/components/CarbonAd'
 import Layout from '../client/components/Layout'
 import MetaTags from '../client/components/MetaTags'
 import PageNav from '../client/components/PageNav'
@@ -97,28 +98,9 @@ const Logo = () => (
 
 const Home = () => {
   const router = useRouter()
-  const carbonAdRef = React.useRef<HTMLDivElement>(null)
 
   React.useEffect(() => {
     Analytics.pageView('home')
-  }, [])
-
-  React.useEffect(() => {
-    const container = carbonAdRef.current
-    if (!container) return
-
-    const script = document.createElement('script')
-    script.async = true
-    script.type = 'text/javascript'
-    script.src =
-      '//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=cover'
-    script.id = '_carbonads_js'
-    container.appendChild(script)
-
-    return () => {
-      container.querySelector('#carbonads')?.remove()
-      script.remove()
-    }
   }, [])
 
   const handleSearchSubmit = (value: string) => {
@@ -162,7 +144,7 @@ const Home = () => {
               <sup>beta</sup>
             </Link>
           </div>
-          <div ref={carbonAdRef} className="homepage__carbon-ad" />
+          <CarbonAd className="homepage__carbon-ad" />
         </div>
       </div>
     </Layout>

--- a/pages/package/[...packageString]/ResultPage.scss
+++ b/pages/package/[...packageString]/ResultPage.scss
@@ -138,6 +138,16 @@
   animation: fade-in-full 0.2s;
 }
 
+.result-page__carbon-ad {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: min($global-spacing * 36, calc(100% - #{$global-spacing * 4}));
+  min-height: 280px;
+  margin: 4vh auto;
+}
+
 .result-pending,
 .result-error {
   min-height: 75vh;

--- a/pages/package/[...packageString]/ResultPage.tsx
+++ b/pages/package/[...packageString]/ResultPage.tsx
@@ -14,6 +14,7 @@ import AutocompleteInputBox from '../../../client/components/AutocompleteInputBo
 import BarGraph from '../../../client/components/BarGraph'
 import { type Reading } from '../../../client/components/BarGraph/BarGraph'
 import BuildProgressIndicator from '../../../client/components/BuildProgressIndicator'
+import CarbonAd from '../../../client/components/CarbonAd'
 import MetaTags, {
   DEFAULT_DESCRIPTION_START,
 } from '../../../client/components/MetaTags'
@@ -571,6 +572,10 @@ class ResultPage extends PureComponent<ResultPageProps, ResultPageState> {
             <div className="content-container">
               <ExportAnalysisSection result={results} />
             </div>
+          )}
+
+          {resultsPromiseState === 'fulfilled' && results && (
+            <CarbonAd className="result-page__carbon-ad" />
           )}
 
           {resultsPromiseState === 'fulfilled' &&


### PR DESCRIPTION
## Summary

- extract the production-safe Carbon loader into a reusable semantic `CarbonAd` component
- keep the existing homepage placement and behavior unchanged
- add an inline Carbon Cover placement immediately after result-page export analysis
- center the result placement with a reserved 280px height and responsive width, without fixed or absolute positioning

## Verification

- `yarn lint` passes with existing repository warnings
- `NEXT_TELEMETRY_DISABLED=1 yarn build` passes
- Playwright confirms the result placement immediately follows `.export-analysis-section`
- Playwright confirms `#carbonads` remains inside `.result-page__carbon-ad` and uses static document flow
- verified at 1280x900 and 390x844; the placement remains centered and does not cover surrounding content

## Local test note

Result-page API requests were proxied to the live Bundlephobia API for browser verification. The live package-history endpoint returned a 429 during the run; the package result, export analysis, and Carbon placement still rendered successfully.