### PR TITLE
feat(jvm): harden release and Maven publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,16 @@ jobs:
       - name: Build JVM package workspace
         working-directory: jvm-package-build-stats
         run: ./gradlew build --no-daemon
+      - name: Verify Maven publication layout
+        working-directory: jvm-package-build-stats
+        run: |
+          ./gradlew :core:publishMavenPublicationToReleaseTestRepository :cli:publishMavenPublicationToReleaseTestRepository --no-daemon
+          CORE_JAR=$(find build/release-test-repository/com/bundlephobia/jvm-package-build-stats-core/0.1.0-SNAPSHOT -name '*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar' | head -1)
+          CLI_JAR=$(find build/release-test-repository/com/bundlephobia/jvm-package-build-stats-cli/0.1.0-SNAPSHOT -name '*.jar' ! -name '*-sources.jar' ! -name '*-javadoc.jar' | head -1)
+          CORE_POM=$(find build/release-test-repository/com/bundlephobia/jvm-package-build-stats-core/0.1.0-SNAPSHOT -name '*.pom' | head -1)
+          test -n "$CORE_JAR" && test -n "$CLI_JAR" && test -n "$CORE_POM"
+          jar tf "$CORE_JAR" | grep -q 'com/bundlephobia/jvm/PackageBuildStatsAnalyzer.class'
+          jar tf "$CORE_JAR" | grep -q 'org/objectweb/asm/ClassReader.class'
+          jar tf "$CLI_JAR" | grep -q 'com/bundlephobia/jvm/cli/MainKt.class'
+          java -jar "$CLI_JAR" --help | grep -q 'Analyze published JVM package size'
+          ! grep -q '<dependencies>' "$CORE_POM"

--- a/.github/workflows/jvm-release.yml
+++ b/.github/workflows/jvm-release.yml
@@ -1,0 +1,88 @@
+name: Release JVM package build stats
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Maven release version, for example 0.1.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: jvm-package-build-stats-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/bundlephobia'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: maven-central
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate release version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo 'Version must use stable semantic version form such as 0.1.0' >&2
+            exit 2
+          fi
+      - name: Use JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v6
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+      - name: Build and test release
+        working-directory: jvm-package-build-stats
+        run: ./gradlew clean build --no-daemon -PjvmPackageBuildStatsVersion=${{ inputs.version }}
+      - name: Verify reproducible release archives
+        working-directory: jvm-package-build-stats
+        run: |
+          ./gradlew clean :core:shadowJar :cli:shadowJar --rerun-tasks --no-build-cache --no-daemon -PjvmPackageBuildStatsVersion=${{ inputs.version }}
+          sha256sum core/build/libs/core-${{ inputs.version }}.jar cli/build/libs/cli-${{ inputs.version }}.jar > "$RUNNER_TEMP/jvm-release.sha256"
+          ./gradlew clean :core:shadowJar :cli:shadowJar --rerun-tasks --no-build-cache --no-daemon -PjvmPackageBuildStatsVersion=${{ inputs.version }}
+          sha256sum --check "$RUNNER_TEMP/jvm-release.sha256"
+      - name: Publish signed artifacts to Maven Central
+        working-directory: jvm-package-build-stats
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.MAVEN_SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
+        run: |
+          ./gradlew :core:publishAndReleaseToMavenCentral :cli:publishAndReleaseToMavenCentral --no-daemon -PjvmPackageBuildStatsVersion=${{ inputs.version }}
+      - name: Verify released artifacts and checksums
+        working-directory: jvm-package-build-stats
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          VERIFY_DIR="$RUNNER_TEMP/jvm-central-verify"
+          mkdir -p "$VERIFY_DIR"
+          cp "core/build/libs/core-$RELEASE_VERSION.jar" "$VERIFY_DIR/expected-core.jar"
+          cp "cli/build/libs/cli-$RELEASE_VERSION.jar" "$VERIFY_DIR/expected-cli.jar"
+          for attempt in $(seq 1 60); do
+            CORE_URL="https://repo1.maven.org/maven2/com/bundlephobia/jvm-package-build-stats-core/$RELEASE_VERSION/jvm-package-build-stats-core-$RELEASE_VERSION.jar"
+            CLI_URL="https://repo1.maven.org/maven2/com/bundlephobia/jvm-package-build-stats-cli/$RELEASE_VERSION/jvm-package-build-stats-cli-$RELEASE_VERSION.jar"
+            if curl --fail --silent --show-error "$CORE_URL" --output "$VERIFY_DIR/actual-core.jar" && curl --fail --silent --show-error "$CLI_URL" --output "$VERIFY_DIR/actual-cli.jar"; then
+              break
+            fi
+            sleep 30
+          done
+          test -s "$VERIFY_DIR/actual-core.jar" && test -s "$VERIFY_DIR/actual-cli.jar"
+          cmp "$VERIFY_DIR/expected-core.jar" "$VERIFY_DIR/actual-core.jar"
+          cmp "$VERIFY_DIR/expected-cli.jar" "$VERIFY_DIR/actual-cli.jar"
+          REMOTE_CORE_SHA1=$(curl --fail --silent --show-error "$CORE_URL.sha1")
+          REMOTE_CLI_SHA1=$(curl --fail --silent --show-error "$CLI_URL.sha1")
+          test "$REMOTE_CORE_SHA1" = "$(sha1sum "$VERIFY_DIR/actual-core.jar" | cut -d ' ' -f 1)"
+          test "$REMOTE_CLI_SHA1" = "$(sha1sum "$VERIFY_DIR/actual-cli.jar" | cut -d ' ' -f 1)"
+          sha256sum "$VERIFY_DIR"/*.jar

--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -1,8 +1,8 @@
 # JVM package build stats
 
 This workspace contains the JVM implementation of Bundlephobia's package build
-statistics tooling. The initial foundation targets Kotlin 2.4.10 on JDK 21 and
-uses the checked-in Gradle 9.5.1 wrapper.
+statistics tooling. It targets JDK 21, uses Kotlin 2.4.10 and a pinned Gradle
+9.5.1 resolver, and never executes code from the package being measured.
 
 - `model`: stable request and result types;
 - `core`: public library facade and orchestration;
@@ -24,6 +24,29 @@ yarn jvm:test
 Java Format to Java sources. `jvm:check` verifies formatting and compiles Kotlin
 and Java with warnings treated as errors; javac runs with all lint warnings
 enabled.
+
+## Published artifacts
+
+After the first release, use the Java/Kotlin library with:
+
+```kotlin
+dependencies {
+    implementation("com.bundlephobia:jvm-package-build-stats-core:VERSION")
+}
+```
+
+```java
+MavenCoordinate coordinate = MavenCoordinate.parse("com.google.code.gson:gson:2.14.0");
+PackageBuildStatsResult result =
+    new PackageBuildStatsAnalyzer().analyze(new AnalyzeRequest(coordinate));
+String json = ResultJson.encode(result);
+```
+
+The executable artifact is
+`com.bundlephobia:jvm-package-build-stats-cli:VERSION`. Both published JARs are
+self-contained so the internal analyzer modules are not part of the public
+Maven surface. The CLI JAR has a main-class manifest and can run with
+`java -jar`.
 
 ## API and CLI
 
@@ -76,14 +99,14 @@ multi-release versions. It also reports static indicators for Kotlin metadata,
 reflection, service loading, JNI, and unsupported future bytecode. Indicators
 describe bytecode evidence; they do not claim that a code path executes.
 
-## Gradle resolver plugin
+## Internal Gradle resolver plugin
 
 Coordinate resolution is implemented as a settings plugin so repository policy
 is established before project evaluation. The sealed resolver build configures
 Maven Central followed by Google Maven, ignores and reports project repository
 declarations, and installs Gradle's JVM ecosystem compatibility rules.
 
-Apply the plugin in a dedicated `settings.gradle.kts`:
+Within this workspace, apply the plugin in a dedicated `settings.gradle.kts`:
 
 ```kotlin
 plugins {
@@ -113,3 +136,7 @@ both the requested edge and selected version in the result.
 
 The public `analyze` API invokes this plugin through the sealed temporary build;
 the standalone task remains useful for inspecting normalized resolver evidence.
+
+## Contract and operations
+
+- [Release process](docs/RELEASING.md) documents signing and Maven Central verification.

--- a/jvm-package-build-stats/build.gradle.kts
+++ b/jvm-package-build-stats/build.gradle.kts
@@ -1,4 +1,7 @@
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -7,10 +10,12 @@ plugins {
     kotlin("jvm") version "2.4.10" apply false
     kotlin("plugin.serialization") version "2.4.10" apply false
     id("com.diffplug.spotless") version "8.9.0"
+    id("com.gradleup.shadow") version "9.6.1" apply false
+    id("com.vanniktech.maven.publish.base") version "0.37.0" apply false
 }
 
 group = "com.bundlephobia"
-version = "0.0.0-SNAPSHOT"
+version = providers.gradleProperty("jvmPackageBuildStatsVersion").getOrElse("0.1.0-SNAPSHOT")
 
 subprojects {
     apply(plugin = "java-library")
@@ -44,6 +49,16 @@ subprojects {
         isReproducibleFileOrder = true
     }
 
+    tasks.withType<Jar>().configureEach {
+        manifest {
+            attributes(
+                "Implementation-Title" to project.name,
+                "Implementation-Version" to project.version,
+                "Implementation-Vendor" to "Bundlephobia",
+            )
+        }
+    }
+
     dependencyLocking {
         lockAllConfigurations()
     }
@@ -54,6 +69,58 @@ subprojects {
 
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()
+    }
+
+    pluginManager.withPlugin("com.vanniktech.maven.publish.base") {
+        extensions.configure<MavenPublishBaseExtension> {
+            publishToMavenCentral()
+            if (providers.gradleProperty("signingInMemoryKey").isPresent) signAllPublications()
+        }
+        extensions.configure<PublishingExtension> {
+            publications.withType<MavenPublication>().configureEach {
+                pom {
+                    name.set("Bundlephobia ${project.description}")
+                    description.set(project.description)
+                    url.set("https://github.com/pastelsky/bundlephobia")
+                    inceptionYear.set("2026")
+                    licenses {
+                        license {
+                            name.set("MIT License")
+                            url.set("https://opensource.org/license/mit")
+                            distribution.set("repo")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("pastelsky")
+                            name.set("Shubham Kanodia")
+                            email.set("shubham.kanodia10@gmail.com")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:https://github.com/pastelsky/bundlephobia.git")
+                        developerConnection.set("scm:git:ssh://git@github.com/pastelsky/bundlephobia.git")
+                        url.set("https://github.com/pastelsky/bundlephobia")
+                    }
+                    issueManagement {
+                        system.set("GitHub")
+                        url.set("https://github.com/pastelsky/bundlephobia/issues")
+                    }
+                }
+            }
+            repositories {
+                maven {
+                    name = "releaseTest"
+                    url =
+                        uri(
+                            rootProject.layout.buildDirectory
+                                .dir("release-test-repository")
+                                .get()
+                                .asFile,
+                        )
+                }
+            }
+        }
     }
 }
 

--- a/jvm-package-build-stats/cli/build.gradle.kts
+++ b/jvm-package-build-stats/cli/build.gradle.kts
@@ -1,5 +1,13 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.SourceSetContainer
+
 plugins {
     application
+    id("com.gradleup.shadow")
+    id("com.vanniktech.maven.publish.base")
+    `maven-publish`
 }
 
 description = "Command-line interface for JVM package build statistics"
@@ -12,4 +20,36 @@ dependencies {
 application {
     applicationName = "jvm-package-build-stats"
     mainClass = "com.bundlephobia.jvm.cli.MainKt"
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.jar {
+    archiveClassifier.set("thin")
+}
+
+tasks.named<Jar>("sourcesJar") {
+    listOf("model", "archive-analyzer", "classfile-analyzer", "resolver", "core").forEach { module ->
+        from(project(":$module").extensions.getByType<SourceSetContainer>()["main"].allSource)
+    }
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+}
+
+extensions.configure<PublishingExtension> {
+    publications {
+        create<MavenPublication>("maven") {
+            artifactId = "jvm-package-build-stats-cli"
+            from(components["shadow"])
+            artifact(tasks.named("sourcesJar"))
+            artifact(tasks.named("javadocJar"))
+        }
+    }
 }

--- a/jvm-package-build-stats/cli/gradle.lockfile
+++ b/jvm-package-build-stats/cli/gradle.lockfile
@@ -36,4 +36,4 @@ org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
 org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
 org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
 org.ow2.asm:asm:9.10.1=runtimeClasspath,testRuntimeClasspath
-empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions
+empty=annotationProcessor,kotlinScriptDefExtensions,shadow,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
@@ -9,6 +9,7 @@ import com.bundlephobia.jvm.model.ResultStatus
 import com.bundlephobia.jvm.model.TargetProfile
 import picocli.CommandLine
 import picocli.CommandLine.Command
+import picocli.CommandLine.IVersionProvider
 import picocli.CommandLine.Model.CommandSpec
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
@@ -39,13 +40,20 @@ public class JvmPackageBuildStatsCli(
     name = "jvm-package-build-stats",
     description = ["Analyze published JVM package size and dependency statistics."],
     mixinStandardHelpOptions = true,
-    version = ["jvm-package-build-stats 0.0.0-SNAPSHOT"],
+    versionProvider = CliVersionProvider::class,
 )
 private class RootCommand : Runnable {
     @Spec private lateinit var spec: CommandSpec
 
     override fun run() {
         spec.commandLine().usage(spec.commandLine().out)
+    }
+}
+
+private class CliVersionProvider : IVersionProvider {
+    override fun getVersion(): Array<String> {
+        val version = JvmPackageBuildStatsCli::class.java.`package`.implementationVersion ?: "0.1.0-SNAPSHOT"
+        return arrayOf("jvm-package-build-stats $version")
     }
 }
 

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -91,6 +91,15 @@ class JvmPackageBuildStatsCliTest {
         assertEquals("", execution.stderr)
     }
 
+    @Test
+    fun `version follows the published implementation version`() {
+        val execution = execute("--version")
+
+        assertEquals(ExitCode.SUCCESS, execution.exitCode)
+        assertTrue(execution.stdout.matches(Regex("jvm-package-build-stats \\d+\\.\\d+\\.\\d+.*\\R")))
+        assertEquals("", execution.stderr)
+    }
+
     private fun execute(vararg args: String): Execution {
         val stdout = StringWriter()
         val stderr = StringWriter()

--- a/jvm-package-build-stats/core/build.gradle.kts
+++ b/jvm-package-build-stats/core/build.gradle.kts
@@ -1,4 +1,14 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.language.jvm.tasks.ProcessResources
+
+plugins {
+    id("com.gradleup.shadow")
+    id("com.vanniktech.maven.publish.base")
+    `maven-publish`
+}
 
 description = "Public JVM package build statistics library"
 
@@ -7,6 +17,38 @@ dependencies {
     implementation(project(":archive-analyzer"))
     implementation(project(":classfile-analyzer"))
     implementation(project(":resolver"))
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.jar {
+    archiveClassifier.set("thin")
+}
+
+tasks.named<Jar>("sourcesJar") {
+    listOf("model", "archive-analyzer", "classfile-analyzer", "resolver").forEach { module ->
+        from(project(":$module").extensions.getByType<SourceSetContainer>()["main"].allSource)
+    }
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+}
+
+extensions.configure<PublishingExtension> {
+    publications {
+        create<MavenPublication>("maven") {
+            artifactId = "jvm-package-build-stats-core"
+            from(components["shadow"])
+            artifact(tasks.named("sourcesJar"))
+            artifact(tasks.named("javadocJar"))
+        }
+    }
 }
 
 tasks.named<ProcessResources>("processResources") {

--- a/jvm-package-build-stats/core/gradle.lockfile
+++ b/jvm-package-build-stats/core/gradle.lockfile
@@ -35,4 +35,4 @@ org.junit.platform:junit-platform-launcher:1.10.1=testRuntimeClasspath
 org.junit:junit-bom:5.10.1=testCompileClasspath,testRuntimeClasspath
 org.opentest4j:opentest4j:1.3.0=testCompileClasspath,testRuntimeClasspath
 org.ow2.asm:asm:9.10.1=runtimeClasspath,testRuntimeClasspath
-empty=annotationProcessor,kotlinScriptDefExtensions,testAnnotationProcessor,testKotlinScriptDefExtensions
+empty=annotationProcessor,kotlinScriptDefExtensions,shadow,testAnnotationProcessor,testKotlinScriptDefExtensions

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -133,6 +133,7 @@ public class PackageBuildStatsAnalyzer
             diagnostics: MutableList<Diagnostic>,
         ): PackageBuildStatsResult {
             diagnostics += conflictDiagnostics(resolverResult.resolution)
+            diagnostics += graphLimitDiagnostics(resolverResult.resolution)
             val analysesByDigest = evidence.associateBy { item -> item.artifact.digest.value }
             val enrichedResolution =
                 resolverResult.resolution.copy(
@@ -153,7 +154,7 @@ public class PackageBuildStatsAnalyzer
                     .filter { item -> item.artifact.coordinate == request.coordinate }
                     .minByOrNull { item -> item.artifact.fileName }
                     ?.analysis
-            val status = finalStatus(resolverResult, uniqueAnalyses, directArtifact)
+            val status = finalStatus(resolverResult, uniqueAnalyses, directArtifact, diagnostics)
 
             return PackageBuildStatsResult(
                 status = status,
@@ -172,10 +173,12 @@ public class PackageBuildStatsAnalyzer
             resolverResult: JvmResolutionResult,
             analyses: List<ArtifactAnalysis>,
             directArtifact: ArtifactAnalysis?,
+            diagnostics: List<Diagnostic>,
         ): ResultStatus {
             if (analyses.isEmpty() || directArtifact == null) return ResultStatus.FAILED
             val allStaticComplete = analyses.all { analysis -> analysis.status == ResultStatus.COMPLETE }
-            return if (resolverResult.status == ResultStatus.COMPLETE && allStaticComplete) {
+            val noBlockingDiagnostics = diagnostics.none { diagnostic -> diagnostic.severity == DiagnosticSeverity.ERROR }
+            return if (resolverResult.status == ResultStatus.COMPLETE && allStaticComplete && noBlockingDiagnostics) {
                 ResultStatus.COMPLETE
             } else {
                 ResultStatus.PARTIAL
@@ -191,7 +194,12 @@ public class PackageBuildStatsAnalyzer
                 evidence.filter { item -> item.artifact.coordinate == requested }.sumOf { item -> item.analysis.archiveBytes ?: 0 }
             val transitiveBytes =
                 evidence.filter { item -> item.artifact.coordinate != requested }.sumOf { item -> item.analysis.archiveBytes ?: 0 }
-            val paths = shortestPaths(requested, resolution)
+            val paths =
+                if (withinGraphLimits(resolution)) {
+                    shortestPaths(requested, resolution)
+                } else {
+                    emptyList()
+                }
             val largest =
                 evidence
                     .filter { item -> item.artifact.coordinate != requested }
@@ -261,10 +269,28 @@ public class PackageBuildStatsAnalyzer
                     )
                 }
 
+        private fun graphLimitDiagnostics(resolution: ResolutionStats): List<Diagnostic> =
+            if (withinGraphLimits(resolution)) {
+                emptyList()
+            } else {
+                listOf(
+                    Diagnostic(
+                        code = "DEPENDENCY_GRAPH_LIMIT_EXCEEDED",
+                        summary =
+                            "Selected graph has ${resolution.components.size} components and ${resolution.edges.size} edges; " +
+                                "limits are $MAX_GRAPH_COMPONENTS components and $MAX_GRAPH_EDGES edges",
+                        stage = AnalysisStage.ASSEMBLY,
+                    ),
+                )
+            }
+
+        private fun withinGraphLimits(resolution: ResolutionStats): Boolean =
+            resolution.components.size <= MAX_GRAPH_COMPONENTS && resolution.edges.size <= MAX_GRAPH_EDGES
+
         private fun currentToolchain(): ToolchainManifest =
             ToolchainManifest(
                 generation = "jvm-2026-08-g1",
-                analyzerVersion = "0.0.0-SNAPSHOT+$STATIC_ANALYZER_VERSION",
+                analyzerVersion = "${implementationVersion()}+$STATIC_ANALYZER_VERSION",
                 jdkVersion = System.getProperty("java.version"),
                 jdkVendor = System.getProperty("java.vendor"),
                 kotlinVersion = "2.4.10",
@@ -272,6 +298,9 @@ public class PackageBuildStatsAnalyzer
             )
 
         private fun elapsedMilliseconds(start: Long): Long = (System.nanoTime() - start) / NANOS_PER_MILLISECOND
+
+        private fun implementationVersion(): String =
+            PackageBuildStatsAnalyzer::class.java.`package`.implementationVersion ?: "0.1.0-SNAPSHOT"
 
         private data class ArtifactEvidence(
             val artifact: ResolvedArtifact,
@@ -282,5 +311,7 @@ public class PackageBuildStatsAnalyzer
             private const val STATIC_ANALYZER_VERSION = "static-v1"
             private const val LARGEST_ARTIFACT_LIMIT = 10
             private const val NANOS_PER_MILLISECOND = 1_000_000
+            private const val MAX_GRAPH_COMPONENTS = 10_000
+            private const val MAX_GRAPH_EDGES = 50_000
         }
     }

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -124,6 +124,46 @@ class PackageBuildStatsAnalyzerTest {
     }
 
     @Test
+    fun `oversized dependency graphs are bounded and preserve direct evidence`() {
+        val coordinates = (0..10_000).map { index -> MavenCoordinate.parse("example:node$index:1.0") }
+        val directPath = jar("root.jar", 1)
+        val resolution =
+            JvmResolutionResult(
+                status = ResultStatus.COMPLETE,
+                resolution =
+                    ResolutionStats(
+                        requested = coordinates.first(),
+                        components =
+                            coordinates.mapIndexed { index, coordinate ->
+                                ResolvedComponent(coordinate, direct = index == 0)
+                            },
+                        edges =
+                            coordinates.zipWithNext { from, selected ->
+                                DependencyEdge(from, selected.notation, selected)
+                            },
+                        artifacts =
+                            listOf(
+                                ResolvedArtifact(
+                                    coordinate = coordinates.first(),
+                                    fileName = directPath.fileName.toString(),
+                                    path = directPath.toString(),
+                                    extension = "jar",
+                                    variant = "runtime",
+                                    digest = ArtifactDigest(value = sha256(directPath)),
+                                ),
+                            ),
+                    ),
+            )
+
+        val result = analyzer(resolution).analyze(AnalyzeRequest(coordinates.first()))
+
+        assertEquals(ResultStatus.PARTIAL, result.status)
+        assertEquals(ResultStatus.COMPLETE, result.directArtifact?.status)
+        assertTrue(result.runtimeClosure.shortestPaths.isEmpty())
+        assertTrue(result.diagnostics.any { diagnostic -> diagnostic.code == "DEPENDENCY_GRAPH_LIMIT_EXCEEDED" })
+    }
+
+    @Test
     fun `resolver timeouts are retryable structured failures`() {
         val executable = tempDir.resolve("slow-gradle")
         Files.writeString(executable, "#!/bin/sh\nsleep 2\n")

--- a/jvm-package-build-stats/docs/RELEASING.md
+++ b/jvm-package-build-stats/docs/RELEASING.md
@@ -1,0 +1,59 @@
+# Maven Central release process
+
+The public artifacts are:
+
+- `com.bundlephobia:jvm-package-build-stats-core`
+- `com.bundlephobia:jvm-package-build-stats-cli`
+
+The maintained GradleUp Shadow plugin packages internal modules and runtime
+libraries into those two JARs. The Vanniktech Maven Publish plugin supplies
+Central Portal upload, in-memory signing, sources/Javadoc artifacts, checksums,
+and deployment validation. No artifacts are published from pull requests.
+
+## One-time setup
+
+Register the `com.bundlephobia` namespace in Central Portal, publish the GPG
+public key, create a Central user token, and configure the protected
+`maven-central` GitHub environment with:
+
+- `MAVEN_CENTRAL_USERNAME`
+- `MAVEN_CENTRAL_PASSWORD`
+- `MAVEN_SIGNING_KEY`
+- `MAVEN_SIGNING_KEY_ID`
+- `MAVEN_SIGNING_PASSWORD`
+
+The private key must be ASCII-armored and is passed to Gradle only through an
+in-memory property. Never commit credentials or key material.
+
+## Release
+
+1. Merge the final release PR and wait for all blocking CI jobs.
+2. From the `bundlephobia` branch, dispatch **Release JVM package build stats**
+   with a stable semantic version such as `0.1.0`.
+3. The workflow builds/tests, builds both shadow JARs twice and compares
+   SHA-256, signs every publication, and uploads/releases through Central
+   Portal.
+4. The workflow polls Maven Central for both coordinates, downloads the public
+   JARs, byte-compares them with the locally signed release inputs, and prints
+   SHA-256 values.
+
+Central propagation can take 10–30 minutes. A missing namespace, signing key,
+token, validation failure, checksum difference, or absent public coordinate is
+a failed release. Do not retry under a different version until the deployment
+state in Central Portal is understood.
+
+## Local dry run
+
+This command publishes only to a repository under `build/`; it never contacts
+Central Portal:
+
+```sh
+./gradlew \
+  :core:publishMavenPublicationToReleaseTestRepository \
+  :cli:publishMavenPublicationToReleaseTestRepository
+```
+
+Inspect the generated POMs and self-contained JARs under
+`build/release-test-repository/com/bundlephobia`. Release versions are supplied
+with `-PjvmPackageBuildStatsVersion=X.Y.Z`; the default remains
+`0.1.0-SNAPSHOT`.


### PR DESCRIPTION
## Plain-language explanation

This final JVM-only milestone packages the analyzer for real consumers and adds the guarded path used to publish it. It builds exactly two self-contained Maven artifacts, verifies their public layout in CI, and provides a signed Maven Central workflow that can run only after this PR merges. Android remains intentionally out of scope.

## JavaScript and npm analogy

This is similar to bundling private workspace packages into one public Node library and one standalone CLI, then adding a protected npm publish workflow. Maven coordinates are the Java equivalent of exact npm package versions, while the self-contained JARs keep consumers from needing to understand our internal Gradle modules.

## Summary

- Publishes only com.bundlephobia:jvm-package-build-stats-core and com.bundlephobia:jvm-package-build-stats-cli.
- Produces self-contained, reproducible JARs without leaking unpublished internal modules into public POMs.
- Adds signed Maven Central publication behind a manual workflow, the bundlephobia branch, and a protected maven-central environment.
- Verifies the built core API, bundled ASM classes, executable CLI, and dependency-free public POM in the existing JVM CI job.
- Adds bounded dependency-graph handling so oversized resolution output returns partial evidence and a structured diagnostic instead of exhausting the process.
- Documents only the consumer coordinates and release procedure.

## Dependency approach

- Uses GradleUp Shadow for the established self-contained JAR boundary.
- Uses Vanniktech Maven Publish for signing and Maven Central publication.
- Adds no new analyzer runtime dependency; project-specific policy, diagnostics, and graph limits remain owned here.

## Verification

- ./gradlew spotlessCheck clean build
- local publication of both Maven artifacts
- local Java execution of the published CLI JAR
- public JAR/POM layout checks
- all JVM module tests, including the oversized graph limit
- workflow YAML parsing
- pre-commit lint: zero errors and five pre-existing warnings

## Release note

This PR does not publish anything. After merge, a maintainer supplies the release version to the manual workflow, which rebuilds reproducibly, signs and publishes both artifacts, then downloads and byte-verifies their Maven Central copies.