### PR TITLE
fix: crash on package pages when hasSideEffects is missing from API response

### DIFF
--- a/client/components/QuickStatsBar/QuickStatsBar.tsx
+++ b/client/components/QuickStatsBar/QuickStatsBar.tsx
@@ -84,7 +84,9 @@ class QuickStatsBar extends Component<QuickStatsBarProps> {
           <div className="quick-stats-bar__stat">
             <SideEffectIcon className="quick-stats-bar__stat-icon" />{' '}
             <span>
-              {!(hasSideEffects === false) && hasSideEffects.length
+              {!(hasSideEffects === false) &&
+              Array.isArray(hasSideEffects) &&
+              hasSideEffects.length
                 ? 'some side-effects'
                 : 'side-effect free'}
             </span>


### PR DESCRIPTION
## Summary

- Fix a client-side crash on package result pages when the API response
  omits the `hasSideEffects` field (e.g. `effect@3.22.1`).

## Problem

`QuickStatsBar` accesses `.length` on `hasSideEffects` without verifying
it's an array. When the API omits the field, the runtime value is
`undefined`. The guard `!(hasSideEffects === false)` passes for
`undefined` (since `undefined !== false`), then `undefined.length`
throws a `TypeError` that crashes the entire page with "Application
error: a client-side exception has occurred".

Reproduced by visiting `/package/effect@3.22.1`.

## Fix

Add an `Array.isArray(hasSideEffects)` check before accessing `.length`.
When `hasSideEffects` is `undefined`, `Array.isArray()` returns `false`,
short-circuits, and the component falls through to `'side-effect free'`.
