### PR TITLE
Add a potato rain easter egg to the search bar

### DIFF
--- a/__tests__/potato-rain.test.ts
+++ b/__tests__/potato-rain.test.ts
@@ -1,0 +1,16 @@
+import { isPotatoQuery } from '../client/components/PotatoRain/potato.utils'
+
+describe('isPotatoQuery', () => {
+  it('matches the easter egg query regardless of case and padding', () => {
+    expect(isPotatoQuery('potato')).toBe(true)
+    expect(isPotatoQuery('  Potato ')).toBe(true)
+    expect(isPotatoQuery('POTATO')).toBe(true)
+  })
+
+  it('does not match package names that merely contain potato', () => {
+    expect(isPotatoQuery('potatoes')).toBe(false)
+    expect(isPotatoQuery('sweet-potato')).toBe(false)
+    expect(isPotatoQuery('potato@1.0.0')).toBe(false)
+    expect(isPotatoQuery('')).toBe(false)
+  })
+})

--- a/client/assets/potato.svg
+++ b/client/assets/potato.svg
@@ -1,0 +1,13 @@
+<svg width="100" height="76" viewBox="0 0 100 76" xmlns="http://www.w3.org/2000/svg">
+    <g fill-rule="evenodd">
+        <path d="M8.5 40C6 26 16 12 32 7.5 46 3.5 62 4.5 76 10c13 5 20.5 15 19 28-1.5 13-12 24-27 30-15 6-32 6.5-45 0C12.5 62.5 10.5 52 8.5 40z" fill="#D3A15F" stroke="#8A5C2B" stroke-width="3.5"/>
+        <path d="M23 23c6-7 16-11.5 27-11.5" stroke="#F0C68A" stroke-width="4.5" stroke-linecap="round" fill="none"/>
+        <g fill="#8A5C2B" opacity=".55">
+            <ellipse cx="34" cy="29" rx="4.2" ry="3"/>
+            <ellipse cx="59" cy="21" rx="3.4" ry="2.4"/>
+            <ellipse cx="71" cy="44" rx="4" ry="2.8"/>
+            <ellipse cx="47" cy="53" rx="3.6" ry="2.6"/>
+            <ellipse cx="25" cy="49" rx="3" ry="2.2"/>
+        </g>
+    </g>
+</svg>

--- a/client/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/client/components/AutocompleteInput/AutocompleteInput.tsx
@@ -31,6 +31,7 @@ export const AutocompleteInput = ({
     suggestions,
     potatoRainId,
     handleSubmit,
+    handleKeyDown,
     handleInputValueChange,
     setSuggestions,
     stopPotatoRain,
@@ -90,6 +91,7 @@ export const AutocompleteInput = ({
               autoCapitalize: 'off',
               spellCheck: false,
               style: { fontSize: searchFontSize! },
+              onKeyDown: handleKeyDown,
             })}
           />
           <div

--- a/client/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/client/components/AutocompleteInput/AutocompleteInput.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames'
 import { useCombobox } from 'downshift'
 
 import SearchIcon from '../Icons/SearchIcon'
+import { PotatoRain } from '../PotatoRain'
 import { parsePackageString } from '../../../utils/common.utils'
 import { useAutocompleteInput } from './hooks/useAutocompleteInput'
 import { SuggestionItem } from './components/SuggestionItem'
@@ -28,9 +29,11 @@ export const AutocompleteInput = ({
   const {
     value,
     suggestions,
+    potatoRainId,
     handleSubmit,
     handleInputValueChange,
     setSuggestions,
+    stopPotatoRain,
   } = useAutocompleteInput({ initialValue, onSubmit: onSearchSubmit })
   const { searchFontSize } = useFontSize({ value })
 
@@ -129,6 +132,9 @@ export const AutocompleteInput = ({
       >
         <SearchIcon className="" />
       </button>
+      {potatoRainId !== null && (
+        <PotatoRain key={potatoRainId} onComplete={stopPotatoRain} />
+      )}
     </form>
   )
 }

--- a/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
+++ b/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
@@ -3,6 +3,7 @@ import debounce from 'debounce'
 
 import { parsePackageString } from '../../../../utils/common.utils'
 import API, { type PackageSuggestion } from '../../../api'
+import { isPotatoQuery } from '../../PotatoRain'
 
 interface UseAutocompleteInputArgs {
   initialValue: string
@@ -15,6 +16,7 @@ export function useAutocompleteInput({
 }: UseAutocompleteInputArgs) {
   const [value, setValue] = React.useState(initialValue)
   const [suggestions, setSuggestions] = React.useState<PackageSuggestion[]>([])
+  const [potatoRainId, setPotatoRainId] = React.useState<number | null>(null)
   const [, startTransition] = React.useTransition()
 
   const getSuggestions = React.useMemo(
@@ -27,8 +29,17 @@ export function useAutocompleteInput({
     [startTransition]
   )
 
+  const stopPotatoRain = React.useCallback(() => setPotatoRainId(null), [])
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+
+    if (isPotatoQuery(value)) {
+      setSuggestions([])
+      setPotatoRainId(id => (id ?? 0) + 1)
+      return
+    }
+
     onSubmit(value)
   }
 
@@ -49,8 +60,10 @@ export function useAutocompleteInput({
   return {
     value,
     suggestions,
+    potatoRainId,
     handleSubmit,
     handleInputValueChange,
     setSuggestions,
+    stopPotatoRain,
   }
 }

--- a/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
+++ b/client/components/AutocompleteInput/hooks/useAutocompleteInput.ts
@@ -31,16 +31,32 @@ export function useAutocompleteInput({
 
   const stopPotatoRain = React.useCallback(() => setPotatoRainId(null), [])
 
+  const startPotatoRain = () => {
+    setSuggestions([])
+    setPotatoRainId(id => (id ?? 0) + 1)
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
     if (isPotatoQuery(value)) {
-      setSuggestions([])
-      setPotatoRainId(id => (id ?? 0) + 1)
+      startPotatoRain()
       return
     }
 
     onSubmit(value)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter' || !isPotatoQuery(value)) return
+
+    // downshift swallows Enter while the suggestions menu is open, so the
+    // easter egg has to claim the keypress before the form is submitted
+    e.preventDefault()
+    ;(
+      e.nativeEvent as KeyboardEvent & { preventDownshiftDefault?: boolean }
+    ).preventDownshiftDefault = true
+    startPotatoRain()
   }
 
   const handleInputValueChange = (nextValue: string) => {
@@ -62,6 +78,7 @@ export function useAutocompleteInput({
     suggestions,
     potatoRainId,
     handleSubmit,
+    handleKeyDown,
     handleInputValueChange,
     setSuggestions,
     stopPotatoRain,

--- a/client/components/PotatoRain/PotatoRain.scss
+++ b/client/components/PotatoRain/PotatoRain.scss
@@ -1,0 +1,66 @@
+.potato-rain {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  pointer-events: none;
+  // sits above the sticky page nav so potatoes fall in front of everything
+  z-index: 10000;
+}
+
+.potato-rain__potato {
+  --potato-top: 0vh;
+  --potato-drift: 0vw;
+  --potato-spin: 0deg;
+
+  position: absolute;
+  top: 0;
+  animation-name: potato-fall;
+  animation-timing-function: linear;
+  animation-fill-mode: both;
+  will-change: transform;
+
+  svg {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+}
+
+@keyframes potato-fall {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, -25vh, 0) rotate(0deg);
+  }
+
+  8% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(var(--potato-drift), 115vh, 0)
+      rotate(var(--potato-spin));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .potato-rain__potato {
+    top: var(--potato-top);
+    animation-name: potato-appear;
+  }
+
+  @keyframes potato-appear {
+    0%,
+    100% {
+      opacity: 0;
+    }
+
+    20%,
+    70% {
+      opacity: 1;
+    }
+  }
+}

--- a/client/components/PotatoRain/PotatoRain.tsx
+++ b/client/components/PotatoRain/PotatoRain.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+
+import Potato from '../../assets/potato.svg'
+
+const POTATO_COUNT = 28
+
+type FallingPotato = {
+  id: number
+  left: number
+  top: number
+  size: number
+  delay: number
+  duration: number
+  drift: number
+  spin: number
+}
+
+const randomBetween = (min: number, max: number) =>
+  min + Math.random() * (max - min)
+
+const createPotatoes = (): FallingPotato[] =>
+  Array.from({ length: POTATO_COUNT }, (_, id) => ({
+    id,
+    left: randomBetween(-2, 94),
+    top: randomBetween(5, 80),
+    size: randomBetween(26, 64),
+    delay: randomBetween(0, 2.4),
+    duration: randomBetween(2.4, 4.4),
+    drift: randomBetween(-12, 12),
+    spin: randomBetween(-540, 540),
+  }))
+
+type PotatoRainProps = {
+  onComplete: () => void
+}
+
+export const PotatoRain = ({ onComplete }: PotatoRainProps) => {
+  const [potatoes] = React.useState(createPotatoes)
+
+  React.useEffect(() => {
+    const lastPotatoLandsIn = Math.max(
+      ...potatoes.map(potato => potato.delay + potato.duration)
+    )
+    const timer = window.setTimeout(onComplete, lastPotatoLandsIn * 1000)
+
+    return () => window.clearTimeout(timer)
+  }, [potatoes, onComplete])
+
+  return createPortal(
+    <div className="potato-rain" aria-hidden="true">
+      {potatoes.map(potato => (
+        <span
+          key={potato.id}
+          className="potato-rain__potato"
+          style={
+            {
+              left: `${potato.left}vw`,
+              width: `${potato.size}px`,
+              animationDelay: `${potato.delay}s`,
+              animationDuration: `${potato.duration}s`,
+              '--potato-top': `${potato.top}vh`,
+              '--potato-drift': `${potato.drift}vw`,
+              '--potato-spin': `${potato.spin}deg`,
+            } as React.CSSProperties
+          }
+        >
+          <Potato />
+        </span>
+      ))}
+    </div>,
+    document.body
+  )
+}

--- a/client/components/PotatoRain/PotatoRain.tsx
+++ b/client/components/PotatoRain/PotatoRain.tsx
@@ -3,7 +3,9 @@ import { createPortal } from 'react-dom'
 
 import Potato from '../../assets/potato.svg'
 
-const POTATO_COUNT = 28
+const MIN_POTATOES = 24
+const MAX_POTATOES = 56
+const VIEWPORT_PX_PER_POTATO = 46
 
 type FallingPotato = {
   id: number
@@ -19,12 +21,18 @@ type FallingPotato = {
 const randomBetween = (min: number, max: number) =>
   min + Math.random() * (max - min)
 
+const getPotatoCount = () => {
+  const scaledCount = Math.round(window.innerWidth / VIEWPORT_PX_PER_POTATO)
+
+  return Math.min(MAX_POTATOES, Math.max(MIN_POTATOES, scaledCount))
+}
+
 const createPotatoes = (): FallingPotato[] =>
-  Array.from({ length: POTATO_COUNT }, (_, id) => ({
+  Array.from({ length: getPotatoCount() }, (_, id) => ({
     id,
     left: randomBetween(-2, 94),
     top: randomBetween(5, 80),
-    size: randomBetween(26, 64),
+    size: randomBetween(30, 72),
     delay: randomBetween(0, 2.4),
     duration: randomBetween(2.4, 4.4),
     drift: randomBetween(-12, 12),

--- a/client/components/PotatoRain/index.ts
+++ b/client/components/PotatoRain/index.ts
@@ -1,0 +1,2 @@
+export { PotatoRain } from './PotatoRain'
+export { isPotatoQuery } from './potato.utils'

--- a/client/components/PotatoRain/potato.utils.ts
+++ b/client/components/PotatoRain/potato.utils.ts
@@ -1,0 +1,4 @@
+const POTATO_QUERY = 'potato'
+
+export const isPotatoQuery = (value: string) =>
+  value.trim().toLowerCase() === POTATO_QUERY

--- a/stylesheets/index.scss
+++ b/stylesheets/index.scss
@@ -25,6 +25,7 @@
 @import '../client/components/JumpingDots/JumpingDots.scss';
 @import '../client/components/Layout/Layout.scss';
 @import '../client/components/PageNav/PageNav.scss';
+@import '../client/components/PotatoRain/PotatoRain.scss';
 @import '../client/components/ProgressHex/ProgressHex.scss';
 @import '../client/components/QuickStatsBar/QuickStatsBar.scss';
 @import '../client/components/ResultLayout/ResultLayout.scss';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Searching for `potato` now rains potatoes over whatever page you are on instead of running a package search.

[potato-rain-easter-egg-demo.mp4](https://cursor.com/agents/bc-a3920479-8b2e-4589-9a47-695ee57b5167/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpotato-rain-easter-egg-demo.mp4)

## How it works

- `PotatoRain` renders a full-screen, `pointer-events: none` overlay into `document.body` via a portal, with each potato getting a randomized column, size, fall duration, delay, horizontal drift and spin. The overlay unmounts itself once the slowest potato has fallen off screen.
- The trigger lives in `useAutocompleteInput`, so it works from every search bar on the site (home, package result, compare, tree) rather than just the homepage. Submitting `potato` (any casing, surrounding whitespace ignored) starts the rain and skips navigation; anything else searches as before.
- Enter is intercepted on the input itself because downshift calls `preventDefault()` on Enter whenever the suggestions menu is open, so the form's `onSubmit` never fires on the first keypress. The handler claims the keypress with `preventDownshiftDefault` so a single Enter is enough and no suggestion gets selected by accident.
- Under `prefers-reduced-motion: reduce` the potatoes fade in scattered across the page and fade out instead of falling.

## Verification

- `yarn lint` (no new warnings), `yarn tsc --noEmit` (no new errors), `next build`, and `yarn jest` all pass. `__tests__/errors-cache.test.ts` fails identically on `bundlephobia`, so it is unrelated.
- Added `__tests__/potato-rain.test.ts` covering the trigger word matching, including that `potatoes`, `sweet-potato` and `potato@1.0.0` still search normally.
- Manually verified in Chrome against a local dev server: typing `potato` and pressing Enter once rains potatoes, the URL stays put, the suggestions dropdown closes, and nothing is left on screen afterwards.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3920479-8b2e-4589-9a47-695ee57b5167?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3920479-8b2e-4589-9a47-695ee57b5167&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

