### PR TITLE
feat(jvm): define model and CLI contract

### DIFF
--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -18,11 +18,14 @@ From the repository root, run:
 ```sh
 yarn jvm:build
 yarn jvm:check
+yarn jvm:format
 yarn jvm:test
 ```
 
-Use `yarn workspace jvm-package-build-stats format` to format Gradle and Kotlin
-sources.
+`jvm:format` applies ktlint to Kotlin and Gradle Kotlin DSL sources and Google
+Java Format to Java sources. `jvm:check` verifies formatting and compiles Kotlin
+and Java with warnings treated as errors; javac runs with all lint warnings
+enabled.
 
 ## API and CLI milestone
 

--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -23,3 +23,24 @@ yarn jvm:test
 
 Use `yarn workspace jvm-package-build-stats format` to format Gradle and Kotlin
 sources.
+
+## API and CLI milestone
+
+The public model accepts only exact `groupId:artifactId:version` coordinates and
+the `jvm-runtime` target. Snapshot, range, dynamic, URL, path, repository, and
+Android inputs are rejected.
+
+The CLI contract is:
+
+```text
+jvm-package-build-stats analyze GROUP:ARTIFACT:VERSION [--target jvm-runtime]
+jvm-package-build-stats inspect FILE.jar
+```
+
+JSON analysis results are written to stdout. Usage and operational messages are
+written to stderr. Exit codes are `0` for success, `1` for an unexpected CLI
+failure, `2` for invalid usage, and `3` for a structured analysis failure.
+
+This milestone intentionally returns `ANALYSIS_NOT_IMPLEMENTED` from both
+analysis commands. Local JAR inspection is implemented in the next milestone;
+Maven resolution is implemented later.

--- a/jvm-package-build-stats/archive-analyzer/gradle.lockfile
+++ b/jvm-package-build-stats/archive-analyzer/gradle.lockfile
@@ -1,0 +1,32 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-runner:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-client:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-reflect:1.6.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-script-runtime:2.4.10=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
+org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/build.gradle.kts
+++ b/jvm-package-build-stats/build.gradle.kts
@@ -27,7 +27,8 @@ subprojects {
 
     tasks.withType<JavaCompile>().configureEach {
         options.release.set(21)
-        options.compilerArgs.add("-Werror")
+        options.encoding = "UTF-8"
+        options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
     }
 
     tasks.withType<KotlinJvmCompile>().configureEach {
@@ -57,6 +58,10 @@ subprojects {
 }
 
 spotless {
+    java {
+        target("**/*.java")
+        googleJavaFormat("1.35.0")
+    }
     kotlin {
         target("**/*.kt")
         ktlint()

--- a/jvm-package-build-stats/build.gradle.kts
+++ b/jvm-package-build-stats/build.gradle.kts
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
     base
     kotlin("jvm") version "2.4.10" apply false
+    kotlin("plugin.serialization") version "2.4.10" apply false
     id("com.diffplug.spotless") version "8.9.0"
 }
 
@@ -44,6 +45,14 @@ subprojects {
 
     dependencyLocking {
         lockAllConfigurations()
+    }
+
+    dependencies {
+        add("testImplementation", kotlin("test"))
+    }
+
+    tasks.withType<Test>().configureEach {
+        useJUnitPlatform()
     }
 }
 

--- a/jvm-package-build-stats/classfile-analyzer/gradle.lockfile
+++ b/jvm-package-build-stats/classfile-analyzer/gradle.lockfile
@@ -1,0 +1,32 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-runner:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-client:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-reflect:1.6.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-script-runtime:2.4.10=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
+org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/cli/build.gradle.kts
+++ b/jvm-package-build-stats/cli/build.gradle.kts
@@ -1,1 +1,15 @@
+plugins {
+    application
+}
+
 description = "Command-line interface for JVM package build statistics"
+
+dependencies {
+    implementation(project(":core"))
+    implementation("info.picocli:picocli:4.7.7")
+}
+
+application {
+    applicationName = "jvm-package-build-stats"
+    mainClass = "com.bundlephobia.jvm.cli.MainKt"
+}

--- a/jvm-package-build-stats/cli/gradle.lockfile
+++ b/jvm-package-build-stats/cli/gradle.lockfile
@@ -1,0 +1,38 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+info.picocli:picocli:4.7.7=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-runner:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-client:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-reflect:1.6.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-script-runtime:2.4.10=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
+org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
@@ -1,0 +1,116 @@
+package com.bundlephobia.jvm.cli
+
+import com.bundlephobia.jvm.PackageBuildStatsAnalyzer
+import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.InvalidCoordinateException
+import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.ResultJson
+import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.TargetProfile
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Model.CommandSpec
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import picocli.CommandLine.Spec
+import java.io.PrintWriter
+import java.nio.file.Path
+import java.util.concurrent.Callable
+
+public class JvmPackageBuildStatsCli(
+    private val analyzer: PackageBuildStatsAnalyzer = PackageBuildStatsAnalyzer(),
+) {
+    public fun execute(
+        args: Array<String>,
+        out: PrintWriter = PrintWriter(System.out, true),
+        err: PrintWriter = PrintWriter(System.err, true),
+    ): Int {
+        val commandLine =
+            CommandLine(RootCommand())
+                .addSubcommand("analyze", AnalyzeCommand(analyzer))
+                .addSubcommand("inspect", InspectCommand(analyzer))
+                .setOut(out)
+                .setErr(err)
+        return commandLine.execute(*args)
+    }
+}
+
+@Command(
+    name = "jvm-package-build-stats",
+    description = ["Analyze published JVM package size and dependency statistics."],
+    mixinStandardHelpOptions = true,
+    version = ["jvm-package-build-stats 0.0.0-SNAPSHOT"],
+)
+private class RootCommand : Runnable {
+    @Spec private lateinit var spec: CommandSpec
+
+    override fun run() {
+        spec.commandLine().usage(spec.commandLine().out)
+    }
+}
+
+@Command(
+    name = "analyze",
+    description = ["Analyze one exact Maven coordinate."],
+    mixinStandardHelpOptions = true,
+)
+private class AnalyzeCommand(
+    private val analyzer: PackageBuildStatsAnalyzer,
+) : Callable<Int> {
+    @Spec private lateinit var spec: CommandSpec
+
+    @Parameters(index = "0", paramLabel = "GROUP:ARTIFACT:VERSION")
+    private lateinit var coordinateValue: String
+
+    @Option(names = ["--target"], defaultValue = "jvm-runtime", paramLabel = "TARGET")
+    private lateinit var targetValue: String
+
+    override fun call(): Int {
+        val coordinate = parseCoordinate(coordinateValue)
+        val target = parseTarget(targetValue)
+        val result = analyzer.analyze(AnalyzeRequest(coordinate, target))
+        spec.commandLine().out.println(ResultJson.encode(result))
+        return if (result.status == ResultStatus.FAILED) ExitCode.ANALYSIS_FAILED else ExitCode.SUCCESS
+    }
+
+    private fun parseCoordinate(value: String): MavenCoordinate =
+        try {
+            MavenCoordinate.parse(value)
+        } catch (error: InvalidCoordinateException) {
+            throw CommandLine.ParameterException(spec.commandLine(), error.message, error)
+        }
+
+    private fun parseTarget(value: String): TargetProfile =
+        try {
+            TargetProfile.parse(value)
+        } catch (error: IllegalArgumentException) {
+            throw CommandLine.ParameterException(spec.commandLine(), error.message, error)
+        }
+}
+
+@Command(
+    name = "inspect",
+    description = ["Inspect one local JAR without executing its contents."],
+    mixinStandardHelpOptions = true,
+)
+private class InspectCommand(
+    private val analyzer: PackageBuildStatsAnalyzer,
+) : Callable<Int> {
+    @Spec private lateinit var spec: CommandSpec
+
+    @Parameters(index = "0", paramLabel = "FILE.jar")
+    private lateinit var path: Path
+
+    override fun call(): Int {
+        val result = analyzer.inspect(path)
+        spec.commandLine().out.println(ResultJson.encode(result))
+        return if (result.status == ResultStatus.FAILED) ExitCode.ANALYSIS_FAILED else ExitCode.SUCCESS
+    }
+}
+
+public object ExitCode {
+    public const val SUCCESS: Int = 0
+    public const val INTERNAL_ERROR: Int = 1
+    public const val USAGE: Int = 2
+    public const val ANALYSIS_FAILED: Int = 3
+}

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/Main.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/Main.kt
@@ -1,0 +1,7 @@
+package com.bundlephobia.jvm.cli
+
+import kotlin.system.exitProcess
+
+public fun main(args: Array<String>) {
+    exitProcess(JvmPackageBuildStatsCli().execute(args))
+}

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -1,0 +1,85 @@
+package com.bundlephobia.jvm.cli
+
+import com.bundlephobia.jvm.model.ResultJson
+import java.io.PrintWriter
+import java.io.StringWriter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class JvmPackageBuildStatsCliTest {
+    @Test
+    fun `analyze validates the coordinate and writes only JSON to stdout`() {
+        val execution = execute("analyze", "com.google.code.gson:gson:2.13.1")
+
+        assertEquals(ExitCode.ANALYSIS_FAILED, execution.exitCode)
+        assertEquals("", execution.stderr)
+        assertEquals(
+            "ANALYSIS_NOT_IMPLEMENTED",
+            ResultJson
+                .decodeResult(execution.stdout.trim())
+                .diagnostics
+                .single()
+                .code,
+        )
+    }
+
+    @Test
+    fun `inspect exposes the command contract without reading the file`() {
+        val execution = execute("inspect", "missing.jar")
+
+        assertEquals(ExitCode.ANALYSIS_FAILED, execution.exitCode)
+        assertEquals("", execution.stderr)
+        assertEquals(
+            "missing.jar",
+            ResultJson.decodeArtifactAnalysis(execution.stdout.trim()).displayName,
+        )
+    }
+
+    @Test
+    fun `invalid coordinates are usage errors and never emit JSON`() {
+        val execution = execute("analyze", "g:a:1-SNAPSHOT")
+
+        assertEquals(ExitCode.USAGE, execution.exitCode)
+        assertEquals("", execution.stdout)
+        assertTrue(execution.stderr.contains("immutable published release"))
+    }
+
+    @Test
+    fun `Android targets are rejected`() {
+        val execution = execute("analyze", "g:a:1", "--target", "android-release")
+
+        assertEquals(ExitCode.USAGE, execution.exitCode)
+        assertEquals("", execution.stdout)
+        assertTrue(execution.stderr.contains("Unsupported target profile"))
+    }
+
+    @Test
+    fun `help is successful`() {
+        val execution = execute("--help")
+
+        assertEquals(ExitCode.SUCCESS, execution.exitCode)
+        assertTrue(execution.stdout.contains("analyze"))
+        assertTrue(execution.stdout.contains("inspect"))
+        assertEquals("", execution.stderr)
+    }
+
+    private fun execute(vararg args: String): Execution {
+        val stdout = StringWriter()
+        val stderr = StringWriter()
+        val exitCode =
+            JvmPackageBuildStatsCli()
+                .execute(
+                    args = arrayOf(*args),
+                    out = PrintWriter(stdout, true),
+                    err = PrintWriter(stderr, true),
+                )
+        return Execution(exitCode, stdout.toString(), stderr.toString())
+    }
+
+    private data class Execution(
+        val exitCode: Int,
+        val stdout: String,
+        val stderr: String,
+    )
+}

--- a/jvm-package-build-stats/core/build.gradle.kts
+++ b/jvm-package-build-stats/core/build.gradle.kts
@@ -1,1 +1,5 @@
 description = "Public JVM package build statistics library"
+
+dependencies {
+    api(project(":model"))
+}

--- a/jvm-package-build-stats/core/gradle.lockfile
+++ b/jvm-package-build-stats/core/gradle.lockfile
@@ -1,0 +1,37 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-runner:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-client:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-reflect:1.6.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-script-runtime:2.4.10=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
+org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -1,0 +1,47 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AnalysisStage
+import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.ArtifactAnalysis
+import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.PackageBuildStatsResult
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.ToolchainManifest
+import java.nio.file.Path
+
+public class PackageBuildStatsAnalyzer {
+    public fun analyze(request: AnalyzeRequest): PackageBuildStatsResult =
+        PackageBuildStatsResult(
+            status = ResultStatus.FAILED,
+            coordinate = request.coordinate,
+            target = request.target,
+            toolchain = currentToolchain(),
+            resolution = ResolutionStats(request.coordinate),
+            diagnostics = listOf(notImplementedDiagnostic()),
+        )
+
+    public fun inspect(path: Path): ArtifactAnalysis =
+        ArtifactAnalysis(
+            status = ResultStatus.FAILED,
+            displayName = path.fileName?.toString() ?: "<jar>",
+            diagnostics = listOf(notImplementedDiagnostic()),
+        )
+
+    private fun notImplementedDiagnostic(): Diagnostic =
+        Diagnostic(
+            code = "ANALYSIS_NOT_IMPLEMENTED",
+            summary = "Analysis behavior is not available in this milestone",
+            stage = AnalysisStage.INPUT,
+        )
+
+    private fun currentToolchain(): ToolchainManifest =
+        ToolchainManifest(
+            generation = "jvm-2026-08-g1",
+            analyzerVersion = "0.0.0-SNAPSHOT",
+            jdkVersion = System.getProperty("java.version"),
+            jdkVendor = System.getProperty("java.vendor"),
+            kotlinVersion = "2.4.10",
+            gradleVersion = "9.5.1",
+        )
+}

--- a/jvm-package-build-stats/core/src/test/java/com/bundlephobia/jvm/JavaApiCompatibilityTest.java
+++ b/jvm-package-build-stats/core/src/test/java/com/bundlephobia/jvm/JavaApiCompatibilityTest.java
@@ -1,0 +1,22 @@
+package com.bundlephobia.jvm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bundlephobia.jvm.model.AnalyzeRequest;
+import com.bundlephobia.jvm.model.MavenCoordinate;
+import com.bundlephobia.jvm.model.PackageBuildStatsResult;
+import com.bundlephobia.jvm.model.ResultStatus;
+import org.junit.jupiter.api.Test;
+
+class JavaApiCompatibilityTest {
+  @Test
+  void publicApiIsCallableFromJava() {
+    MavenCoordinate coordinate = MavenCoordinate.parse("com.google.code.gson:gson:2.13.1");
+    AnalyzeRequest request = new AnalyzeRequest(coordinate);
+
+    PackageBuildStatsResult result = new PackageBuildStatsAnalyzer().analyze(request);
+
+    assertEquals(ResultStatus.FAILED, result.getStatus());
+    assertEquals(coordinate, result.getCoordinate());
+  }
+}

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -1,0 +1,32 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.ResultStatus
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PackageBuildStatsAnalyzerTest {
+    private val analyzer = PackageBuildStatsAnalyzer()
+
+    @Test
+    fun `returns an explicit failed result until coordinate analysis is implemented`() {
+        val coordinate = MavenCoordinate.parse("com.google.code.gson:gson:2.13.1")
+
+        val result = analyzer.analyze(AnalyzeRequest(coordinate))
+
+        assertEquals(ResultStatus.FAILED, result.status)
+        assertEquals(coordinate, result.coordinate)
+        assertEquals("ANALYSIS_NOT_IMPLEMENTED", result.diagnostics.single().code)
+    }
+
+    @Test
+    fun `does not inspect local files in the API shell milestone`() {
+        val result = analyzer.inspect(Path.of("example.jar"))
+
+        assertEquals(ResultStatus.FAILED, result.status)
+        assertEquals("example.jar", result.displayName)
+        assertEquals("ANALYSIS_NOT_IMPLEMENTED", result.diagnostics.single().code)
+    }
+}

--- a/jvm-package-build-stats/model/build.gradle.kts
+++ b/jvm-package-build-stats/model/build.gradle.kts
@@ -1,1 +1,9 @@
+plugins {
+    kotlin("plugin.serialization")
+}
+
 description = "Stable JVM package build statistics model"
+
+dependencies {
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+}

--- a/jvm-package-build-stats/model/gradle.lockfile
+++ b/jvm-package-build-stats/model/gradle.lockfile
@@ -1,0 +1,38 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-runner:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-client:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-reflect:1.6.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-script-runtime:2.4.10=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-serialization-compiler-plugin-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0=compileClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
+org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/MavenCoordinate.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/MavenCoordinate.kt
@@ -1,0 +1,93 @@
+package com.bundlephobia.jvm.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+@Serializable
+@ConsistentCopyVisibility
+public data class MavenCoordinate private constructor(
+    public val groupId: String,
+    public val artifactId: String,
+    public val version: String,
+) {
+    @Transient public val notation: String = "$groupId:$artifactId:$version"
+
+    override fun toString(): String = notation
+
+    public companion object {
+        private val groupPattern =
+            Regex("[A-Za-z0-9_][A-Za-z0-9_-]*(?:\\.[A-Za-z0-9_][A-Za-z0-9_-]*)*")
+        private val artifactPattern = Regex("[A-Za-z0-9_](?:[A-Za-z0-9_.-]*[A-Za-z0-9_])?")
+        private val versionPattern = Regex("[A-Za-z0-9](?:[A-Za-z0-9._+-]*[A-Za-z0-9])?")
+        private val dynamicVersions =
+            setOf("latest", "latest.integration", "latest.release", "release")
+
+        @JvmStatic
+        public fun parse(value: String): MavenCoordinate {
+            if (value.isEmpty()) {
+                throw InvalidCoordinateException(CoordinateError.EMPTY, "Coordinate must not be empty")
+            }
+            if (value != value.trim()) {
+                throw InvalidCoordinateException(
+                    CoordinateError.FORMAT,
+                    "Coordinate must not contain surrounding whitespace",
+                )
+            }
+
+            val parts = value.split(':')
+            if (parts.size != 3 || parts.any(String::isEmpty)) {
+                throw InvalidCoordinateException(
+                    CoordinateError.FORMAT,
+                    "Coordinate must use the exact groupId:artifactId:version form",
+                )
+            }
+
+            val (groupId, artifactId, version) = parts
+            if (!groupPattern.matches(groupId)) {
+                throw InvalidCoordinateException(
+                    CoordinateError.INVALID_GROUP,
+                    "groupId contains unsupported characters or empty segments",
+                )
+            }
+            if (!artifactPattern.matches(artifactId)) {
+                throw InvalidCoordinateException(
+                    CoordinateError.INVALID_ARTIFACT,
+                    "artifactId contains unsupported characters",
+                )
+            }
+            if (
+                version.contains("SNAPSHOT", ignoreCase = true) ||
+                version.lowercase() in dynamicVersions ||
+                version.contains('*') ||
+                version.endsWith(".+")
+            ) {
+                throw InvalidCoordinateException(
+                    CoordinateError.NON_IMMUTABLE_VERSION,
+                    "version must identify one immutable published release",
+                )
+            }
+            if (!versionPattern.matches(version)) {
+                throw InvalidCoordinateException(
+                    CoordinateError.INVALID_VERSION,
+                    "version contains unsupported characters",
+                )
+            }
+
+            return MavenCoordinate(groupId, artifactId, version)
+        }
+    }
+}
+
+public enum class CoordinateError {
+    EMPTY,
+    FORMAT,
+    INVALID_GROUP,
+    INVALID_ARTIFACT,
+    INVALID_VERSION,
+    NON_IMMUTABLE_VERSION,
+}
+
+public class InvalidCoordinateException(
+    public val reason: CoordinateError,
+    message: String,
+) : IllegalArgumentException(message)

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultJson.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultJson.kt
@@ -1,0 +1,26 @@
+package com.bundlephobia.jvm.model
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+public object ResultJson {
+    private val json =
+        Json {
+            encodeDefaults = true
+            explicitNulls = true
+            ignoreUnknownKeys = false
+            prettyPrint = false
+        }
+
+    @JvmStatic
+    public fun encode(result: PackageBuildStatsResult): String = json.encodeToString(result)
+
+    @JvmStatic
+    public fun encode(analysis: ArtifactAnalysis): String = json.encodeToString(analysis)
+
+    @JvmStatic
+    public fun decodeResult(value: String): PackageBuildStatsResult = json.decodeFromString(value)
+
+    @JvmStatic
+    public fun decodeArtifactAnalysis(value: String): ArtifactAnalysis = json.decodeFromString(value)
+}

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
@@ -1,0 +1,194 @@
+package com.bundlephobia.jvm.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public enum class ResultStatus {
+    @SerialName("complete")
+    COMPLETE,
+
+    @SerialName("partial")
+    PARTIAL,
+
+    @SerialName("failed")
+    FAILED,
+}
+
+@Serializable
+public enum class TargetProfile {
+    @SerialName("jvm-runtime")
+    JVM_RUNTIME,
+    ;
+
+    public companion object {
+        @JvmStatic
+        public fun parse(value: String): TargetProfile =
+            when (value) {
+                "jvm-runtime" -> JVM_RUNTIME
+                else -> throw IllegalArgumentException("Unsupported target profile: $value")
+            }
+    }
+}
+
+@Serializable
+public enum class DiagnosticSeverity {
+    @SerialName("info")
+    INFO,
+
+    @SerialName("warning")
+    WARNING,
+
+    @SerialName("error")
+    ERROR,
+}
+
+@Serializable
+public enum class AnalysisStage {
+    @SerialName("input")
+    INPUT,
+
+    @SerialName("resolution")
+    RESOLUTION,
+
+    @SerialName("archive-analysis")
+    ARCHIVE_ANALYSIS,
+
+    @SerialName("classfile-analysis")
+    CLASSFILE_ANALYSIS,
+
+    @SerialName("assembly")
+    ASSEMBLY,
+}
+
+@Serializable
+public enum class RetryClassification {
+    @SerialName("never")
+    NEVER,
+
+    @SerialName("retryable")
+    RETRYABLE,
+
+    @SerialName("unknown")
+    UNKNOWN,
+}
+
+@Serializable
+public data class Diagnostic
+    @JvmOverloads
+    constructor(
+        public val code: String,
+        public val summary: String,
+        public val stage: AnalysisStage,
+        public val severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+        public val retry: RetryClassification = RetryClassification.NEVER,
+        public val correlationId: String? = null,
+    )
+
+@Serializable
+public data class AnalyzeRequest
+    @JvmOverloads
+    constructor(
+        public val coordinate: MavenCoordinate,
+        public val target: TargetProfile = TargetProfile.JVM_RUNTIME,
+    )
+
+@Serializable
+public data class ToolchainManifest(
+    public val generation: String,
+    public val analyzerVersion: String,
+    public val jdkVersion: String,
+    public val jdkVendor: String,
+    public val kotlinVersion: String,
+    public val gradleVersion: String,
+)
+
+@Serializable
+public data class ArtifactDigest(
+    public val algorithm: String = "sha256",
+    public val value: String,
+)
+
+@Serializable
+public data class PayloadCategoryStats(
+    public val category: String,
+    public val compressedBytes: Long,
+    public val expandedBytes: Long,
+    public val entries: Int,
+)
+
+@Serializable
+public data class NamespaceStats(
+    public val name: String,
+    public val classBytes: Long,
+    public val classes: Int,
+    public val publicTypes: Int,
+    public val publicMembers: Int,
+)
+
+@Serializable
+public data class ArtifactAnalysis(
+    public val schemaVersion: Int = 1,
+    public val status: ResultStatus,
+    public val displayName: String,
+    public val digest: ArtifactDigest? = null,
+    public val archiveBytes: Long? = null,
+    public val expandedBytes: Long? = null,
+    public val payload: List<PayloadCategoryStats> = emptyList(),
+    public val namespaces: List<NamespaceStats> = emptyList(),
+    public val diagnostics: List<Diagnostic> = emptyList(),
+)
+
+@Serializable
+public data class ResolvedComponent(
+    public val coordinate: MavenCoordinate,
+    public val variant: String? = null,
+    public val direct: Boolean,
+    public val artifacts: List<ArtifactAnalysis> = emptyList(),
+)
+
+@Serializable
+public data class DependencyEdge(
+    public val from: MavenCoordinate,
+    public val requested: String,
+    public val selected: MavenCoordinate? = null,
+)
+
+@Serializable
+public data class ResolutionStats(
+    public val requested: MavenCoordinate,
+    public val components: List<ResolvedComponent> = emptyList(),
+    public val edges: List<DependencyEdge> = emptyList(),
+)
+
+@Serializable
+public data class RuntimeClosureStats(
+    public val compressedBytes: Long = 0,
+    public val expandedBytes: Long = 0,
+    public val directArtifactBytes: Long = 0,
+    public val transitiveArtifactBytes: Long = 0,
+    public val components: Int = 0,
+    public val artifacts: Int = 0,
+    public val dependencyDepth: Int = 0,
+)
+
+@Serializable
+public data class TimingStats(
+    public val totalMilliseconds: Long = 0,
+    public val stagesMilliseconds: Map<String, Long> = emptyMap(),
+)
+
+@Serializable
+public data class PackageBuildStatsResult(
+    public val schemaVersion: Int = 1,
+    public val status: ResultStatus,
+    public val coordinate: MavenCoordinate,
+    public val target: TargetProfile,
+    public val toolchain: ToolchainManifest,
+    public val resolution: ResolutionStats,
+    public val artifacts: List<ArtifactAnalysis> = emptyList(),
+    public val directArtifact: ArtifactAnalysis? = null,
+    public val runtimeClosure: RuntimeClosureStats = RuntimeClosureStats(),
+    public val diagnostics: List<Diagnostic> = emptyList(),
+    public val timings: TimingStats = TimingStats(),
+)

--- a/jvm-package-build-stats/model/src/test/kotlin/com/bundlephobia/jvm/model/MavenCoordinateTest.kt
+++ b/jvm-package-build-stats/model/src/test/kotlin/com/bundlephobia/jvm/model/MavenCoordinateTest.kt
@@ -1,0 +1,57 @@
+package com.bundlephobia.jvm.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MavenCoordinateTest {
+    @Test
+    fun `parses exact Maven coordinates`() {
+        val coordinate = MavenCoordinate.parse("com.squareup.okhttp3:okhttp:4.12.0")
+
+        assertEquals("com.squareup.okhttp3", coordinate.groupId)
+        assertEquals("okhttp", coordinate.artifactId)
+        assertEquals("4.12.0", coordinate.version)
+        assertEquals("com.squareup.okhttp3:okhttp:4.12.0", coordinate.notation)
+    }
+
+    @Test
+    fun `allows legacy groups and exact build metadata`() {
+        assertEquals("junit:junit:4.13.2", MavenCoordinate.parse("junit:junit:4.13.2").notation)
+        assertEquals(
+            "example_group:example-artifact:1.0.0+build7",
+            MavenCoordinate.parse("example_group:example-artifact:1.0.0+build7").notation,
+        )
+    }
+
+    @Test
+    fun `rejects malformed coordinates`() {
+        listOf(
+            "",
+            "g:a",
+            "g:a:v:extra",
+            " g:a:1",
+            "g::1",
+            "https://repo.example/g:a:1",
+            "g/a:a:1",
+        ).forEach { value -> assertFailsWith<InvalidCoordinateException> { MavenCoordinate.parse(value) } }
+    }
+
+    @Test
+    fun `rejects mutable versions`() {
+        listOf("1.0-SNAPSHOT", "latest.release", "RELEASE", "1.+", "[1.0,2.0)").forEach { version ->
+            val error =
+                assertFailsWith<InvalidCoordinateException> {
+                    MavenCoordinate.parse("example:library:$version")
+                }
+            assertEquals(
+                if (version == "[1.0,2.0)") {
+                    CoordinateError.INVALID_VERSION
+                } else {
+                    CoordinateError.NON_IMMUTABLE_VERSION
+                },
+                error.reason,
+            )
+        }
+    }
+}

--- a/jvm-package-build-stats/model/src/test/kotlin/com/bundlephobia/jvm/model/ResultJsonTest.kt
+++ b/jvm-package-build-stats/model/src/test/kotlin/com/bundlephobia/jvm/model/ResultJsonTest.kt
@@ -1,0 +1,38 @@
+package com.bundlephobia.jvm.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ResultJsonTest {
+    @Test
+    fun `round trips the stable result contract`() {
+        val coordinate = MavenCoordinate.parse("com.google.code.gson:gson:2.13.1")
+        val result =
+            PackageBuildStatsResult(
+                status = ResultStatus.PARTIAL,
+                coordinate = coordinate,
+                target = TargetProfile.JVM_RUNTIME,
+                toolchain =
+                    ToolchainManifest(
+                        generation = "jvm-test-g1",
+                        analyzerVersion = "0.0.0-test",
+                        jdkVersion = "21.0.11",
+                        jdkVendor = "Temurin",
+                        kotlinVersion = "2.4.10",
+                        gradleVersion = "9.5.1",
+                    ),
+                resolution = ResolutionStats(coordinate),
+                runtimeClosure = RuntimeClosureStats(compressedBytes = 1_024),
+            )
+
+        val encoded = ResultJson.encode(result)
+        val decoded = ResultJson.decodeResult(encoded)
+
+        assertEquals(result, decoded)
+        assertTrue(encoded.contains("\"schemaVersion\":1"))
+        assertTrue(encoded.contains("\"target\":\"jvm-runtime\""))
+        assertTrue(encoded.contains("\"compressedBytes\":1024"))
+        assertTrue(encoded.contains("\"directArtifact\":null"))
+    }
+}

--- a/jvm-package-build-stats/resolver/gradle.lockfile
+++ b/jvm-package-build-stats/resolver/gradle.lockfile
@@ -1,0 +1,32 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
+org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-cri-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-build-tools-impl:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-compiler-runner:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-client:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-daemon-embeddable:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-reflect:1.6.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlin:kotlin-script-runtime:2.4.10=kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.10.1=testRuntimeClasspath
+org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
+org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
+org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "test": "jest",
     "jvm:build": "yarn workspace jvm-package-build-stats build",
     "jvm:check": "yarn workspace jvm-package-build-stats check",
+    "jvm:format": "yarn workspace jvm-package-build-stats format",
     "jvm:test": "yarn workspace jvm-package-build-stats test",
     "test:recommendations": "node --test .github/scripts/*.test.mjs",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary

Implements PR 2 of the serial JVM-only delivery plan.

- adds strict exact Maven coordinate parsing and rejects mutable or unsupported inputs
- defines the schemaVersion 1 Java-friendly result model, diagnostics, timings, digests, and toolchain manifest
- exposes blocking analyze(AnalyzeRequest) and inspect(Path) library entrypoints
- adds analyze and inspect CLI commands with JSON stdout, stderr usage diagnostics, and stable exit codes
- accepts only jvm-runtime and explicitly rejects Android targets
- adds Kotlin and Java API consumer fixtures plus coordinate, JSON, and CLI contract tests
- formats Kotlin and Gradle scripts with ktlint and Java with pinned Google Java Format
- treats Kotlin and full javac lint warnings as errors

Analysis behavior remains intentionally unavailable until later serial PRs; the shell returns a structured ANALYSIS_NOT_IMPLEMENTED result. No archive inspection, resolution, Android support, or publication is included.

## Verification

- clean Gradle build, check, test, packaging, and installDist
- Java and Kotlin API consumer tests
- installed CLI smoke checks: help=0, analysis-shell=3, invalid-input=2
- JVM format task and Spotless verification
- Bundlephobia lint (0 errors; 5 existing warnings)
- recommendation tests (11 passing)
- production Next.js build

Based on the latest remote bundlephobia branch after PR #1058 merged.