### PR TITLE
Enable bounded HAProxy access logging

### DIFF
--- a/operations/cron/haproxy-logrotate
+++ b/operations/cron/haproxy-logrotate
@@ -1,0 +1,2 @@
+# Check frequently so maxsize can bound access-log growth during traffic spikes.
+*/10 * * * * root /usr/sbin/logrotate /etc/logrotate.d/haproxy

--- a/operations/haproxy/haproxy.cfg
+++ b/operations/haproxy/haproxy.cfg
@@ -1,4 +1,5 @@
 global
+    log /dev/log local0 info
     chroot /var/lib/haproxy
     user haproxy
     group haproxy
@@ -9,6 +10,9 @@ global
 
 defaults
     mode http
+    log global
+    option httplog
+    option dontlognull
     timeout connect 250ms
     timeout client 65s
     timeout server 60s
@@ -29,11 +33,15 @@ backend automated_client_usage
 frontend bundlephobia_http
     bind :80
 
+    log-format "client_ip=%[var(txn.client_ip)] method=%HM uri=%{+Q}HU status=%ST bytes=%B request_ms=%TR queue_ms=%Tw connect_ms=%Tc response_ms=%Tr total_ms=%Ta termination=%tsc user_agent=%{+Q}[var(txn.user_agent)] client=%{+Q}[var(txn.bundlephobia_user)] build_ms=%[var(txn.build_duration_ms)]"
+
     acl request_from_cloudflare src -f /etc/haproxy/cloudflare-networks.lst
     acl valid_cloudflare_client_ip req.hdr_ip(CF-Connecting-IP) -m found
 
     http-request set-var(txn.client_ip) src
     http-request set-var(txn.client_ip) req.hdr_ip(CF-Connecting-IP) if request_from_cloudflare valid_cloudflare_client_ip
+    http-request set-var(txn.user_agent) req.hdr(User-Agent)
+    http-request set-var(txn.bundlephobia_user) req.hdr(X-Bundlephobia-User)
     http-request set-header CF-Connecting-IP %[var(txn.client_ip)]
 
     acl api_request path_beg /api/
@@ -67,6 +75,7 @@ frontend bundlephobia_http
     http-request deny deny_status 429 if api_request strictly_limited_automation strict_automation_request_rate_exceeded
     http-request deny deny_status 429 if api_request !strictly_limited_automation automated_request_rate_exceeded
 
+    http-response set-var(txn.build_duration_ms) res.hdr(X-Bundlephobia-Build-Duration-Ms) if { res.hdr(X-Bundlephobia-Build-Duration-Ms) -m found }
     http-response sc-add-gpc(0,0) res.hdr_val(X-Bundlephobia-Build-Duration-Ms),add(99),div(100) if { res.hdr(X-Bundlephobia-Build-Duration-Ms) -m found }
     http-response del-header X-Bundlephobia-Build-Duration-Ms
 

--- a/operations/logrotate/haproxy
+++ b/operations/logrotate/haproxy
@@ -1,0 +1,14 @@
+/var/log/haproxy.log {
+    daily
+    maxsize 100M
+    rotate 7
+    missingok
+    notifempty
+    compress
+    delaycompress
+    create 0640 syslog adm
+    su root adm
+    postrotate
+        [ ! -x /usr/lib/rsyslog/rsyslog-rotate ] || /usr/lib/rsyslog/rsyslog-rotate
+    endscript
+}

--- a/operations/rsyslog/49-haproxy.conf
+++ b/operations/rsyslog/49-haproxy.conf
@@ -1,0 +1,8 @@
+# HAProxy runs chrooted and sends logs to this additional syslog socket.
+$AddUnixListenSocket /var/lib/haproxy/dev/log
+
+# Keep proxy access logs separate from the general system log.
+:programname, startswith, "haproxy" {
+  /var/log/haproxy.log
+  stop
+}


### PR DESCRIPTION
## Summary
- enable structured HAProxy access logs with real client IP, request timing, client marker, user agent, and completed build duration
- route HAProxy syslog output to a dedicated file
- rotate daily or at 100 MiB, retain seven rotations, and check the size threshold every 10 minutes
- declare Ubuntu 24-compatible rotation ownership and permissions

## Verification
- `haproxy -c -f /etc/haproxy/haproxy.cfg`
- `rsyslogd -N1`
- executed `/usr/sbin/logrotate /etc/logrotate.d/haproxy`
- verified cached and live public requests are written to `/var/log/haproxy.log`
- confirmed HAProxy, rsyslog, cron, PM2, and public API remain healthy