### PR TITLE
feat(jvm): complete end-to-end coordinate analysis

### DIFF
--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -25,7 +25,7 @@ Java Format to Java sources. `jvm:check` verifies formatting and compiles Kotlin
 and Java with warnings treated as errors; javac runs with all lint warnings
 enabled.
 
-## API and CLI milestone
+## API and CLI
 
 The public model accepts only exact `groupId:artifactId:version` coordinates and
 the `jvm-runtime` target. Snapshot, range, dynamic, URL, path, repository, and
@@ -42,10 +42,26 @@ JSON analysis results are written to stdout. Usage and operational messages are
 written to stderr. Exit codes are `0` for success, `1` for an unexpected CLI
 failure, `2` for invalid usage, and `3` for a structured analysis failure.
 
-Coordinate analysis intentionally returns `ANALYSIS_NOT_IMPLEMENTED` until the
-resolver milestone. Local `inspect` analysis is available now: it hashes the JAR,
-reads its ZIP central directory, validates declared entry sizes, and then
-streams each safe entry without extracting or executing it.
+`analyze` resolves the selected JVM runtime graph, copies each unique JAR into
+an immutable SHA-256 cache, and combines archive, classfile, dependency, and
+namespace evidence. It reports direct and transitive bytes, dependency depth,
+shortest selected paths, largest transitive JARs, and conflict-selection
+diagnostics. `inspect` performs the same static JAR analysis without resolving
+dependencies.
+
+The default cache is
+`~/.cache/bundlephobia/jvm-package-build-stats`; library callers can supply an
+explicit cache directory, Gradle wrapper, and resolution timeout through
+`PackageBuildStatsConfig`. Static evidence is keyed by artifact digest and
+analyzer version. Repeated analysis therefore reuses immutable bytes and static
+results while still resolving the current requested graph.
+
+Resolution runs in a temporary empty Gradle build. It evaluates only the owned
+settings plugin and an empty build script: dependency-provided classes, tests,
+annotation processors, build plugins, and scripts are never loaded or run.
+Cancellation and timeouts stop that subprocess, and temporary build files are
+removed. If graph resolution is incomplete after some artifacts were selected,
+the result remains `partial` and preserves the completed static evidence.
 
 Inspection reports exact archive bytes and mutually exclusive byte totals for
 bytecode, metadata, services, licenses, signatures, Kotlin metadata, and other
@@ -95,5 +111,5 @@ The root coordinate remains strictly exact. Transitive dependencies may request
 ranges because Gradle normalizes them to selected exact components and preserves
 both the requested edge and selected version in the result.
 
-The public `analyze` API remains disconnected until the end-to-end orchestration
-milestone; this plugin is the isolated resolver boundary it will invoke.
+The public `analyze` API invokes this plugin through the sealed temporary build;
+the standalone task remains useful for inspecting normalized resolver evidence.

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -1,5 +1,7 @@
 package com.bundlephobia.jvm.cli
 
+import com.bundlephobia.jvm.PackageBuildStatsAnalyzer
+import com.bundlephobia.jvm.PackageBuildStatsConfig
 import com.bundlephobia.jvm.model.ResultJson
 import com.bundlephobia.jvm.model.ResultStatus
 import org.junit.jupiter.api.io.TempDir
@@ -17,19 +19,17 @@ class JvmPackageBuildStatsCliTest {
     @TempDir lateinit var tempDir: Path
 
     @Test
-    fun `analyze validates the coordinate and writes only JSON to stdout`() {
-        val execution = execute("analyze", "com.google.code.gson:gson:2.13.1")
+    fun `analyze resolves the coordinate and writes only JSON to stdout`() {
+        val execution = execute("analyze", "com.google.code.gson:gson:2.14.0")
 
-        assertEquals(ExitCode.ANALYSIS_FAILED, execution.exitCode)
+        assertEquals(ExitCode.SUCCESS, execution.exitCode, execution.stdout)
         assertEquals("", execution.stderr)
-        assertEquals(
-            "ANALYSIS_NOT_IMPLEMENTED",
-            ResultJson
-                .decodeResult(execution.stdout.trim())
-                .diagnostics
-                .single()
-                .code,
-        )
+        val result = ResultJson.decodeResult(execution.stdout.trim())
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals("com.google.code.gson:gson:2.14.0", result.coordinate.notation)
+        assertTrue(result.runtimeClosure.compressedBytes > 0)
+        assertTrue(result.artifacts.isNotEmpty())
+        assertEquals("gson-2.14.0.jar", result.directArtifact?.displayName)
     }
 
     @Test
@@ -95,12 +95,17 @@ class JvmPackageBuildStatsCliTest {
         val stdout = StringWriter()
         val stderr = StringWriter()
         val exitCode =
-            JvmPackageBuildStatsCli()
-                .execute(
-                    args = arrayOf(*args),
-                    out = PrintWriter(stdout, true),
-                    err = PrintWriter(stderr, true),
-                )
+            JvmPackageBuildStatsCli(
+                PackageBuildStatsAnalyzer(
+                    PackageBuildStatsConfig(
+                        cacheDirectory = tempDir.resolve("cache"),
+                    ),
+                ),
+            ).execute(
+                args = arrayOf(*args),
+                out = PrintWriter(stdout, true),
+                err = PrintWriter(stderr, true),
+            )
         return Execution(exitCode, stdout.toString(), stderr.toString())
     }
 

--- a/jvm-package-build-stats/core/build.gradle.kts
+++ b/jvm-package-build-stats/core/build.gradle.kts
@@ -1,7 +1,25 @@
+import org.gradle.language.jvm.tasks.ProcessResources
+
 description = "Public JVM package build statistics library"
 
 dependencies {
     api(project(":model"))
     implementation(project(":archive-analyzer"))
     implementation(project(":classfile-analyzer"))
+    implementation(project(":resolver"))
+}
+
+tasks.named<ProcessResources>("processResources") {
+    from(rootProject.file("gradlew")) {
+        into("bundled-gradle")
+    }
+    from(rootProject.file("gradlew.bat")) {
+        into("bundled-gradle")
+    }
+    from(rootProject.file("gradle/wrapper/gradle-wrapper.jar")) {
+        into("bundled-gradle/gradle/wrapper")
+    }
+    from(rootProject.file("gradle/wrapper/gradle-wrapper.properties")) {
+        into("bundled-gradle/gradle/wrapper")
+    }
 }

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AnalysisCache.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AnalysisCache.kt
@@ -1,0 +1,113 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.ArtifactAnalysis
+import com.bundlephobia.jvm.model.ResolvedArtifact
+import com.bundlephobia.jvm.model.ResultJson
+import com.bundlephobia.jvm.model.ResultStatus
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.DigestInputStream
+import java.security.MessageDigest
+import java.util.HexFormat
+
+/** Content-addressed artifact and static-analysis cache; values are immutable for a digest and analyzer version. */
+internal class AnalysisCache(
+    private val root: Path,
+    private val analyzerVersion: String,
+) {
+    fun materialize(artifact: ResolvedArtifact): Path {
+        require(artifact.digest.algorithm == "sha256") { "Unsupported digest ${artifact.digest.algorithm}" }
+        val target = digestPath(root.resolve("artifacts/sha256"), artifact.digest.value, ".jar")
+        if (Files.isRegularFile(target)) return target
+
+        Files.createDirectories(target.parent)
+        val temporary = Files.createTempFile(target.parent, ".${artifact.digest.value}.", ".tmp")
+        try {
+            Files.copy(Path.of(artifact.path), temporary, StandardCopyOption.REPLACE_EXISTING)
+            val actual = sha256(temporary)
+            check(actual == artifact.digest.value) {
+                "Artifact digest changed after resolution: expected ${artifact.digest.value}, found $actual"
+            }
+            publishImmutable(temporary, target)
+        } finally {
+            Files.deleteIfExists(temporary)
+        }
+        return target
+    }
+
+    fun analyze(
+        digest: String,
+        displayName: String,
+        artifactPath: Path,
+        inspector: (Path) -> ArtifactAnalysis,
+    ): ArtifactAnalysis {
+        val target = digestPath(root.resolve("analysis/$analyzerVersion"), digest, ".json")
+        read(target, digest)?.let { return it.copy(displayName = displayName) }
+
+        val analysis = inspector(artifactPath).copy(displayName = displayName)
+        if (analysis.status != ResultStatus.FAILED) write(target, ResultJson.encode(analysis))
+        return analysis
+    }
+
+    private fun read(
+        path: Path,
+        digest: String,
+    ): ArtifactAnalysis? {
+        if (!Files.isRegularFile(path)) return null
+        return runCatching { ResultJson.decodeArtifactAnalysis(Files.readString(path)) }
+            .getOrNull()
+            ?.takeIf { analysis -> analysis.digest?.value == digest }
+    }
+
+    private fun write(
+        target: Path,
+        value: String,
+    ) {
+        Files.createDirectories(target.parent)
+        val temporary = Files.createTempFile(target.parent, ".${target.fileName}.", ".tmp")
+        try {
+            Files.writeString(temporary, value)
+            publishImmutable(temporary, target)
+        } finally {
+            Files.deleteIfExists(temporary)
+        }
+    }
+
+    private fun publishImmutable(
+        temporary: Path,
+        target: Path,
+    ) {
+        if (Files.exists(target)) return
+        try {
+            Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE)
+        } catch (_: AtomicMoveNotSupportedException) {
+            if (!Files.exists(target)) Files.move(temporary, target)
+        } catch (_: FileAlreadyExistsException) {
+            // A concurrent analyzer published the same immutable digest first.
+        }
+    }
+
+    private fun digestPath(
+        base: Path,
+        digest: String,
+        suffix: String,
+    ): Path {
+        require(digest.matches(SHA256_PATTERN)) { "Invalid SHA-256 digest" }
+        return base.resolve(digest.take(2)).resolve("$digest$suffix")
+    }
+
+    private fun sha256(path: Path): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        Files.newInputStream(path).use { input ->
+            DigestInputStream(input, digest).use { it.transferTo(java.io.OutputStream.nullOutputStream()) }
+        }
+        return HexFormat.of().formatHex(digest.digest())
+    }
+
+    private companion object {
+        private val SHA256_PATTERN = Regex("[0-9a-f]{64}")
+    }
+}

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/GradleResolverClient.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/GradleResolverClient.kt
@@ -1,0 +1,196 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AnalysisStage
+import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.JvmResolutionResult
+import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResultJson
+import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.RetryClassification
+import com.bundlephobia.jvm.resolver.ResolverPluginClasspathAnchor
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import java.util.concurrent.TimeUnit
+
+internal fun interface ResolverClient {
+    fun resolve(coordinate: MavenCoordinate): JvmResolutionResult
+}
+
+/** Runs the owned resolver plugin in an empty build whose repositories and tasks are sealed. */
+internal class GradleResolverClient(
+    private val config: PackageBuildStatsConfig,
+) : ResolverClient {
+    override fun resolve(coordinate: MavenCoordinate): JvmResolutionResult {
+        val directory = Files.createTempDirectory("jvm-package-build-stats-")
+        return try {
+            writeBuild(directory)
+            runGradle(directory, coordinate)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            failure(coordinate, "RESOLUTION_CANCELLED", "Resolution was cancelled", RetryClassification.RETRYABLE)
+        } catch (_: Exception) {
+            failure(
+                coordinate,
+                "RESOLVER_PROCESS_FAILED",
+                "The sealed Gradle resolver could not start or return a result",
+                RetryClassification.UNKNOWN,
+            )
+        } finally {
+            deleteRecursively(directory)
+        }
+    }
+
+    private fun writeBuild(directory: Path) {
+        writeBundledWrapper(directory)
+        val classpath =
+            listOf(
+                ResolverPluginClasspathAnchor::class.java,
+                ResultJson::class.java,
+                Json::class.java,
+                KSerializer::class.java,
+                Unit::class.java,
+            ).mapNotNull { type ->
+                type.protectionDomain
+                    ?.codeSource
+                    ?.location
+                    ?.toURI()
+                    ?.let(Path::of)
+            }.map { it.toAbsolutePath().normalize() }
+                .distinct()
+
+        val files = classpath.joinToString(",\n") { path -> "            \"${path.escapeKotlinString()}\"" }
+        Files.writeString(
+            directory.resolve("settings.gradle.kts"),
+            """
+            buildscript {
+                dependencies {
+                    classpath(files(
+            $files
+                    ))
+                }
+            }
+
+            pluginManager.apply(${ResolverPluginClasspathAnchor.PLUGIN_CLASS}::class.java)
+            rootProject.name = "jvm-package-build-stats-resolution"
+            """.trimIndent() + "\n",
+        )
+        Files.writeString(
+            directory.resolve("build.gradle.kts"),
+            "// Intentionally empty: package build logic and plugins are never evaluated.\n",
+        )
+        Files.writeString(
+            directory.resolve("gradle.properties"),
+            "org.gradle.daemon=false\norg.gradle.configuration-cache=false\norg.gradle.caching=false\n",
+        )
+    }
+
+    private fun runGradle(
+        directory: Path,
+        coordinate: MavenCoordinate,
+    ): JvmResolutionResult {
+        val process =
+            ProcessBuilder(
+                gradleCommand(directory),
+                "--no-daemon",
+                "--console=plain",
+                ResolverPluginClasspathAnchor.RESOLVE_TASK_NAME,
+                "-P${ResolverPluginClasspathAnchor.COORDINATE_PROPERTY}=${coordinate.notation}",
+            ).directory(directory.toFile())
+                .redirectOutput(directory.resolve("gradle.stdout").toFile())
+                .redirectError(directory.resolve("gradle.stderr").toFile())
+                .start()
+
+        val completed =
+            try {
+                process.waitFor(config.resolutionTimeoutMilliseconds, TimeUnit.MILLISECONDS)
+            } catch (error: InterruptedException) {
+                stop(process)
+                throw error
+            }
+        if (!completed) {
+            stop(process)
+            return failure(
+                coordinate,
+                "RESOLUTION_TIMEOUT",
+                "Resolution exceeded ${config.resolutionTimeoutMilliseconds} ms",
+                RetryClassification.RETRYABLE,
+            )
+        }
+
+        val resultFile = directory.resolve("build/jvm-resolver/result.json")
+        if (Files.isRegularFile(resultFile)) return ResultJson.decodeResolution(Files.readString(resultFile))
+        return failure(
+            coordinate,
+            "RESOLVER_PROCESS_FAILED",
+            "The sealed Gradle resolver exited with status ${process.exitValue()} without a result",
+            RetryClassification.UNKNOWN,
+        )
+    }
+
+    private fun gradleCommand(directory: Path): String {
+        config.gradleExecutable?.let { return it.toAbsolutePath().normalize().toString() }
+        val executable = if (isWindows()) directory.resolve("gradlew.bat") else directory.resolve("gradlew")
+        return executable.toString()
+    }
+
+    private fun writeBundledWrapper(directory: Path) {
+        BUNDLED_WRAPPER_FILES.forEach { resource ->
+            val target = directory.resolve(resource.removePrefix("bundled-gradle/"))
+            Files.createDirectories(target.parent)
+            val input = requireNotNull(javaClass.classLoader.getResourceAsStream(resource)) { "Missing $resource" }
+            input.use { Files.copy(it, target) }
+        }
+        if (!isWindows()) check(directory.resolve("gradlew").toFile().setExecutable(true)) { "Could not make Gradle wrapper executable" }
+    }
+
+    private fun failure(
+        coordinate: MavenCoordinate,
+        code: String,
+        summary: String,
+        retry: RetryClassification,
+    ): JvmResolutionResult =
+        JvmResolutionResult(
+            status = ResultStatus.FAILED,
+            resolution = ResolutionStats(coordinate),
+            diagnostics =
+                listOf(
+                    Diagnostic(
+                        code = code,
+                        summary = summary,
+                        stage = AnalysisStage.RESOLUTION,
+                        retry = retry,
+                    ),
+                ),
+        )
+
+    private fun deleteRecursively(directory: Path) {
+        if (!Files.exists(directory)) return
+        Files.walk(directory).use { paths ->
+            paths.sorted(Comparator.reverseOrder()).forEach { path -> runCatching { Files.deleteIfExists(path) } }
+        }
+    }
+
+    private fun stop(process: Process) {
+        process.destroy()
+        if (!process.waitFor(PROCESS_SHUTDOWN_SECONDS, TimeUnit.SECONDS)) process.destroyForcibly()
+    }
+
+    private fun Path.escapeKotlinString(): String = toString().replace("\\", "\\\\").replace("\"", "\\\"")
+
+    private companion object {
+        private const val PROCESS_SHUTDOWN_SECONDS = 5L
+        private val BUNDLED_WRAPPER_FILES =
+            listOf(
+                "bundled-gradle/gradlew",
+                "bundled-gradle/gradlew.bat",
+                "bundled-gradle/gradle/wrapper/gradle-wrapper.jar",
+                "bundled-gradle/gradle/wrapper/gradle-wrapper.properties",
+            )
+
+        private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+    }
+}

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -5,54 +5,282 @@ import com.bundlephobia.jvm.classfile.JarClassfileAnalyzer
 import com.bundlephobia.jvm.model.AnalysisStage
 import com.bundlephobia.jvm.model.AnalyzeRequest
 import com.bundlephobia.jvm.model.ArtifactAnalysis
+import com.bundlephobia.jvm.model.DependencyPath
 import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.DiagnosticSeverity
+import com.bundlephobia.jvm.model.JvmResolutionResult
+import com.bundlephobia.jvm.model.MavenCoordinate
 import com.bundlephobia.jvm.model.PackageBuildStatsResult
 import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResolvedArtifact
 import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.RetryClassification
+import com.bundlephobia.jvm.model.RuntimeArtifactSummary
+import com.bundlephobia.jvm.model.RuntimeClosureStats
+import com.bundlephobia.jvm.model.TimingStats
 import com.bundlephobia.jvm.model.ToolchainManifest
 import java.nio.file.Path
+import java.util.ArrayDeque
+import kotlin.time.measureTimedValue
 
-public class PackageBuildStatsAnalyzer {
-    private val archiveAnalyzer = JarArchiveAnalyzer()
-    private val classfileAnalyzer = JarClassfileAnalyzer()
+/** Stable entry point for local JAR inspection and exact Maven coordinate analysis. */
+public class PackageBuildStatsAnalyzer
+    @JvmOverloads
+    constructor(
+        public val config: PackageBuildStatsConfig = PackageBuildStatsConfig(),
+    ) {
+        private val archiveAnalyzer = JarArchiveAnalyzer()
+        private val classfileAnalyzer = JarClassfileAnalyzer()
+        private var resolverClient: ResolverClient = GradleResolverClient(config)
 
-    public fun analyze(request: AnalyzeRequest): PackageBuildStatsResult =
-        PackageBuildStatsResult(
-            status = ResultStatus.FAILED,
-            coordinate = request.coordinate,
-            target = request.target,
-            toolchain = currentToolchain(),
-            resolution = ResolutionStats(request.coordinate),
-            diagnostics = listOf(notImplementedDiagnostic()),
+        internal constructor(
+            config: PackageBuildStatsConfig,
+            resolverClient: ResolverClient,
+        ) : this(config) {
+            this.resolverClient = resolverClient
+        }
+
+        /** Resolves and statically analyzes one exact JVM runtime dependency closure. */
+        public fun analyze(request: AnalyzeRequest): PackageBuildStatsResult {
+            val totalStart = System.nanoTime()
+            val stageTimings = linkedMapOf<String, Long>()
+            val diagnostics = mutableListOf<Diagnostic>()
+
+            val resolutionTimed = measureTimedValue { resolverClient.resolve(request.coordinate) }
+            stageTimings["resolution"] = resolutionTimed.duration.inWholeMilliseconds
+            val resolverResult = resolutionTimed.value
+            diagnostics += resolverResult.diagnostics
+
+            val cache = AnalysisCache(config.cacheDirectory, STATIC_ANALYZER_VERSION)
+            val evidence = mutableListOf<ArtifactEvidence>()
+            val analysisTimed =
+                measureTimedValue {
+                    resolverResult.resolution.artifacts
+                        .asSequence()
+                        .filter { artifact -> artifact.extension == "jar" }
+                        .distinctBy { artifact -> artifact.digest.value }
+                        .sortedBy { artifact -> artifact.digest.value }
+                        .forEach { artifact ->
+                            analyzeArtifact(cache, artifact, diagnostics)?.let(evidence::add)
+                        }
+                }
+            stageTimings["artifact-analysis"] = analysisTimed.duration.inWholeMilliseconds
+
+            val assemblyTimed =
+                measureTimedValue {
+                    assemble(
+                        request = request,
+                        resolverResult = resolverResult,
+                        evidence = evidence,
+                        diagnostics = diagnostics,
+                    )
+                }
+            stageTimings["assembly"] = assemblyTimed.duration.inWholeMilliseconds
+            return assemblyTimed.value.copy(
+                timings =
+                    TimingStats(
+                        totalMilliseconds = elapsedMilliseconds(totalStart),
+                        stagesMilliseconds = stageTimings,
+                    ),
+            )
+        }
+
+        /** Inspects a local JAR without resolving dependencies or loading any classes. */
+        public fun inspect(path: Path): ArtifactAnalysis {
+            val archive = archiveAnalyzer.analyze(path)
+            if (archive.status != ResultStatus.COMPLETE) return archive
+
+            val classfiles = classfileAnalyzer.analyze(path)
+            return archive.copy(
+                status = if (classfiles.diagnostics.isEmpty()) ResultStatus.COMPLETE else ResultStatus.PARTIAL,
+                namespaces = classfiles.namespaces,
+                classfiles = classfiles.stats,
+                diagnostics = classfiles.diagnostics,
+            )
+        }
+
+        private fun analyzeArtifact(
+            cache: AnalysisCache,
+            artifact: ResolvedArtifact,
+            diagnostics: MutableList<Diagnostic>,
+        ): ArtifactEvidence? =
+            try {
+                val cachedPath = cache.materialize(artifact)
+                val analysis =
+                    cache.analyze(
+                        digest = artifact.digest.value,
+                        displayName = artifact.fileName,
+                        artifactPath = cachedPath,
+                        inspector = ::inspect,
+                    )
+                diagnostics += analysis.diagnostics
+                ArtifactEvidence(artifact, analysis)
+            } catch (_: Exception) {
+                diagnostics +=
+                    Diagnostic(
+                        code = "ARTIFACT_ANALYSIS_FAILED",
+                        summary = "Could not cache or analyze ${artifact.coordinate.notation} (${artifact.fileName})",
+                        stage = AnalysisStage.ARCHIVE_ANALYSIS,
+                        retry = RetryClassification.UNKNOWN,
+                    )
+                null
+            }
+
+        private fun assemble(
+            request: AnalyzeRequest,
+            resolverResult: JvmResolutionResult,
+            evidence: List<ArtifactEvidence>,
+            diagnostics: MutableList<Diagnostic>,
+        ): PackageBuildStatsResult {
+            diagnostics += conflictDiagnostics(resolverResult.resolution)
+            val analysesByDigest = evidence.associateBy { item -> item.artifact.digest.value }
+            val enrichedResolution =
+                resolverResult.resolution.copy(
+                    components =
+                        resolverResult.resolution.components.map { component ->
+                            component.copy(
+                                artifacts =
+                                    resolverResult.resolution.artifacts
+                                        .filter { artifact -> artifact.coordinate == component.coordinate }
+                                        .mapNotNull { artifact -> analysesByDigest[artifact.digest.value]?.analysis }
+                                        .sortedBy(ArtifactAnalysis::displayName),
+                            )
+                        },
+                )
+            val uniqueAnalyses = evidence.map { it.analysis }.sortedBy { it.digest?.value ?: "" }
+            val directArtifact =
+                evidence
+                    .filter { item -> item.artifact.coordinate == request.coordinate }
+                    .minByOrNull { item -> item.artifact.fileName }
+                    ?.analysis
+            val status = finalStatus(resolverResult, uniqueAnalyses, directArtifact)
+
+            return PackageBuildStatsResult(
+                status = status,
+                coordinate = request.coordinate,
+                target = request.target,
+                toolchain = currentToolchain(),
+                resolution = enrichedResolution,
+                artifacts = uniqueAnalyses,
+                directArtifact = directArtifact,
+                runtimeClosure = closureStats(request.coordinate, enrichedResolution, evidence),
+                diagnostics = diagnostics.distinctBy { it.code to it.summary }.sortedWith(compareBy(Diagnostic::code, Diagnostic::summary)),
+            )
+        }
+
+        private fun finalStatus(
+            resolverResult: JvmResolutionResult,
+            analyses: List<ArtifactAnalysis>,
+            directArtifact: ArtifactAnalysis?,
+        ): ResultStatus {
+            if (analyses.isEmpty() || directArtifact == null) return ResultStatus.FAILED
+            val allStaticComplete = analyses.all { analysis -> analysis.status == ResultStatus.COMPLETE }
+            return if (resolverResult.status == ResultStatus.COMPLETE && allStaticComplete) {
+                ResultStatus.COMPLETE
+            } else {
+                ResultStatus.PARTIAL
+            }
+        }
+
+        private fun closureStats(
+            requested: MavenCoordinate,
+            resolution: ResolutionStats,
+            evidence: List<ArtifactEvidence>,
+        ): RuntimeClosureStats {
+            val directBytes =
+                evidence.filter { item -> item.artifact.coordinate == requested }.sumOf { item -> item.analysis.archiveBytes ?: 0 }
+            val transitiveBytes =
+                evidence.filter { item -> item.artifact.coordinate != requested }.sumOf { item -> item.analysis.archiveBytes ?: 0 }
+            val paths = shortestPaths(requested, resolution)
+            val largest =
+                evidence
+                    .filter { item -> item.artifact.coordinate != requested }
+                    .map { item ->
+                        RuntimeArtifactSummary(
+                            coordinate = item.artifact.coordinate,
+                            fileName = item.artifact.fileName,
+                            digest = item.artifact.digest,
+                            archiveBytes = item.analysis.archiveBytes ?: 0,
+                            expandedBytes = item.analysis.expandedBytes ?: 0,
+                        )
+                    }.sortedWith(compareByDescending(RuntimeArtifactSummary::archiveBytes).thenBy { it.coordinate.notation })
+                    .take(LARGEST_ARTIFACT_LIMIT)
+
+            return RuntimeClosureStats(
+                compressedBytes = directBytes + transitiveBytes,
+                expandedBytes = evidence.sumOf { item -> item.analysis.expandedBytes ?: 0 },
+                directArtifactBytes = directBytes,
+                transitiveArtifactBytes = transitiveBytes,
+                components =
+                    resolution.components
+                        .map { it.coordinate }
+                        .distinct()
+                        .size,
+                artifacts = evidence.size,
+                dependencyDepth = paths.maxOfOrNull(DependencyPath::depth) ?: 0,
+                shortestPaths = paths,
+                largestTransitiveArtifacts = largest,
+            )
+        }
+
+        private fun shortestPaths(
+            requested: MavenCoordinate,
+            resolution: ResolutionStats,
+        ): List<DependencyPath> {
+            if (resolution.components.none { component -> component.coordinate == requested }) return emptyList()
+            val adjacency =
+                resolution.edges
+                    .filter { edge -> edge.selected != null }
+                    .groupBy({ edge -> edge.from }, { edge -> requireNotNull(edge.selected) })
+                    .mapValues { (_, coordinates) -> coordinates.distinct().sortedBy(MavenCoordinate::notation) }
+            val paths = linkedMapOf(requested to listOf(requested))
+            val queue = ArrayDeque<MavenCoordinate>().apply { add(requested) }
+            while (queue.isNotEmpty()) {
+                val from = queue.removeFirst()
+                adjacency[from].orEmpty().forEach { selected ->
+                    if (selected !in paths) {
+                        paths[selected] = requireNotNull(paths[from]) + selected
+                        queue.add(selected)
+                    }
+                }
+            }
+            return paths
+                .map { (coordinate, path) -> DependencyPath(coordinate, path.size - 1, path) }
+                .sortedWith(compareBy(DependencyPath::depth, { it.coordinate.notation }))
+        }
+
+        private fun conflictDiagnostics(resolution: ResolutionStats): List<Diagnostic> =
+            resolution.components
+                .filter { component -> component.selectionReasons.any { reason -> reason.startsWith("conflict_resolution:") } }
+                .map { component ->
+                    Diagnostic(
+                        code = "DEPENDENCY_CONFLICT_SELECTED",
+                        summary = "Gradle selected ${component.coordinate.notation} after dependency conflict resolution",
+                        stage = AnalysisStage.RESOLUTION,
+                        severity = DiagnosticSeverity.INFO,
+                    )
+                }
+
+        private fun currentToolchain(): ToolchainManifest =
+            ToolchainManifest(
+                generation = "jvm-2026-08-g1",
+                analyzerVersion = "0.0.0-SNAPSHOT+$STATIC_ANALYZER_VERSION",
+                jdkVersion = System.getProperty("java.version"),
+                jdkVendor = System.getProperty("java.vendor"),
+                kotlinVersion = "2.4.10",
+                gradleVersion = "9.5.1",
+            )
+
+        private fun elapsedMilliseconds(start: Long): Long = (System.nanoTime() - start) / NANOS_PER_MILLISECOND
+
+        private data class ArtifactEvidence(
+            val artifact: ResolvedArtifact,
+            val analysis: ArtifactAnalysis,
         )
 
-    public fun inspect(path: Path): ArtifactAnalysis {
-        val archive = archiveAnalyzer.analyze(path)
-        if (archive.status != ResultStatus.COMPLETE) return archive
-
-        val classfiles = classfileAnalyzer.analyze(path)
-        return archive.copy(
-            status = if (classfiles.diagnostics.isEmpty()) ResultStatus.COMPLETE else ResultStatus.PARTIAL,
-            namespaces = classfiles.namespaces,
-            classfiles = classfiles.stats,
-            diagnostics = classfiles.diagnostics,
-        )
+        private companion object {
+            private const val STATIC_ANALYZER_VERSION = "static-v1"
+            private const val LARGEST_ARTIFACT_LIMIT = 10
+            private const val NANOS_PER_MILLISECOND = 1_000_000
+        }
     }
-
-    private fun notImplementedDiagnostic(): Diagnostic =
-        Diagnostic(
-            code = "ANALYSIS_NOT_IMPLEMENTED",
-            summary = "Analysis behavior is not available in this milestone",
-            stage = AnalysisStage.INPUT,
-        )
-
-    private fun currentToolchain(): ToolchainManifest =
-        ToolchainManifest(
-            generation = "jvm-2026-08-g1",
-            analyzerVersion = "0.0.0-SNAPSHOT",
-            jdkVersion = System.getProperty("java.version"),
-            jdkVendor = System.getProperty("java.vendor"),
-            kotlinVersion = "2.4.10",
-            gradleVersion = "9.5.1",
-        )
-}

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsConfig.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsConfig.kt
@@ -1,0 +1,25 @@
+package com.bundlephobia.jvm
+
+import java.nio.file.Path
+
+/** Runtime controls for coordinate resolution and immutable analysis caching. */
+public data class PackageBuildStatsConfig
+    @JvmOverloads
+    constructor(
+        /** Persistent cache root. Callers running in workers should provide an explicit directory. */
+        public val cacheDirectory: Path = defaultCacheDirectory(),
+        /** Gradle executable or wrapper. When absent, the analyzer uses its bundled pinned wrapper. */
+        public val gradleExecutable: Path? = null,
+        /** Hard wall-clock limit for the sealed Gradle resolution process. */
+        public val resolutionTimeoutMilliseconds: Long = 120_000,
+    ) {
+        init {
+            require(resolutionTimeoutMilliseconds > 0) { "resolutionTimeoutMilliseconds must be positive" }
+        }
+
+        public companion object {
+            @JvmStatic
+            public fun defaultCacheDirectory(): Path =
+                Path.of(System.getProperty("user.home"), ".cache", "bundlephobia", "jvm-package-build-stats")
+        }
+    }

--- a/jvm-package-build-stats/core/src/test/java/com/bundlephobia/jvm/JavaApiCompatibilityTest.java
+++ b/jvm-package-build-stats/core/src/test/java/com/bundlephobia/jvm/JavaApiCompatibilityTest.java
@@ -1,6 +1,7 @@
 package com.bundlephobia.jvm;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.bundlephobia.jvm.model.AnalyzeRequest;
 import com.bundlephobia.jvm.model.MavenCoordinate;
@@ -16,7 +17,7 @@ class JavaApiCompatibilityTest {
 
     PackageBuildStatsResult result = new PackageBuildStatsAnalyzer().analyze(request);
 
-    assertEquals(ResultStatus.FAILED, result.getStatus());
+    assertNotEquals(ResultStatus.FAILED, result.getStatus());
     assertEquals(coordinate, result.getCoordinate());
   }
 }

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -1,35 +1,159 @@
 package com.bundlephobia.jvm
 
 import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.ArtifactDigest
+import com.bundlephobia.jvm.model.DependencyEdge
+import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.JvmResolutionResult
 import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResolvedArtifact
+import com.bundlephobia.jvm.model.ResolvedComponent
 import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.TimingStats
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.security.MessageDigest
+import java.util.HexFormat
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PackageBuildStatsAnalyzerTest {
     @TempDir lateinit var tempDir: Path
 
-    private val analyzer = PackageBuildStatsAnalyzer()
+    @Test
+    fun `aggregates the unique runtime closure and deterministic shortest paths`() {
+        val root = MavenCoordinate.parse("example:root:1.0")
+        val middle = MavenCoordinate.parse("example:middle:1.0")
+        val leaf = MavenCoordinate.parse("example:leaf:1.0")
+        val baseResolution =
+            resolution(
+                requested = root,
+                coordinates = listOf(root, middle, leaf),
+                edges =
+                    listOf(
+                        DependencyEdge(root, middle.notation, middle),
+                        DependencyEdge(middle, leaf.notation, leaf),
+                    ),
+            )
+        val resolution =
+            baseResolution.copy(
+                resolution =
+                    baseResolution.resolution.copy(
+                        components =
+                            baseResolution.resolution.components.map { component ->
+                                if (component.coordinate == middle) {
+                                    component.copy(selectionReasons = listOf("conflict_resolution:selected by rule"))
+                                } else {
+                                    component
+                                }
+                            },
+                    ),
+            )
+        val analyzer = analyzer(resolution)
+
+        val result = analyzer.analyze(AnalyzeRequest(root))
+
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals(3, result.runtimeClosure.artifacts)
+        assertEquals(3, result.runtimeClosure.components)
+        assertEquals(2, result.runtimeClosure.dependencyDepth)
+        assertEquals(
+            listOf(root, middle, leaf),
+            result.runtimeClosure.shortestPaths
+                .last()
+                .path,
+        )
+        assertEquals(
+            result.runtimeClosure.compressedBytes,
+            result.runtimeClosure.directArtifactBytes + result.runtimeClosure.transitiveArtifactBytes,
+        )
+        assertEquals(2, result.runtimeClosure.largestTransitiveArtifacts.size)
+        assertEquals(
+            1,
+            result.resolution.components
+                .single { it.coordinate == root }
+                .artifacts.size,
+        )
+        assertTrue(result.diagnostics.any { diagnostic -> diagnostic.code == "DEPENDENCY_CONFLICT_SELECTED" })
+    }
 
     @Test
-    fun `returns an explicit failed result until coordinate analysis is implemented`() {
-        val coordinate = MavenCoordinate.parse("com.google.code.gson:gson:2.13.1")
+    fun `repeated analysis uses immutable caches and returns identical normalized evidence`() {
+        val coordinate = MavenCoordinate.parse("example:cached:1.0")
+        val resolution = resolution(coordinate, listOf(coordinate))
+        val analyzer = analyzer(resolution)
 
-        val result = analyzer.analyze(AnalyzeRequest(coordinate))
+        val first = analyzer.analyze(AnalyzeRequest(coordinate))
+        resolution.resolution.artifacts.forEach { Files.delete(Path.of(it.path)) }
+        val second = analyzer.analyze(AnalyzeRequest(coordinate))
+
+        assertEquals(ResultStatus.COMPLETE, second.status)
+        assertEquals(first.copy(timings = TimingStats()), second.copy(timings = TimingStats()))
+        assertTrue(Files.walk(tempDir.resolve("cache/analysis")).use { paths -> paths.anyMatch(Files::isRegularFile) })
+    }
+
+    @Test
+    fun `resolution failures preserve completed static evidence`() {
+        val coordinate = MavenCoordinate.parse("example:partial:1.0")
+        val complete = resolution(coordinate, listOf(coordinate))
+        val failed =
+            complete.copy(
+                status = ResultStatus.FAILED,
+                diagnostics =
+                    listOf(
+                        Diagnostic(
+                            code = "UNRESOLVED_DEPENDENCY",
+                            summary = "A transitive dependency was unavailable",
+                            stage = com.bundlephobia.jvm.model.AnalysisStage.RESOLUTION,
+                        ),
+                    ),
+            )
+
+        val result = analyzer(failed).analyze(AnalyzeRequest(coordinate))
+
+        assertEquals(ResultStatus.PARTIAL, result.status)
+        assertEquals(1, result.artifacts.size)
+        assertEquals(ResultStatus.COMPLETE, result.directArtifact?.status)
+        assertEquals("UNRESOLVED_DEPENDENCY", result.diagnostics.single().code)
+    }
+
+    @Test
+    fun `resolver timeouts are retryable structured failures`() {
+        val executable = tempDir.resolve("slow-gradle")
+        Files.writeString(executable, "#!/bin/sh\nsleep 2\n")
+        Files.setPosixFilePermissions(
+            executable,
+            setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+            ),
+        )
+        val coordinate = MavenCoordinate.parse("example:timeout:1.0")
+
+        val result =
+            GradleResolverClient(
+                PackageBuildStatsConfig(
+                    cacheDirectory = tempDir.resolve("cache"),
+                    gradleExecutable = executable,
+                    resolutionTimeoutMilliseconds = 25,
+                ),
+            ).resolve(coordinate)
 
         assertEquals(ResultStatus.FAILED, result.status)
-        assertEquals(coordinate, result.coordinate)
-        assertEquals("ANALYSIS_NOT_IMPLEMENTED", result.diagnostics.single().code)
+        assertEquals("RESOLUTION_TIMEOUT", result.diagnostics.single().code)
+        assertEquals(com.bundlephobia.jvm.model.RetryClassification.RETRYABLE, result.diagnostics.single().retry)
     }
 
     @Test
     fun `returns a structured input failure for a missing local jar`() {
-        val result = analyzer.inspect(Path.of("example.jar"))
+        val result = PackageBuildStatsAnalyzer().inspect(Path.of("example.jar"))
 
         assertEquals(ResultStatus.FAILED, result.status)
         assertEquals("example.jar", result.displayName)
@@ -47,11 +171,62 @@ class PackageBuildStatsAnalyzerTest {
             output.closeEntry()
         }
 
-        val result = analyzer.inspect(jar)
+        val result = PackageBuildStatsAnalyzer().inspect(jar)
 
         assertEquals(ResultStatus.COMPLETE, result.status)
         assertEquals(1, result.classfiles?.analyzedClasses)
         assertEquals("com.bundlephobia.jvm", result.namespaces.single().name)
         assertEquals(classBytes.size.toLong(), result.namespaces.single().classBytes)
     }
+
+    private fun analyzer(resolution: JvmResolutionResult): PackageBuildStatsAnalyzer =
+        PackageBuildStatsAnalyzer(
+            config = PackageBuildStatsConfig(cacheDirectory = tempDir.resolve("cache")),
+            resolverClient = ResolverClient { resolution },
+        )
+
+    private fun resolution(
+        requested: MavenCoordinate,
+        coordinates: List<MavenCoordinate>,
+        edges: List<DependencyEdge> = emptyList(),
+    ): JvmResolutionResult {
+        val artifacts =
+            coordinates.mapIndexed { index, coordinate ->
+                val path = jar("${coordinate.artifactId}.jar", index + 1)
+                ResolvedArtifact(
+                    coordinate = coordinate,
+                    fileName = path.fileName.toString(),
+                    path = path.toString(),
+                    extension = "jar",
+                    variant = "runtime",
+                    digest = ArtifactDigest(value = sha256(path)),
+                )
+            }
+        return JvmResolutionResult(
+            status = ResultStatus.COMPLETE,
+            resolution =
+                ResolutionStats(
+                    requested = requested,
+                    components = coordinates.map { coordinate -> ResolvedComponent(coordinate, direct = coordinate == requested) },
+                    edges = edges,
+                    artifacts = artifacts,
+                    repositories = listOf("maven-central", "google-maven"),
+                ),
+        )
+    }
+
+    private fun jar(
+        name: String,
+        size: Int,
+    ): Path {
+        val jar = tempDir.resolve(name)
+        ZipOutputStream(Files.newOutputStream(jar)).use { output ->
+            output.putNextEntry(ZipEntry("example/resource-$size.txt"))
+            output.write(ByteArray(size) { size.toByte() })
+            output.closeEntry()
+        }
+        return jar
+    }
+
+    private fun sha256(path: Path): String = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path)))
 }

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
@@ -249,13 +249,40 @@ public data class JvmResolutionResult(
 
 @Serializable
 public data class RuntimeClosureStats(
+    /** Bytes occupied by every unique runtime JAR, including the requested artifact. */
     public val compressedBytes: Long = 0,
+    /** Sum of uncompressed entry bytes across every unique runtime JAR. */
     public val expandedBytes: Long = 0,
+    /** Archive bytes belonging to the requested component. */
     public val directArtifactBytes: Long = 0,
+    /** Archive bytes belonging to selected transitive components. */
     public val transitiveArtifactBytes: Long = 0,
     public val components: Int = 0,
     public val artifacts: Int = 0,
+    /** Maximum shortest-path distance from the requested component. */
     public val dependencyDepth: Int = 0,
+    /** Deterministic shortest path to every reachable selected component. */
+    public val shortestPaths: List<DependencyPath> = emptyList(),
+    /** Up to ten largest transitive runtime JARs, ordered by archive bytes. */
+    public val largestTransitiveArtifacts: List<RuntimeArtifactSummary> = emptyList(),
+)
+
+/** A shortest selected-dependency path beginning at the requested component. */
+@Serializable
+public data class DependencyPath(
+    public val coordinate: MavenCoordinate,
+    public val depth: Int,
+    public val path: List<MavenCoordinate>,
+)
+
+/** Size summary for a runtime artifact without exposing a machine-local path. */
+@Serializable
+public data class RuntimeArtifactSummary(
+    public val coordinate: MavenCoordinate,
+    public val fileName: String,
+    public val digest: ArtifactDigest,
+    public val archiveBytes: Long,
+    public val expandedBytes: Long,
 )
 
 @Serializable

--- a/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/ResolverPluginClasspathAnchor.kt
+++ b/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/ResolverPluginClasspathAnchor.kt
@@ -1,0 +1,12 @@
+package com.bundlephobia.jvm.resolver
+
+/**
+ * Locates the resolver plugin artifact without loading Gradle API types in library or CLI processes.
+ *
+ * The generated, sealed Gradle build uses this class's code source as its plugin classpath.
+ */
+public object ResolverPluginClasspathAnchor {
+    public const val PLUGIN_CLASS: String = "com.bundlephobia.jvm.resolver.JvmRuntimeResolverPlugin"
+    public const val RESOLVE_TASK_NAME: String = "resolveJvmRuntime"
+    public const val COORDINATE_PROPERTY: String = "jvmResolver.coordinate"
+}


### PR DESCRIPTION
## Plain-language explanation

Given an exact Maven coordinate, the public library and CLI can now answer the full question: which JVM runtime JARs would Gradle select, how large are they on disk and when expanded, what packages and public APIs do they contain, and how did each dependency enter the graph? The analyzer resolves the graph in an empty sealed build, copies every unique JAR into an immutable SHA-256 cache, runs the existing static analyzers once per digest, and combines the evidence into one result. Package code, tests, processors, plugins, and scripts are never loaded or executed.

## JavaScript/npm analogy

This is roughly the JVM equivalent of taking an exact npm package version, computing its production dependency tree, caching each unique tarball by integrity hash, inspecting the files and exports in every package, and returning both per-package evidence and whole-tree totals. Gradle plays the role of the npm dependency and conditional-export resolver; Maven coordinates replace npm package names; JARs replace published tarballs; and the classfile analyzer is analogous to inspecting built JavaScript exports without importing or running the package.

## Summary

- connect Gradle runtime resolution, archive inspection, classfile analysis, and result assembly through PackageBuildStatsAnalyzer.analyze
- complete the CLI analyze GROUP:ARTIFACT:VERSION path
- analyze each unique selected JAR once by SHA-256 and attach its evidence back to resolved components
- report direct, transitive, and unique closure bytes, dependency depth, deterministic shortest paths, largest transitive artifacts, and conflict-selection diagnostics
- add immutable artifact and static-analysis caches keyed by digest and analyzer version
- bundle the pinned Gradle 9.5.1 wrapper so the packaged CLI works outside the repository
- add resolution timeouts, interruption cancellation, subprocess cleanup, retry classifications, and partial results that retain completed static evidence

## Dependency approach

This adds no new third-party library. Gradle remains the canonical variant-aware resolver; ASM remains the canonical classfile reader; Kotlin serialization remains the existing stable JSON boundary; and JDK process, ZIP, hashing, and filesystem APIs cover the small orchestration and immutable-cache policy that is specific to this product.

## Testing

- unit coverage for closure totals, paths, conflict diagnostics, cache reuse, retryable timeouts, and preservation of static evidence after resolution failures
- Java consumer compatibility coverage
- real CLI integration against com.google.code.gson:gson:2.14.0
- packaged distribution launched from a temporary directory outside the checkout and successfully analyzed Gson using its bundled wrapper
- ./gradlew spotlessApply check test build --console=plain
- yarn jvm:check
- yarn jvm:test
- yarn jvm:build
- repository pre-commit lint: 0 errors, 5 existing warnings

## Scope

This is PR 6 of the serial JVM-only plan. Publication, the broader compatibility sample, hostile graph hardening, reproducibility promotion checks, and final API and CLI methodology documentation remain PR 7. Android and R8 work remains deferred.