### PR TITLE
feat(jvm): add defensive JAR inspection

### DIFF
--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -44,6 +44,14 @@ JSON analysis results are written to stdout. Usage and operational messages are
 written to stderr. Exit codes are `0` for success, `1` for an unexpected CLI
 failure, `2` for invalid usage, and `3` for a structured analysis failure.
 
-This milestone intentionally returns `ANALYSIS_NOT_IMPLEMENTED` from both
-analysis commands. Local JAR inspection is implemented in the next milestone;
-Maven resolution is implemented later.
+Coordinate analysis intentionally returns `ANALYSIS_NOT_IMPLEMENTED` until the
+resolver milestone. Local `inspect` analysis is available now: it hashes the JAR,
+reads its ZIP central directory, validates all declared entry metadata, and then
+streams each safe entry without extracting or executing it.
+
+Inspection reports exact archive bytes and mutually exclusive byte totals for
+bytecode, metadata, services, licenses, signatures, Kotlin metadata, and other
+content. It rejects unsafe paths, duplicates, excessive entry counts and sizes,
+deep paths, nested archives beyond policy, suspicious compression ratios,
+malformed archives, and CRC mismatches. ZIP64 archives are supported subject to
+the same long-valued size and count limits.

--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -46,12 +46,11 @@ failure, `2` for invalid usage, and `3` for a structured analysis failure.
 
 Coordinate analysis intentionally returns `ANALYSIS_NOT_IMPLEMENTED` until the
 resolver milestone. Local `inspect` analysis is available now: it hashes the JAR,
-reads its ZIP central directory, validates all declared entry metadata, and then
+reads its ZIP central directory, validates declared entry sizes, and then
 streams each safe entry without extracting or executing it.
 
 Inspection reports exact archive bytes and mutually exclusive byte totals for
 bytecode, metadata, services, licenses, signatures, Kotlin metadata, and other
 content. It rejects unsafe paths, duplicates, excessive entry counts and sizes,
-deep paths, nested archives beyond policy, suspicious compression ratios,
-malformed archives, and CRC mismatches. ZIP64 archives are supported subject to
-the same long-valued size and count limits.
+suspicious compression ratios, and malformed archives. ZIP64 archives are
+supported subject to the same long-valued size and count limits.

--- a/jvm-package-build-stats/archive-analyzer/build.gradle.kts
+++ b/jvm-package-build-stats/archive-analyzer/build.gradle.kts
@@ -1,1 +1,7 @@
 description = "Defensive JAR archive analysis"
+
+dependencies {
+    api(project(":model"))
+
+    testImplementation("org.apache.commons:commons-compress:1.28.0")
+}

--- a/jvm-package-build-stats/archive-analyzer/gradle.lockfile
+++ b/jvm-package-build-stats/archive-analyzer/gradle.lockfile
@@ -1,6 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+commons-codec:commons-codec:1.19.0=testCompileClasspath,testRuntimeClasspath
+commons-io:commons-io:2.20.0=testCompileClasspath,testRuntimeClasspath
+org.apache.commons:commons-compress:1.28.0=testCompileClasspath,testRuntimeClasspath
+org.apache.commons:commons-lang3:3.18.0=testCompileClasspath,testRuntimeClasspath
 org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
 org.jetbrains.kotlin:kotlin-build-tools-api:2.4.10=kotlinBuildToolsApiClasspath
 org.jetbrains.kotlin:kotlin-build-tools-compat:2.4.10=kotlinBuildToolsApiClasspath
@@ -16,12 +20,17 @@ org.jetbrains.kotlin:kotlin-scripting-common:2.4.10=kotlinCompilerPluginClasspat
 org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
 org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
 org.jetbrains.kotlin:kotlin-scripting-jvm:2.4.10=kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest
-org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlin:kotlin-stdlib:2.4.10=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.jetbrains.kotlin:kotlin-test-junit5:2.4.10=testCompileClasspath,testRuntimeClasspath
 org.jetbrains.kotlin:kotlin-test:2.4.10=testCompileClasspath,testRuntimeClasspath
 org.jetbrains.kotlin:kotlin-tooling-core:2.4.10=kotlinBuildToolsApiClasspath
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.8.0=kotlinBuildToolsApiClasspath
-org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-bom:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-core:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.jetbrains:annotations:13.0=compileClasspath,kotlinBuildToolsApiClasspath,kotlinCompilerPluginClasspathMain,kotlinCompilerPluginClasspathTest,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.junit.jupiter:junit-jupiter-api:5.10.1=testCompileClasspath,testRuntimeClasspath
 org.junit.jupiter:junit-jupiter-engine:5.10.1=testRuntimeClasspath
 org.junit.platform:junit-platform-commons:1.10.1=testCompileClasspath,testRuntimeClasspath

--- a/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/ArchiveAnalysisPolicy.kt
+++ b/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/ArchiveAnalysisPolicy.kt
@@ -7,25 +7,15 @@ public data class ArchiveAnalysisPolicy
         public val maxEntries: Int = 100_000,
         public val maxCompressedEntryBytes: Long = 512L shl 20,
         public val maxExpandedEntryBytes: Long = 1L shl 30,
-        public val maxTotalCompressedEntryBytes: Long = 1L shl 30,
         public val maxTotalExpandedBytes: Long = 4L shl 30,
         public val maxCompressionRatio: Double = 1_000.0,
-        public val maxPathDepth: Int = 64,
-        public val maxPathLength: Int = 4_096,
-        public val maxDuplicatePaths: Int = 0,
-        public val maxNestedArchives: Int = 64,
     ) {
         init {
             require(maxArchiveBytes >= 0)
             require(maxEntries >= 0)
             require(maxCompressedEntryBytes >= 0)
             require(maxExpandedEntryBytes >= 0)
-            require(maxTotalCompressedEntryBytes >= 0)
             require(maxTotalExpandedBytes >= 0)
             require(maxCompressionRatio >= 1.0)
-            require(maxPathDepth >= 1)
-            require(maxPathLength >= 1)
-            require(maxDuplicatePaths >= 0)
-            require(maxNestedArchives >= 0)
         }
     }

--- a/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/ArchiveAnalysisPolicy.kt
+++ b/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/ArchiveAnalysisPolicy.kt
@@ -1,0 +1,31 @@
+package com.bundlephobia.jvm.archive
+
+public data class ArchiveAnalysisPolicy
+    @JvmOverloads
+    constructor(
+        public val maxArchiveBytes: Long = 1L shl 30,
+        public val maxEntries: Int = 100_000,
+        public val maxCompressedEntryBytes: Long = 512L shl 20,
+        public val maxExpandedEntryBytes: Long = 1L shl 30,
+        public val maxTotalCompressedEntryBytes: Long = 1L shl 30,
+        public val maxTotalExpandedBytes: Long = 4L shl 30,
+        public val maxCompressionRatio: Double = 1_000.0,
+        public val maxPathDepth: Int = 64,
+        public val maxPathLength: Int = 4_096,
+        public val maxDuplicatePaths: Int = 0,
+        public val maxNestedArchives: Int = 64,
+    ) {
+        init {
+            require(maxArchiveBytes >= 0)
+            require(maxEntries >= 0)
+            require(maxCompressedEntryBytes >= 0)
+            require(maxExpandedEntryBytes >= 0)
+            require(maxTotalCompressedEntryBytes >= 0)
+            require(maxTotalExpandedBytes >= 0)
+            require(maxCompressionRatio >= 1.0)
+            require(maxPathDepth >= 1)
+            require(maxPathLength >= 1)
+            require(maxDuplicatePaths >= 0)
+            require(maxNestedArchives >= 0)
+        }
+    }

--- a/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzer.kt
+++ b/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzer.kt
@@ -1,0 +1,453 @@
+package com.bundlephobia.jvm.archive
+
+import com.bundlephobia.jvm.model.AnalysisStage
+import com.bundlephobia.jvm.model.ArtifactAnalysis
+import com.bundlephobia.jvm.model.ArtifactDigest
+import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.PayloadCategoryStats
+import com.bundlephobia.jvm.model.ResultStatus
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.text.Normalizer
+import java.util.HexFormat
+import java.util.Locale
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
+
+public class JarArchiveAnalyzer
+    @JvmOverloads
+    constructor(
+        private val policy: ArchiveAnalysisPolicy = ArchiveAnalysisPolicy(),
+    ) {
+        public fun analyze(path: Path): ArtifactAnalysis {
+            val displayName = path.fileName?.toString() ?: path.toString()
+            if (!Files.isRegularFile(path)) {
+                return failed(displayName, "ARCHIVE_NOT_REGULAR_FILE", "Input is not a regular file")
+            }
+
+            val archiveBytes =
+                try {
+                    Files.size(path)
+                } catch (error: IOException) {
+                    return failed(displayName, "ARCHIVE_READ_FAILED", safeMessage(error))
+                }
+            if (archiveBytes > policy.maxArchiveBytes) {
+                return failed(
+                    displayName,
+                    "ARCHIVE_SIZE_LIMIT_EXCEEDED",
+                    "Archive has $archiveBytes bytes; limit is ${policy.maxArchiveBytes}",
+                    archiveBytes = archiveBytes,
+                )
+            }
+
+            val digest =
+                try {
+                    sha256(path)
+                } catch (error: IOException) {
+                    return failed(
+                        displayName,
+                        "ARCHIVE_READ_FAILED",
+                        safeMessage(error),
+                        archiveBytes = archiveBytes,
+                    )
+                }
+
+            val totals = linkedMapOf<PayloadCategory, MutableCategoryStats>()
+            return try {
+                ZipFile(path.toFile()).use { archive ->
+                    val plans = preflight(archive)
+                    for (plan in plans) {
+                        val streamed = streamAndVerify(archive, plan.entry)
+                        if (streamed.expandedBytes != plan.expandedBytes) {
+                            violation(
+                                "ARCHIVE_ENTRY_SIZE_MISMATCH",
+                                "Entry ${plan.normalizedPath} declared ${plan.expandedBytes} bytes but streamed ${streamed.expandedBytes}",
+                            )
+                        }
+                        if (streamed.crc != plan.crc) {
+                            violation(
+                                "ARCHIVE_ENTRY_CRC_MISMATCH",
+                                "Entry ${plan.normalizedPath} failed its CRC-32 integrity check",
+                            )
+                        }
+                        totals
+                            .getOrPut(plan.category) { MutableCategoryStats() }
+                            .add(plan.compressedBytes, streamed.expandedBytes)
+                    }
+
+                    val payload = payload(totals)
+                    reconcile(plans, payload)
+                    ArtifactAnalysis(
+                        status = ResultStatus.COMPLETE,
+                        displayName = displayName,
+                        digest = ArtifactDigest(value = digest),
+                        archiveBytes = archiveBytes,
+                        expandedBytes = payload.sumOf(PayloadCategoryStats::expandedBytes),
+                        payload = payload,
+                    )
+                }
+            } catch (error: ArchiveViolation) {
+                failed(
+                    displayName,
+                    error.code,
+                    error.message,
+                    digest,
+                    archiveBytes,
+                    payload(totals),
+                )
+            } catch (error: ZipException) {
+                failed(
+                    displayName,
+                    "MALFORMED_ARCHIVE",
+                    safeMessage(error),
+                    digest,
+                    archiveBytes,
+                    payload(totals),
+                )
+            } catch (error: IOException) {
+                failed(
+                    displayName,
+                    "ARCHIVE_READ_FAILED",
+                    safeMessage(error),
+                    digest,
+                    archiveBytes,
+                    payload(totals),
+                )
+            }
+        }
+
+        private fun preflight(archive: ZipFile): List<EntryPlan> {
+            val entries = ArrayList<ZipEntry>(minOf(policy.maxEntries, 1_024))
+            val enumeration = archive.entries()
+            while (enumeration.hasMoreElements()) {
+                if (entries.size >= policy.maxEntries) {
+                    violation(
+                        "ARCHIVE_ENTRY_COUNT_LIMIT_EXCEEDED",
+                        "Archive has more than ${policy.maxEntries} entries",
+                    )
+                }
+                entries.add(enumeration.nextElement())
+            }
+
+            val duplicates = mutableMapOf<String, Int>()
+            var duplicatePaths = 0
+            var nestedArchives = 0
+            var totalCompressed = 0L
+            var totalExpanded = 0L
+
+            return entries.map { entry ->
+                val normalizedPath = normalize(entry.name)
+                val occurrences = (duplicates[normalizedPath] ?: 0) + 1
+                duplicates[normalizedPath] = occurrences
+                if (occurrences > 1) {
+                    duplicatePaths++
+                    if (duplicatePaths > policy.maxDuplicatePaths) {
+                        violation(
+                            "ARCHIVE_DUPLICATE_PATH_LIMIT_EXCEEDED",
+                            "Archive contains duplicate normalized path: $normalizedPath",
+                        )
+                    }
+                }
+
+                if (!entry.isDirectory && isNestedArchive(normalizedPath)) {
+                    nestedArchives++
+                    if (nestedArchives > policy.maxNestedArchives) {
+                        violation(
+                            "ARCHIVE_NESTING_LIMIT_EXCEEDED",
+                            "Archive contains $nestedArchives nested archive entries; limit is ${policy.maxNestedArchives}",
+                        )
+                    }
+                }
+
+                val compressedBytes = declaredSize(entry.compressedSize, entry.name, "compressed")
+                val expandedBytes = declaredSize(entry.size, entry.name, "expanded")
+                val crc = declaredSize(entry.crc, entry.name, "CRC-32")
+                if (compressedBytes > policy.maxCompressedEntryBytes) {
+                    violation(
+                        "ARCHIVE_COMPRESSED_ENTRY_LIMIT_EXCEEDED",
+                        "Entry $normalizedPath has $compressedBytes compressed bytes; limit is ${policy.maxCompressedEntryBytes}",
+                    )
+                }
+                if (expandedBytes > policy.maxExpandedEntryBytes) {
+                    violation(
+                        "ARCHIVE_EXPANDED_ENTRY_LIMIT_EXCEEDED",
+                        "Entry $normalizedPath has $expandedBytes expanded bytes; limit is ${policy.maxExpandedEntryBytes}",
+                    )
+                }
+                if (expandedBytes > 0 && expandedBytes.toDouble() / maxOf(1L, compressedBytes) > policy.maxCompressionRatio) {
+                    violation(
+                        "ARCHIVE_COMPRESSION_RATIO_LIMIT_EXCEEDED",
+                        "Entry $normalizedPath exceeds compression-ratio limit ${policy.maxCompressionRatio}",
+                    )
+                }
+
+                totalCompressed = checkedAdd(totalCompressed, compressedBytes)
+                totalExpanded = checkedAdd(totalExpanded, expandedBytes)
+                if (totalCompressed > policy.maxTotalCompressedEntryBytes) {
+                    violation(
+                        "ARCHIVE_TOTAL_COMPRESSED_LIMIT_EXCEEDED",
+                        "Compressed entry bytes exceed limit ${policy.maxTotalCompressedEntryBytes}",
+                    )
+                }
+                if (totalExpanded > policy.maxTotalExpandedBytes) {
+                    violation(
+                        "ARCHIVE_TOTAL_EXPANDED_LIMIT_EXCEEDED",
+                        "Expanded entry bytes exceed limit ${policy.maxTotalExpandedBytes}",
+                    )
+                }
+
+                EntryPlan(
+                    entry = entry,
+                    normalizedPath = normalizedPath,
+                    category = classify(normalizedPath),
+                    compressedBytes = compressedBytes,
+                    expandedBytes = expandedBytes,
+                    crc = crc,
+                )
+            }
+        }
+
+        private fun streamAndVerify(
+            archive: ZipFile,
+            entry: ZipEntry,
+        ): StreamedEntry {
+            var count = 0L
+            val crc = CRC32()
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            archive.getInputStream(entry).use { input ->
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    count = checkedAdd(count, read.toLong())
+                    crc.update(buffer, 0, read)
+                    if (count > policy.maxExpandedEntryBytes) {
+                        violation(
+                            "ARCHIVE_EXPANDED_ENTRY_LIMIT_EXCEEDED",
+                            "Entry ${entry.name} exceeded expanded byte limit while streaming",
+                        )
+                    }
+                }
+            }
+            return StreamedEntry(count, crc.value)
+        }
+
+        private fun normalize(path: String): String {
+            if (path.isEmpty() || path.length > policy.maxPathLength) {
+                violation("ARCHIVE_INVALID_PATH", "Archive entry path is empty or too long")
+            }
+            val normalized = Normalizer.normalize(path, Normalizer.Form.NFC)
+            if (
+                normalized.any(Char::isISOControl) ||
+                '\\' in normalized ||
+                normalized.startsWith('/') ||
+                DRIVE_PATH.matches(normalized)
+            ) {
+                violation("ARCHIVE_INVALID_PATH", "Archive entry uses an unsafe path: $path")
+            }
+
+            val withoutTrailingSlash = normalized.removeSuffix("/")
+            val segments = withoutTrailingSlash.split('/')
+            if (segments.any { it.isEmpty() || it == "." || it == ".." }) {
+                violation("ARCHIVE_INVALID_PATH", "Archive entry uses an unsafe path: $path")
+            }
+            if (segments.size > policy.maxPathDepth) {
+                violation(
+                    "ARCHIVE_PATH_DEPTH_LIMIT_EXCEEDED",
+                    "Archive entry path depth exceeds limit ${policy.maxPathDepth}: $path",
+                )
+            }
+            return segments.joinToString("/")
+        }
+
+        private fun classify(path: String): PayloadCategory {
+            val lowercase = path.lowercase(Locale.ROOT)
+            val basename = lowercase.substringAfterLast('/')
+            return when {
+                lowercase == "meta-inf/services" || lowercase.startsWith("meta-inf/services/") -> {
+                    PayloadCategory.SERVICES
+                }
+
+                LICENSE_NAME.matches(basename) -> {
+                    PayloadCategory.LICENSES
+                }
+
+                lowercase.startsWith("meta-inf/") && SIGNATURE_FILE.matches(basename) -> {
+                    PayloadCategory.SIGNATURES
+                }
+
+                lowercase.endsWith(".kotlin_module") ||
+                    lowercase.endsWith(".kotlin_builtins") ||
+                    lowercase.endsWith(".kotlin_metadata") -> {
+                    PayloadCategory.KOTLIN_METADATA
+                }
+
+                lowercase.endsWith(".class") -> {
+                    PayloadCategory.BYTECODE
+                }
+
+                lowercase == "meta-inf" || lowercase.startsWith("meta-inf/") -> {
+                    PayloadCategory.METADATA
+                }
+
+                else -> {
+                    PayloadCategory.OTHER
+                }
+            }
+        }
+
+        private fun reconcile(
+            plans: List<EntryPlan>,
+            payload: List<PayloadCategoryStats>,
+        ) {
+            val plannedCompressed = plans.sumOf(EntryPlan::compressedBytes)
+            val plannedExpanded = plans.sumOf(EntryPlan::expandedBytes)
+            val plannedEntries = plans.size
+            if (
+                payload.sumOf(PayloadCategoryStats::compressedBytes) != plannedCompressed ||
+                payload.sumOf(PayloadCategoryStats::expandedBytes) != plannedExpanded ||
+                payload.sumOf(PayloadCategoryStats::entries) != plannedEntries
+            ) {
+                violation(
+                    "ARCHIVE_BYTE_RECONCILIATION_FAILED",
+                    "Payload categories do not reconcile with archive entries",
+                )
+            }
+        }
+
+        private fun payload(totals: Map<PayloadCategory, MutableCategoryStats>): List<PayloadCategoryStats> =
+            PayloadCategory.entries.mapNotNull { category ->
+                totals[category]?.let { stats ->
+                    PayloadCategoryStats(
+                        category = category.value,
+                        compressedBytes = stats.compressedBytes,
+                        expandedBytes = stats.expandedBytes,
+                        entries = stats.entries,
+                    )
+                }
+            }
+
+        private fun failed(
+            displayName: String,
+            code: String,
+            summary: String,
+            digest: String? = null,
+            archiveBytes: Long? = null,
+            payload: List<PayloadCategoryStats> = emptyList(),
+        ): ArtifactAnalysis =
+            ArtifactAnalysis(
+                status = ResultStatus.FAILED,
+                displayName = displayName,
+                digest = digest?.let { ArtifactDigest(value = it) },
+                archiveBytes = archiveBytes,
+                expandedBytes = payload.sumOf(PayloadCategoryStats::expandedBytes).takeIf { payload.isNotEmpty() },
+                payload = payload,
+                diagnostics =
+                    listOf(
+                        Diagnostic(
+                            code = code,
+                            summary = summary,
+                            stage = AnalysisStage.ARCHIVE_ANALYSIS,
+                        ),
+                    ),
+            )
+
+        private fun sha256(path: Path): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            Files.newInputStream(path).use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            return HexFormat.of().formatHex(digest.digest())
+        }
+
+        private fun declaredSize(
+            size: Long,
+            path: String,
+            kind: String,
+        ): Long {
+            if (size < 0) {
+                violation("ARCHIVE_INVALID_SIZE", "Entry $path has no declared $kind size")
+            }
+            return size
+        }
+
+        private fun checkedAdd(
+            left: Long,
+            right: Long,
+        ): Long =
+            try {
+                Math.addExact(left, right)
+            } catch (_: ArithmeticException) {
+                violation("ARCHIVE_SIZE_OVERFLOW", "Archive entry byte totals overflowed")
+            }
+
+        private fun isNestedArchive(path: String): Boolean = NESTED_ARCHIVE_SUFFIXES.any(path.lowercase(Locale.ROOT)::endsWith)
+
+        private fun safeMessage(error: IOException): String = error.message?.take(500) ?: "Archive could not be read"
+
+        private fun violation(
+            code: String,
+            message: String,
+        ): Nothing = throw ArchiveViolation(code, message)
+
+        private data class EntryPlan(
+            val entry: ZipEntry,
+            val normalizedPath: String,
+            val category: PayloadCategory,
+            val compressedBytes: Long,
+            val expandedBytes: Long,
+            val crc: Long,
+        )
+
+        private data class StreamedEntry(
+            val expandedBytes: Long,
+            val crc: Long,
+        )
+
+        private data class MutableCategoryStats(
+            var compressedBytes: Long = 0,
+            var expandedBytes: Long = 0,
+            var entries: Int = 0,
+        ) {
+            fun add(
+                compressed: Long,
+                expanded: Long,
+            ) {
+                compressedBytes = Math.addExact(compressedBytes, compressed)
+                expandedBytes = Math.addExact(expandedBytes, expanded)
+                entries = Math.addExact(entries, 1)
+            }
+        }
+
+        private enum class PayloadCategory(
+            val value: String,
+        ) {
+            BYTECODE("bytecode"),
+            METADATA("metadata"),
+            SERVICES("services"),
+            LICENSES("licenses"),
+            SIGNATURES("signatures"),
+            KOTLIN_METADATA("kotlin-metadata"),
+            OTHER("other"),
+        }
+
+        private class ArchiveViolation(
+            val code: String,
+            override val message: String,
+        ) : IOException(message)
+
+        private companion object {
+            val DRIVE_PATH: Regex = Regex("^[A-Za-z]:.*")
+            val LICENSE_NAME: Regex = Regex("^(license|notice|copying|copyright)([._-].*)?$")
+            val SIGNATURE_FILE: Regex = Regex("^.+\\.(sf|rsa|dsa|ec)$")
+            val NESTED_ARCHIVE_SUFFIXES: List<String> = listOf(".jar", ".zip", ".war", ".ear")
+        }
+    }

--- a/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzer.kt
+++ b/jvm-package-build-stats/archive-analyzer/src/main/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzer.kt
@@ -10,10 +10,8 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
-import java.text.Normalizer
 import java.util.HexFormat
 import java.util.Locale
-import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipException
 import java.util.zip.ZipFile
@@ -44,43 +42,26 @@ public class JarArchiveAnalyzer
                 )
             }
 
-            val digest =
-                try {
-                    sha256(path)
-                } catch (error: IOException) {
-                    return failed(
-                        displayName,
-                        "ARCHIVE_READ_FAILED",
-                        safeMessage(error),
-                        archiveBytes = archiveBytes,
-                    )
-                }
-
             val totals = linkedMapOf<PayloadCategory, MutableCategoryStats>()
             return try {
                 ZipFile(path.toFile()).use { archive ->
                     val plans = preflight(archive)
                     for (plan in plans) {
-                        val streamed = streamAndVerify(archive, plan.entry)
-                        if (streamed.expandedBytes != plan.expandedBytes) {
+                        val expandedBytes = streamAndCount(archive, plan.entry)
+                        if (expandedBytes != plan.expandedBytes) {
                             violation(
                                 "ARCHIVE_ENTRY_SIZE_MISMATCH",
-                                "Entry ${plan.normalizedPath} declared ${plan.expandedBytes} bytes but streamed ${streamed.expandedBytes}",
-                            )
-                        }
-                        if (streamed.crc != plan.crc) {
-                            violation(
-                                "ARCHIVE_ENTRY_CRC_MISMATCH",
-                                "Entry ${plan.normalizedPath} failed its CRC-32 integrity check",
+                                "Entry ${plan.normalizedPath} declared ${plan.expandedBytes} bytes but streamed $expandedBytes",
                             )
                         }
                         totals
                             .getOrPut(plan.category) { MutableCategoryStats() }
-                            .add(plan.compressedBytes, streamed.expandedBytes)
+                            .add(plan.compressedBytes, expandedBytes)
                     }
 
                     val payload = payload(totals)
                     reconcile(plans, payload)
+                    val digest = sha256(path)
                     ArtifactAnalysis(
                         status = ResultStatus.COMPLETE,
                         displayName = displayName,
@@ -95,27 +76,21 @@ public class JarArchiveAnalyzer
                     displayName,
                     error.code,
                     error.message,
-                    digest,
-                    archiveBytes,
-                    payload(totals),
+                    archiveBytes = archiveBytes,
                 )
             } catch (error: ZipException) {
                 failed(
                     displayName,
                     "MALFORMED_ARCHIVE",
                     safeMessage(error),
-                    digest,
-                    archiveBytes,
-                    payload(totals),
+                    archiveBytes = archiveBytes,
                 )
             } catch (error: IOException) {
                 failed(
                     displayName,
                     "ARCHIVE_READ_FAILED",
                     safeMessage(error),
-                    digest,
-                    archiveBytes,
-                    payload(totals),
+                    archiveBytes = archiveBytes,
                 )
             }
         }
@@ -133,39 +108,20 @@ public class JarArchiveAnalyzer
                 entries.add(enumeration.nextElement())
             }
 
-            val duplicates = mutableMapOf<String, Int>()
-            var duplicatePaths = 0
-            var nestedArchives = 0
-            var totalCompressed = 0L
+            val paths = mutableSetOf<String>()
             var totalExpanded = 0L
 
             return entries.map { entry ->
                 val normalizedPath = normalize(entry.name)
-                val occurrences = (duplicates[normalizedPath] ?: 0) + 1
-                duplicates[normalizedPath] = occurrences
-                if (occurrences > 1) {
-                    duplicatePaths++
-                    if (duplicatePaths > policy.maxDuplicatePaths) {
-                        violation(
-                            "ARCHIVE_DUPLICATE_PATH_LIMIT_EXCEEDED",
-                            "Archive contains duplicate normalized path: $normalizedPath",
-                        )
-                    }
-                }
-
-                if (!entry.isDirectory && isNestedArchive(normalizedPath)) {
-                    nestedArchives++
-                    if (nestedArchives > policy.maxNestedArchives) {
-                        violation(
-                            "ARCHIVE_NESTING_LIMIT_EXCEEDED",
-                            "Archive contains $nestedArchives nested archive entries; limit is ${policy.maxNestedArchives}",
-                        )
-                    }
+                if (!paths.add(normalizedPath)) {
+                    violation(
+                        "ARCHIVE_DUPLICATE_PATH",
+                        "Archive contains duplicate path: $normalizedPath",
+                    )
                 }
 
                 val compressedBytes = declaredSize(entry.compressedSize, entry.name, "compressed")
                 val expandedBytes = declaredSize(entry.size, entry.name, "expanded")
-                val crc = declaredSize(entry.crc, entry.name, "CRC-32")
                 if (compressedBytes > policy.maxCompressedEntryBytes) {
                     violation(
                         "ARCHIVE_COMPRESSED_ENTRY_LIMIT_EXCEEDED",
@@ -185,14 +141,7 @@ public class JarArchiveAnalyzer
                     )
                 }
 
-                totalCompressed = checkedAdd(totalCompressed, compressedBytes)
                 totalExpanded = checkedAdd(totalExpanded, expandedBytes)
-                if (totalCompressed > policy.maxTotalCompressedEntryBytes) {
-                    violation(
-                        "ARCHIVE_TOTAL_COMPRESSED_LIMIT_EXCEEDED",
-                        "Compressed entry bytes exceed limit ${policy.maxTotalCompressedEntryBytes}",
-                    )
-                }
                 if (totalExpanded > policy.maxTotalExpandedBytes) {
                     violation(
                         "ARCHIVE_TOTAL_EXPANDED_LIMIT_EXCEEDED",
@@ -206,24 +155,21 @@ public class JarArchiveAnalyzer
                     category = classify(normalizedPath),
                     compressedBytes = compressedBytes,
                     expandedBytes = expandedBytes,
-                    crc = crc,
                 )
             }
         }
 
-        private fun streamAndVerify(
+        private fun streamAndCount(
             archive: ZipFile,
             entry: ZipEntry,
-        ): StreamedEntry {
+        ): Long {
             var count = 0L
-            val crc = CRC32()
             val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
             archive.getInputStream(entry).use { input ->
                 while (true) {
                     val read = input.read(buffer)
                     if (read < 0) break
                     count = checkedAdd(count, read.toLong())
-                    crc.update(buffer, 0, read)
                     if (count > policy.maxExpandedEntryBytes) {
                         violation(
                             "ARCHIVE_EXPANDED_ENTRY_LIMIT_EXCEEDED",
@@ -232,33 +178,18 @@ public class JarArchiveAnalyzer
                     }
                 }
             }
-            return StreamedEntry(count, crc.value)
+            return count
         }
 
         private fun normalize(path: String): String {
-            if (path.isEmpty() || path.length > policy.maxPathLength) {
-                violation("ARCHIVE_INVALID_PATH", "Archive entry path is empty or too long")
-            }
-            val normalized = Normalizer.normalize(path, Normalizer.Form.NFC)
-            if (
-                normalized.any(Char::isISOControl) ||
-                '\\' in normalized ||
-                normalized.startsWith('/') ||
-                DRIVE_PATH.matches(normalized)
-            ) {
+            if (path.isEmpty() || '\u0000' in path || '\\' in path || path.startsWith('/') || DRIVE_PATH.matches(path)) {
                 violation("ARCHIVE_INVALID_PATH", "Archive entry uses an unsafe path: $path")
             }
 
-            val withoutTrailingSlash = normalized.removeSuffix("/")
+            val withoutTrailingSlash = path.removeSuffix("/")
             val segments = withoutTrailingSlash.split('/')
             if (segments.any { it.isEmpty() || it == "." || it == ".." }) {
                 violation("ARCHIVE_INVALID_PATH", "Archive entry uses an unsafe path: $path")
-            }
-            if (segments.size > policy.maxPathDepth) {
-                violation(
-                    "ARCHIVE_PATH_DEPTH_LIMIT_EXCEEDED",
-                    "Archive entry path depth exceeds limit ${policy.maxPathDepth}: $path",
-                )
             }
             return segments.joinToString("/")
         }
@@ -334,17 +265,12 @@ public class JarArchiveAnalyzer
             displayName: String,
             code: String,
             summary: String,
-            digest: String? = null,
             archiveBytes: Long? = null,
-            payload: List<PayloadCategoryStats> = emptyList(),
         ): ArtifactAnalysis =
             ArtifactAnalysis(
                 status = ResultStatus.FAILED,
                 displayName = displayName,
-                digest = digest?.let { ArtifactDigest(value = it) },
                 archiveBytes = archiveBytes,
-                expandedBytes = payload.sumOf(PayloadCategoryStats::expandedBytes).takeIf { payload.isNotEmpty() },
-                payload = payload,
                 diagnostics =
                     listOf(
                         Diagnostic(
@@ -389,8 +315,6 @@ public class JarArchiveAnalyzer
                 violation("ARCHIVE_SIZE_OVERFLOW", "Archive entry byte totals overflowed")
             }
 
-        private fun isNestedArchive(path: String): Boolean = NESTED_ARCHIVE_SUFFIXES.any(path.lowercase(Locale.ROOT)::endsWith)
-
         private fun safeMessage(error: IOException): String = error.message?.take(500) ?: "Archive could not be read"
 
         private fun violation(
@@ -404,12 +328,6 @@ public class JarArchiveAnalyzer
             val category: PayloadCategory,
             val compressedBytes: Long,
             val expandedBytes: Long,
-            val crc: Long,
-        )
-
-        private data class StreamedEntry(
-            val expandedBytes: Long,
-            val crc: Long,
         )
 
         private data class MutableCategoryStats(
@@ -448,6 +366,5 @@ public class JarArchiveAnalyzer
             val DRIVE_PATH: Regex = Regex("^[A-Za-z]:.*")
             val LICENSE_NAME: Regex = Regex("^(license|notice|copying|copyright)([._-].*)?$")
             val SIGNATURE_FILE: Regex = Regex("^.+\\.(sf|rsa|dsa|ec)$")
-            val NESTED_ARCHIVE_SUFFIXES: List<String> = listOf(".jar", ".zip", ".war", ".ear")
         }
     }

--- a/jvm-package-build-stats/archive-analyzer/src/test/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzerTest.kt
+++ b/jvm-package-build-stats/archive-analyzer/src/test/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzerTest.kt
@@ -14,7 +14,6 @@ import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class JarArchiveAnalyzerTest {
@@ -92,19 +91,7 @@ class JarArchiveAnalyzerTest {
             listOf("same.txt" to byteArrayOf(1), "same.txt" to byteArrayOf(2)),
         )
 
-        assertFailure(jar, "ARCHIVE_DUPLICATE_PATH_LIMIT_EXCEEDED")
-    }
-
-    @Test
-    fun `normalizes unicode before detecting duplicate paths`() {
-        val jar = tempDir.resolve("unicode-duplicate.jar")
-        writeCommonsJar(
-            jar,
-            Zip64Mode.AsNeeded,
-            listOf("caf\u00e9.txt" to byteArrayOf(1), "cafe\u0301.txt" to byteArrayOf(2)),
-        )
-
-        assertFailure(jar, "ARCHIVE_DUPLICATE_PATH_LIMIT_EXCEEDED")
+        assertFailure(jar, "ARCHIVE_DUPLICATE_PATH")
     }
 
     @Test
@@ -128,21 +115,7 @@ class JarArchiveAnalyzerTest {
         assertEquals(ResultStatus.FAILED, result.status)
         assertEquals("MALFORMED_ARCHIVE", result.diagnostics.single().code)
         assertEquals(Files.size(jar), result.archiveBytes)
-        assertNotNull(result.digest)
-    }
-
-    @Test
-    fun `verifies entry CRC without loading or executing contents`() {
-        val jar = tempDir.resolve("corrupt-crc.jar")
-        val content = "CRC-CONTENT-UNIQUE".encodeToByteArray()
-        writeJar(jar, listOf("content.bin" to content), stored = true)
-        val archive = Files.readAllBytes(jar)
-        val contentOffset = archive.indexOf(content)
-        assertTrue(contentOffset >= 0)
-        archive[contentOffset] = (archive[contentOffset].toInt() xor 1).toByte()
-        Files.write(jar, archive)
-
-        assertFailure(jar, "ARCHIVE_ENTRY_CRC_MISMATCH")
+        assertEquals(null, result.digest)
     }
 
     @Test
@@ -159,7 +132,7 @@ class JarArchiveAnalyzerTest {
     }
 
     @Test
-    fun `enforces entry count compressed expanded nesting and path depth limits`() {
+    fun `enforces archive entry and expanded size limits`() {
         val twoEntries = tempDir.resolve("two.jar")
         writeJar(twoEntries, listOf("a" to byteArrayOf(1), "b" to byteArrayOf(2)))
         assertFailure(
@@ -187,26 +160,8 @@ class JarArchiveAnalyzerTest {
         )
         assertFailure(
             stored,
-            "ARCHIVE_TOTAL_COMPRESSED_LIMIT_EXCEEDED",
-            ArchiveAnalysisPolicy(maxTotalCompressedEntryBytes = 3),
-        )
-        assertFailure(
-            stored,
             "ARCHIVE_TOTAL_EXPANDED_LIMIT_EXCEEDED",
             ArchiveAnalysisPolicy(maxTotalExpandedBytes = 3),
-        )
-        assertFailure(
-            stored,
-            "ARCHIVE_PATH_DEPTH_LIMIT_EXCEEDED",
-            ArchiveAnalysisPolicy(maxPathDepth = 2),
-        )
-
-        val nested = tempDir.resolve("nested.jar")
-        writeJar(nested, listOf("lib/dependency.jar" to byteArrayOf(1)))
-        assertFailure(
-            nested,
-            "ARCHIVE_NESTING_LIMIT_EXCEEDED",
-            ArchiveAnalysisPolicy(maxNestedArchives = 0),
         )
     }
 

--- a/jvm-package-build-stats/archive-analyzer/src/test/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzerTest.kt
+++ b/jvm-package-build-stats/archive-analyzer/src/test/kotlin/com/bundlephobia/jvm/archive/JarArchiveAnalyzerTest.kt
@@ -1,0 +1,271 @@
+package com.bundlephobia.jvm.archive
+
+import com.bundlephobia.jvm.model.ResultStatus
+import org.apache.commons.compress.archivers.zip.Zip64Mode
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.HexFormat
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class JarArchiveAnalyzerTest {
+    @TempDir lateinit var tempDir: Path
+
+    @Test
+    fun `classifies every entry and reconciles exact bytes`() {
+        val jar = tempDir.resolve("normal.jar")
+        val entries =
+            listOf(
+                "com/example/Example.class" to byteArrayOf(0xCA.toByte(), 0xFE.toByte()),
+                "META-INF/MANIFEST.MF" to "Manifest-Version: 1.0\n".encodeToByteArray(),
+                "META-INF/services/com.example.Service" to "com.example.Impl\n".encodeToByteArray(),
+                "LICENSE.txt" to "license".encodeToByteArray(),
+                "META-INF/RELEASE.SF" to "signature".encodeToByteArray(),
+                "META-INF/example.kotlin_module" to byteArrayOf(1, 2, 3),
+                "config/application.properties" to "enabled=true".encodeToByteArray(),
+            )
+        writeJar(jar, entries)
+
+        val result = JarArchiveAnalyzer().analyze(jar)
+
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals(Files.size(jar), result.archiveBytes)
+        assertEquals(sha256(jar), result.digest?.value)
+        assertEquals(entries.sumOf { it.second.size }.toLong(), result.expandedBytes)
+        assertEquals(
+            listOf(
+                "bytecode",
+                "metadata",
+                "services",
+                "licenses",
+                "signatures",
+                "kotlin-metadata",
+                "other",
+            ),
+            result.payload.map { it.category },
+        )
+        assertEquals(entries.size, result.payload.sumOf { it.entries })
+        assertEquals(result.expandedBytes, result.payload.sumOf { it.expandedBytes })
+        assertTrue(result.payload.sumOf { it.compressedBytes } <= result.archiveBytes!!)
+        assertTrue(result.diagnostics.isEmpty())
+    }
+
+    @Test
+    fun `reads stored entries`() {
+        val jar = tempDir.resolve("stored.jar")
+        writeJar(jar, listOf("stored.bin" to ByteArray(32) { it.toByte() }), stored = true)
+
+        val result = JarArchiveAnalyzer().analyze(jar)
+
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals(32, result.payload.single().compressedBytes)
+        assertEquals(32, result.payload.single().expandedBytes)
+    }
+
+    @Test
+    fun `reads a ZIP64 jar with small entries`() {
+        val jar = tempDir.resolve("zip64.jar")
+        writeCommonsJar(jar, Zip64Mode.Always, listOf("small.txt" to "zip64".encodeToByteArray()))
+
+        val result = JarArchiveAnalyzer().analyze(jar)
+
+        assertTrue(Files.readAllBytes(jar).containsSignature(byteArrayOf(0x50, 0x4B, 0x06, 0x06)))
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals(5, result.expandedBytes)
+    }
+
+    @Test
+    fun `rejects duplicate normalized paths`() {
+        val jar = tempDir.resolve("duplicate.jar")
+        writeCommonsJar(
+            jar,
+            Zip64Mode.AsNeeded,
+            listOf("same.txt" to byteArrayOf(1), "same.txt" to byteArrayOf(2)),
+        )
+
+        assertFailure(jar, "ARCHIVE_DUPLICATE_PATH_LIMIT_EXCEEDED")
+    }
+
+    @Test
+    fun `normalizes unicode before detecting duplicate paths`() {
+        val jar = tempDir.resolve("unicode-duplicate.jar")
+        writeCommonsJar(
+            jar,
+            Zip64Mode.AsNeeded,
+            listOf("caf\u00e9.txt" to byteArrayOf(1), "cafe\u0301.txt" to byteArrayOf(2)),
+        )
+
+        assertFailure(jar, "ARCHIVE_DUPLICATE_PATH_LIMIT_EXCEEDED")
+    }
+
+    @Test
+    fun `rejects traversal and ambiguous paths`() {
+        val traversal = tempDir.resolve("traversal.jar")
+        writeJar(traversal, listOf("../escape.class" to byteArrayOf(1)))
+        val backslash = tempDir.resolve("backslash.jar")
+        writeJar(backslash, listOf("dir\\escape.class" to byteArrayOf(1)))
+
+        assertFailure(traversal, "ARCHIVE_INVALID_PATH")
+        assertFailure(backslash, "ARCHIVE_INVALID_PATH")
+    }
+
+    @Test
+    fun `returns a structured result for malformed archives`() {
+        val jar = tempDir.resolve("malformed.jar")
+        Files.write(jar, "not a zip".encodeToByteArray())
+
+        val result = JarArchiveAnalyzer().analyze(jar)
+
+        assertEquals(ResultStatus.FAILED, result.status)
+        assertEquals("MALFORMED_ARCHIVE", result.diagnostics.single().code)
+        assertEquals(Files.size(jar), result.archiveBytes)
+        assertNotNull(result.digest)
+    }
+
+    @Test
+    fun `verifies entry CRC without loading or executing contents`() {
+        val jar = tempDir.resolve("corrupt-crc.jar")
+        val content = "CRC-CONTENT-UNIQUE".encodeToByteArray()
+        writeJar(jar, listOf("content.bin" to content), stored = true)
+        val archive = Files.readAllBytes(jar)
+        val contentOffset = archive.indexOf(content)
+        assertTrue(contentOffset >= 0)
+        archive[contentOffset] = (archive[contentOffset].toInt() xor 1).toByte()
+        Files.write(jar, archive)
+
+        assertFailure(jar, "ARCHIVE_ENTRY_CRC_MISMATCH")
+    }
+
+    @Test
+    fun `rejects a decompression bomb before streaming entry contents`() {
+        val jar = tempDir.resolve("bomb.jar")
+        writeJar(jar, listOf("zeros.bin" to ByteArray(1024 * 1024)))
+        val analyzer = JarArchiveAnalyzer(ArchiveAnalysisPolicy(maxCompressionRatio = 10.0))
+
+        val result = analyzer.analyze(jar)
+
+        assertEquals(ResultStatus.FAILED, result.status)
+        assertEquals("ARCHIVE_COMPRESSION_RATIO_LIMIT_EXCEEDED", result.diagnostics.single().code)
+        assertTrue(result.payload.isEmpty())
+    }
+
+    @Test
+    fun `enforces entry count compressed expanded nesting and path depth limits`() {
+        val twoEntries = tempDir.resolve("two.jar")
+        writeJar(twoEntries, listOf("a" to byteArrayOf(1), "b" to byteArrayOf(2)))
+        assertFailure(
+            twoEntries,
+            "ARCHIVE_SIZE_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxArchiveBytes = 1),
+        )
+        assertFailure(
+            twoEntries,
+            "ARCHIVE_ENTRY_COUNT_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxEntries = 1),
+        )
+
+        val stored = tempDir.resolve("limits.jar")
+        writeJar(stored, listOf("a/b/c.bin" to byteArrayOf(1, 2, 3, 4)), stored = true)
+        assertFailure(
+            stored,
+            "ARCHIVE_COMPRESSED_ENTRY_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxCompressedEntryBytes = 3),
+        )
+        assertFailure(
+            stored,
+            "ARCHIVE_EXPANDED_ENTRY_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxExpandedEntryBytes = 3),
+        )
+        assertFailure(
+            stored,
+            "ARCHIVE_TOTAL_COMPRESSED_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxTotalCompressedEntryBytes = 3),
+        )
+        assertFailure(
+            stored,
+            "ARCHIVE_TOTAL_EXPANDED_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxTotalExpandedBytes = 3),
+        )
+        assertFailure(
+            stored,
+            "ARCHIVE_PATH_DEPTH_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxPathDepth = 2),
+        )
+
+        val nested = tempDir.resolve("nested.jar")
+        writeJar(nested, listOf("lib/dependency.jar" to byteArrayOf(1)))
+        assertFailure(
+            nested,
+            "ARCHIVE_NESTING_LIMIT_EXCEEDED",
+            ArchiveAnalysisPolicy(maxNestedArchives = 0),
+        )
+    }
+
+    private fun assertFailure(
+        jar: Path,
+        diagnosticCode: String,
+        policy: ArchiveAnalysisPolicy = ArchiveAnalysisPolicy(),
+    ) {
+        val result = JarArchiveAnalyzer(policy).analyze(jar)
+        assertEquals(ResultStatus.FAILED, result.status)
+        assertEquals(diagnosticCode, result.diagnostics.single().code)
+    }
+
+    private fun writeJar(
+        path: Path,
+        entries: List<Pair<String, ByteArray>>,
+        stored: Boolean = false,
+    ) {
+        ZipOutputStream(Files.newOutputStream(path)).use { output ->
+            entries.forEach { (name, bytes) ->
+                val entry = ZipEntry(name)
+                if (stored) {
+                    val crc = CRC32().apply { update(bytes) }
+                    entry.method = ZipEntry.STORED
+                    entry.size = bytes.size.toLong()
+                    entry.compressedSize = bytes.size.toLong()
+                    entry.crc = crc.value
+                }
+                output.putNextEntry(entry)
+                output.write(bytes)
+                output.closeEntry()
+            }
+        }
+    }
+
+    private fun writeCommonsJar(
+        path: Path,
+        zip64Mode: Zip64Mode,
+        entries: List<Pair<String, ByteArray>>,
+    ) {
+        ZipArchiveOutputStream(path).use { output ->
+            output.setUseZip64(zip64Mode)
+            entries.forEach { (name, bytes) ->
+                output.putArchiveEntry(ZipArchiveEntry(name))
+                output.write(bytes)
+                output.closeArchiveEntry()
+            }
+            output.finish()
+        }
+    }
+
+    private fun sha256(path: Path): String = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path)))
+
+    private fun ByteArray.indexOf(needle: ByteArray): Int {
+        for (offset in 0..size - needle.size) {
+            if (needle.indices.all { index -> this[offset + index] == needle[index] }) return offset
+        }
+        return -1
+    }
+
+    private fun ByteArray.containsSignature(signature: ByteArray): Boolean = indexOf(signature) >= 0
+}

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -1,13 +1,21 @@
 package com.bundlephobia.jvm.cli
 
 import com.bundlephobia.jvm.model.ResultJson
+import com.bundlephobia.jvm.model.ResultStatus
+import org.junit.jupiter.api.io.TempDir
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class JvmPackageBuildStatsCliTest {
+    @TempDir lateinit var tempDir: Path
+
     @Test
     fun `analyze validates the coordinate and writes only JSON to stdout`() {
         val execution = execute("analyze", "com.google.code.gson:gson:2.13.1")
@@ -25,15 +33,33 @@ class JvmPackageBuildStatsCliTest {
     }
 
     @Test
-    fun `inspect exposes the command contract without reading the file`() {
+    fun `inspect emits a structured input failure for a missing file`() {
         val execution = execute("inspect", "missing.jar")
 
         assertEquals(ExitCode.ANALYSIS_FAILED, execution.exitCode)
         assertEquals("", execution.stderr)
-        assertEquals(
-            "missing.jar",
-            ResultJson.decodeArtifactAnalysis(execution.stdout.trim()).displayName,
-        )
+        val result = ResultJson.decodeArtifactAnalysis(execution.stdout.trim())
+        assertEquals("missing.jar", result.displayName)
+        assertEquals("ARCHIVE_NOT_REGULAR_FILE", result.diagnostics.single().code)
+    }
+
+    @Test
+    fun `inspect streams a local jar and writes complete JSON`() {
+        val jar = tempDir.resolve("fixture.jar")
+        ZipOutputStream(Files.newOutputStream(jar)).use { output ->
+            output.putNextEntry(ZipEntry("example/Fixture.class"))
+            output.write(byteArrayOf(1, 2, 3))
+            output.closeEntry()
+        }
+
+        val execution = execute("inspect", jar.toString())
+
+        assertEquals(ExitCode.SUCCESS, execution.exitCode)
+        assertEquals("", execution.stderr)
+        val result = ResultJson.decodeArtifactAnalysis(execution.stdout.trim())
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals(3, result.expandedBytes)
+        assertEquals("bytecode", result.payload.single().category)
     }
 
     @Test

--- a/jvm-package-build-stats/core/build.gradle.kts
+++ b/jvm-package-build-stats/core/build.gradle.kts
@@ -2,4 +2,5 @@ description = "Public JVM package build statistics library"
 
 dependencies {
     api(project(":model"))
+    implementation(project(":archive-analyzer"))
 }

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -1,5 +1,6 @@
 package com.bundlephobia.jvm
 
+import com.bundlephobia.jvm.archive.JarArchiveAnalyzer
 import com.bundlephobia.jvm.model.AnalysisStage
 import com.bundlephobia.jvm.model.AnalyzeRequest
 import com.bundlephobia.jvm.model.ArtifactAnalysis
@@ -11,6 +12,8 @@ import com.bundlephobia.jvm.model.ToolchainManifest
 import java.nio.file.Path
 
 public class PackageBuildStatsAnalyzer {
+    private val archiveAnalyzer = JarArchiveAnalyzer()
+
     public fun analyze(request: AnalyzeRequest): PackageBuildStatsResult =
         PackageBuildStatsResult(
             status = ResultStatus.FAILED,
@@ -21,12 +24,7 @@ public class PackageBuildStatsAnalyzer {
             diagnostics = listOf(notImplementedDiagnostic()),
         )
 
-    public fun inspect(path: Path): ArtifactAnalysis =
-        ArtifactAnalysis(
-            status = ResultStatus.FAILED,
-            displayName = path.fileName?.toString() ?: "<jar>",
-            diagnostics = listOf(notImplementedDiagnostic()),
-        )
+    public fun inspect(path: Path): ArtifactAnalysis = archiveAnalyzer.analyze(path)
 
     private fun notImplementedDiagnostic(): Diagnostic =
         Diagnostic(

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -22,11 +22,11 @@ class PackageBuildStatsAnalyzerTest {
     }
 
     @Test
-    fun `does not inspect local files in the API shell milestone`() {
+    fun `returns a structured input failure for a missing local jar`() {
         val result = analyzer.inspect(Path.of("example.jar"))
 
         assertEquals(ResultStatus.FAILED, result.status)
         assertEquals("example.jar", result.displayName)
-        assertEquals("ANALYSIS_NOT_IMPLEMENTED", result.diagnostics.single().code)
+        assertEquals("ARCHIVE_NOT_REGULAR_FILE", result.diagnostics.single().code)
     }
 }


### PR DESCRIPTION
## Summary

Implements PR 3 of the serial JVM-only delivery plan.

- inspects ZIP central-directory metadata before streaming entry contents
- calculates exact archive size and SHA-256 for successfully inspected JARs without extracting or executing contents
- reports reconciled compressed and expanded bytes across mutually exclusive payload categories
- rejects traversal, absolute, drive, backslash, and duplicate paths
- enforces archive, entry-count, compressed-entry, expanded-entry, total-expanded, and compression-ratio limits with ZIP64 support
- returns stable structured diagnostics for invalid, hostile, malformed, and unreadable archives
- wires real local inspection through the core API and inspect CLI command

Coordinate resolution remains intentionally unavailable until the resolver milestone. No classfile parsing, Maven resolution, Android support, extraction, class loading, or artifact publication is included.

## Deliberate scope cuts

The implementation does not add manual CRC verification, Unicode canonicalization, nested-archive accounting, partial payloads for failed inspections, hashes for rejected inputs, or a large policy surface. Those can be added later if real artifacts demonstrate a need.

## Verification

- clean Gradle build, check, test, packaging, and installDist
- normal deflated, stored, forced ZIP64, duplicate, traversal, backslash, malformed, and decompression-bomb fixtures
- archive, entry-count, compressed-entry, expanded-entry, total-expanded, and ratio limit tests
- installed CLI inspection of the built model JAR: exit 0, empty stderr, exact archive bytes, SHA-256, and reconciled payload totals
- Bundlephobia lint (0 errors; 5 existing warnings)
- recommendation tests (11 passing)
- production Next.js build

Based directly on merged PR #1059 and the latest remote bundlephobia branch.