### PR TITLE
Advertise the public APIs for automated consumers

### DIFF
--- a/client/assets/public/openapi.json
+++ b/client/assets/public/openapi.json
@@ -1,0 +1,256 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Bundlephobia API",
+    "description": "Read-only APIs for the cost of adding an npm package to a frontend bundle. Sizes are produced by building the package with a real bundler, so a first request for an uncached package version may take several seconds while the build runs.\n\nNo authentication. Requests are rate limited per IP, and requests that trigger a fresh build are limited more tightly than requests served from cache.",
+    "version": "1.0.0",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    },
+    "externalDocs": {
+      "url": "https://github.com/pastelsky/bundlephobia#readme"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://bundlephobia.com"
+    }
+  ],
+  "tags": [
+    { "name": "size", "description": "Bundle size of a package and its exports" },
+    { "name": "discovery", "description": "Finding and comparing packages" }
+  ],
+  "paths": {
+    "/api/size": {
+      "get": {
+        "operationId": "getPackageSize",
+        "tags": ["size"],
+        "summary": "Minified and gzipped size of an npm package",
+        "parameters": [{ "$ref": "#/components/parameters/package" }],
+        "responses": {
+          "200": {
+            "description": "Build result for the resolved package version.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PackageBuild" }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/BuildError" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/exports": {
+      "get": {
+        "operationId": "getPackageExports",
+        "tags": ["size"],
+        "summary": "Named exports of an npm package",
+        "parameters": [{ "$ref": "#/components/parameters/package" }],
+        "responses": {
+          "200": {
+            "description": "Map of export name to the resolved file that provides it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/BuildError" }
+        }
+      }
+    },
+    "/api/exports-sizes": {
+      "get": {
+        "operationId": "getExportSizes",
+        "tags": ["size"],
+        "summary": "Size of each named export, for judging tree-shaking",
+        "parameters": [{ "$ref": "#/components/parameters/package" }],
+        "responses": {
+          "200": {
+            "description": "One entry per export.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ExportAsset" }
+                }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/BuildError" },
+          "429": { "$ref": "#/components/responses/RateLimited" }
+        }
+      }
+    },
+    "/api/package-history": {
+      "get": {
+        "operationId": "getPackageHistory",
+        "tags": ["size"],
+        "summary": "Size across published versions of a package",
+        "description": "Any version parameter in `package` is ignored; the whole known history for the package name is returned. Entries are partial, since a version is only present once it has been built.",
+        "parameters": [{ "$ref": "#/components/parameters/package" }],
+        "responses": {
+          "200": {
+            "description": "Map of version string to a partial build result.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/PackageBuild"
+                  }
+                }
+              }
+            }
+          },
+          "422": { "$ref": "#/components/responses/BuildError" }
+        }
+      }
+    },
+    "/api/similar-packages": {
+      "get": {
+        "operationId": "getSimilarPackages",
+        "tags": ["discovery"],
+        "summary": "Packages that serve a similar purpose",
+        "parameters": [{ "$ref": "#/components/parameters/package" }],
+        "responses": {
+          "200": {
+            "description": "Suggested alternatives to the given package.",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          },
+          "422": { "$ref": "#/components/responses/BuildError" }
+        }
+      }
+    },
+    "/api/recent": {
+      "get": {
+        "operationId": "getRecentSearches",
+        "tags": ["discovery"],
+        "summary": "Recently looked up packages",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of entries to return.",
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recently requested packages.",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "type": "object" } } } }
+          },
+          "422": { "$ref": "#/components/responses/BuildError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "package": {
+        "name": "package",
+        "in": "query",
+        "required": true,
+        "description": "Package name, optionally with a semver version or range, for example `react`, `react@18.2.0` or `@tanstack/react-query`.",
+        "schema": { "type": "string" },
+        "examples": {
+          "unscoped": { "value": "react" },
+          "pinned": { "value": "react@18.2.0" },
+          "scoped": { "value": "@tanstack/react-query" }
+        }
+      }
+    },
+    "schemas": {
+      "PackageBuild": {
+        "type": "object",
+        "description": "Result of bundling a single resolved package version.",
+        "properties": {
+          "name": { "type": "string" },
+          "version": { "type": "string" },
+          "description": { "type": "string" },
+          "repository": { "type": "string" },
+          "size": {
+            "type": "integer",
+            "description": "Minified size in bytes."
+          },
+          "gzip": {
+            "type": "integer",
+            "description": "Minified and gzipped size in bytes."
+          },
+          "dependencyCount": { "type": "integer" },
+          "hasSideEffects": {
+            "description": "`false` for none, `true` when unknown, or the specific files declaring side effects.",
+            "oneOf": [
+              { "type": "boolean" },
+              { "type": "array", "items": { "type": "string" } }
+            ]
+          },
+          "hasJSModule": { "type": "boolean" },
+          "hasJSNext": { "type": "boolean" },
+          "isModuleType": {
+            "type": "boolean",
+            "description": "Whether the package declares `\"type\": \"module\"`."
+          },
+          "ignoredMissingDependencies": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "dependencySizes": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/DependencySize" }
+          }
+        }
+      },
+      "DependencySize": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "approximateSize": {
+            "type": "integer",
+            "description": "Approximate contribution to the bundle, in bytes."
+          }
+        }
+      },
+      "ExportAsset": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "gzip": {
+            "type": "integer",
+            "description": "Minified and gzipped size in bytes."
+          },
+          "type": { "type": "string" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Error class, for example `PackageNotFoundError` or `BuildError`."
+          },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "responses": {
+      "BuildError": {
+        "description": "The package could not be resolved or built.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Too many requests that require a fresh build. Retry later, or request a package version that is already cached."
+      }
+    }
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -20,6 +20,11 @@ import { parsePackageString } from './utils/common.utils'
 import firebaseUtils from './utils/firebase.utils'
 import logger from './server/Logger'
 import remoteMcpClient from './server/mcp/remoteClient'
+import {
+  buildApiCatalog,
+  CATALOG_CONTENT_TYPE,
+  linkHeaderMiddleware,
+} from './server/agentDiscovery'
 
 import limit from './server/middlewares/rateLimit.middleware'
 import exportsMiddlware from './server/middlewares/exports.middleware'
@@ -68,6 +73,7 @@ app.prepare().then(() => {
   server.use(bodyParser())
   server.use(requestLoggerMiddleware)
   server.use(cacheControl())
+  server.use(linkHeaderMiddleware)
 
   if (!dev) {
     server.use(
@@ -456,6 +462,16 @@ app.prepare().then(() => {
       }
     }
   )
+
+  router.get('/.well-known/api-catalog', async ctx => {
+    ctx.cacheControl = {
+      maxAge: config.CACHE.PUBLIC_ASSETS,
+    }
+    // Set explicitly rather than via ctx.type, which would run the media type
+    // through mime lookup and append a charset after the profile parameter.
+    ctx.set('Content-Type', CATALOG_CONTENT_TYPE)
+    ctx.body = buildApiCatalog()
+  })
 
   router.get('/result', async ctx => {
     invariant(ctx.query.p, 'p parameter is required')

--- a/server/agentDiscovery.ts
+++ b/server/agentDiscovery.ts
@@ -1,0 +1,102 @@
+import { Context, Next } from 'koa'
+
+/**
+ * Machine-readable discovery for automated API consumers.
+ *
+ * Two related pieces:
+ *   - an API catalog at /.well-known/api-catalog (RFC 9727), listing every
+ *     public read API and linking each to the OpenAPI description
+ *   - `Link` response headers (RFC 8288) on the homepage, so a client that
+ *     fetches only `/` still finds the catalog without guessing at paths
+ *
+ * Only the public read APIs belong here. The /admin routes are credentialed
+ * and the /api/mcp/* routes proxy an upstream MCP server for our own UI, so
+ * neither is something we want to advertise.
+ */
+
+/**
+ * Canonical origin, matching the hardcoded host in robots.txt and sitemap.xml.
+ * Deliberately not derived from the request: behind Cloudflare, `ctx.origin`
+ * reports the internal scheme unless Koa is configured to trust the proxy, and
+ * a catalog that advertises `http://` anchors is worse than no catalog.
+ */
+const ORIGIN = 'https://bundlephobia.com'
+
+const CATALOG_PATH = '/.well-known/api-catalog'
+const OPENAPI_PATH = '/openapi.json'
+const DOCS_URL = 'https://github.com/pastelsky/bundlephobia#readme'
+
+const OPENAPI_TYPE = 'application/openapi+json'
+
+/** RFC 9727 §3 requires the profile parameter alongside the linkset media type. */
+export const CATALOG_CONTENT_TYPE =
+  'application/linkset+json; profile="https://www.rfc-editor.org/info/rfc9727"'
+
+const PUBLIC_APIS = [
+  { path: '/api/size', title: 'Minified and gzipped size of an npm package' },
+  { path: '/api/exports', title: 'Named exports of an npm package' },
+  { path: '/api/exports-sizes', title: 'Size of each named export' },
+  {
+    path: '/api/package-history',
+    title: 'Size across published versions of a package',
+  },
+  {
+    path: '/api/similar-packages',
+    title: 'Packages similar to a given package',
+  },
+  { path: '/api/recent', title: 'Recently looked up packages' },
+]
+
+/**
+ * Builds the linkset document.
+ *
+ * RFC 9727 Appendix A shows two shapes, and this emits both: one context
+ * object anchored at the catalog with an `item` link per API, then one anchored
+ * at each API carrying its `service-desc` and `service-doc`. Clients that walk
+ * `item` links and clients that read per-API anchors both find what they need.
+ *
+ * No `status` relation — there is no health endpoint to point at, and inventing
+ * one that always returns 200 would be worse than omitting the link.
+ */
+export function buildApiCatalog() {
+  return {
+    linkset: [
+      {
+        anchor: `${ORIGIN}${CATALOG_PATH}`,
+        item: PUBLIC_APIS.map(api => ({
+          href: `${ORIGIN}${api.path}`,
+          title: api.title,
+        })),
+      },
+      ...PUBLIC_APIS.map(api => ({
+        anchor: `${ORIGIN}${api.path}`,
+        'service-desc': [
+          { href: `${ORIGIN}${OPENAPI_PATH}`, type: OPENAPI_TYPE },
+        ],
+        'service-doc': [{ href: DOCS_URL, type: 'text/html' }],
+      })),
+    ],
+  }
+}
+
+/**
+ * Relative-reference targets resolve against the request URI per RFC 8288 §3,
+ * which keeps these correct in local development too.
+ */
+const HOMEPAGE_LINK_HEADER = [
+  `<${CATALOG_PATH}>; rel="api-catalog"; type="application/linkset+json"`,
+  `<${OPENAPI_PATH}>; rel="service-desc"; type="${OPENAPI_TYPE}"`,
+  `<${DOCS_URL}>; rel="service-doc"; type="text/html"`,
+].join(', ')
+
+/**
+ * Sets the header before the catch-all hands the response to Next, which writes
+ * to `ctx.res` directly and would otherwise flush headers first.
+ */
+export async function linkHeaderMiddleware(ctx: Context, next: Next) {
+  if (ctx.path === '/') {
+    ctx.set('Link', HOMEPAGE_LINK_HEADER)
+  }
+
+  await next()
+}


### PR DESCRIPTION
Agents that want package sizes currently have to be told our endpoints out of band, or scrape a page whose numbers arrive client-side. This describes the API in a form they can find on their own.

### What's here

- **`/openapi.json`** — an OpenAPI 3.1 description of the six public read endpoints, written from the existing domain types (`PackageBuildBase`, `PackageExportAsset`) rather than hand-waved, including the real `package`/`limit` parameters and the 422/429 responses.
- **`/.well-known/api-catalog`** — an RFC 9727 catalog pointing at it, served as `application/linkset+json` with the required profile parameter.
- **`Link` headers on `/`** — RFC 8288, with `api-catalog`, `service-desc` and `service-doc`, so a client that fetches only the homepage still finds the rest.

### Notes

The catalog emits both shapes from RFC 9727 Appendix A — one context object anchored at the catalog with an `item` per API, and one anchored at each API carrying its `service-desc`/`service-doc` — so clients following either convention find what they need.

`Content-Type` is set directly rather than through `ctx.type`, which would run the media type through mime lookup and append a charset after the profile parameter.

Only the public read endpoints are listed. `/admin/*` is credentialed and `/api/mcp/*` proxies an upstream MCP server for our own UI, so neither is advertised. No `status` relation, since there is no health endpoint to point at.

### Verifying

```sh
curl -sI https://bundlephobia.com/ | grep -i link
curl -s https://bundlephobia.com/.well-known/api-catalog | jq .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)