### PR TITLE
Add Android compatibility preflight and SDK provisioning

### DIFF
--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -7,7 +7,7 @@ statistics tooling. It targets JDK 21, uses Kotlin 2.4.10 and a pinned Gradle
 - `model`: stable request and result types;
 - `core`: public library facade and orchestration;
 - `resolver`: Gradle-backed Maven coordinate resolution;
-- `archive-analyzer`: defensive JAR archive analysis;
+- `archive-analyzer`: defensive JAR/AAR archive analysis;
 - `classfile-analyzer`: non-loading JVM classfile analysis;
 - `cli`: command-line application.
 
@@ -55,13 +55,13 @@ for the shared terminology and the intentional ecosystem differences around
 compressed size, exports, tree shaking, ESM, JPMS, and Gradle variants.
 
 The public model accepts only exact `groupId:artifactId:version` coordinates and
-the `jvm-runtime` target. Snapshot, range, dynamic, URL, path, repository, and
-Android inputs are rejected.
+the `jvm-runtime` or `android-runtime` target. Snapshot, range, dynamic, URL,
+path, and repository inputs are rejected.
 
 The CLI contract is:
 
 ```text
-jvm-package-stats stats GROUP:ARTIFACT:VERSION [--target jvm-runtime] [--java-version VERSION]
+jvm-package-stats stats GROUP:ARTIFACT:VERSION [--target jvm-runtime|android-runtime] [--java-version VERSION]
 jvm-package-stats inspect FILE.jar [--java-version VERSION]
 ```
 
@@ -80,10 +80,42 @@ shortest selected paths, largest transitive JARs, and conflict-selection
 diagnostics. `inspect` performs the same static JAR analysis without resolving
 dependencies.
 
+### Android compatibility preflight
+
+`--target android-runtime` asks Gradle for Android runtime variants and accepts
+both AAR and JAR artifacts. Before any Android compilation, D8, or R8 work, the
+analyzer reads bounded `aar-metadata.properties` and manifest inputs without
+executing package code. It reports the effective `minSdk`, required
+`compileSdk`, SDK extension, minimum Android Gradle Plugin version, selected
+immutable toolchain profile, missing SDK packages, and bounded per-AAR evidence.
+
+The default policy tries the canonical stable profile first: API 36, Build Tools
+36.0.0, AGP 9.3.1, Gradle 9.5.0, and JDK 17. It uses a pinned API 37 preview
+profile only when dependency metadata requires it. Callers can replace this
+small profile list as Android evolves; the analyzer contains no growing matrix
+of library-specific exceptions.
+
+Tool installation is disabled by default. A service or CLI caller may provide
+an SDK root and `sdkmanager`, then opt in:
+
+```sh
+java -jar jvm-package-build-stats-cli.jar stats \
+  androidx.recyclerview:recyclerview:1.4.0 \
+  --target android-runtime --pretty \
+  --android-sdk-root /opt/android-sdk \
+  --sdkmanager /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager \
+  --install-missing-android-tooling
+```
+
+Only the exact selected `platforms;android-N` and `build-tools;VERSION` packages
+are passed to `sdkmanager`. Installation uses a small SDK-root lock, has a hard
+timeout, and discards tool output. The preflight is the compatibility gate for
+DEX measurement; DEX method counts are not yet part of this result schema.
+
 The library does not persist artifacts or results; service callers own caching
 and retention policy. Library callers can supply a Gradle wrapper, resolution
-timeout, temporary root, and diagnostic-output bound through
-`PackageBuildStatsConfig`.
+timeout, temporary root, diagnostic-output bound, Android profiles, SDK root,
+and optional `sdkmanager` provisioning through `PackageBuildStatsConfig`.
 
 Resolution runs in a temporary empty Gradle build. It evaluates only the owned
 settings plugin and an empty build script: dependency-provided classes, tests,
@@ -139,7 +171,7 @@ Then run the owned task with one exact coordinate:
 The task writes `build/jvm-resolver/result.json`. It records sorted components,
 selected JVM runtime variants and attributes, dependency edges and selection
 reasons, artifact paths and SHA-256 digests, and the permitted repository IDs.
-Unresolved edges, forbidden project repositories, and non-JAR runtime artifacts
+Unresolved edges, forbidden project repositories, and unsupported runtime artifacts
 produce stable structured diagnostics. Gradle's public resolution API does not
 expose reliable per-artifact repository provenance, so repository IDs describe
 the complete ordered repository set rather than claiming which repository

--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -120,6 +120,14 @@ temporary directory with count and byte limits, and generated DEX files are
 deleted after their bounded headers are read. Use `--android-dex-timeout` to
 override the D8 timeout.
 
+The requested AAR is also attributed separately: `directArtifact.classfiles`
+reports the classes, methods, fields, and classfile bytes physically defined by
+its `classes.jar` and embedded `libs/*.jar`. Pretty output shows these as
+`DIRECT LIBRARY CODE` before the closure-wide DEX section. Defined methods
+include constructors, static initializers, and compiler-generated methods; they
+are an ownership count, not a prediction of what R8 will retain in a specific
+application.
+
 These are canonical unshrunk D8 measurements, not an estimate. R8-shrunk counts
 are intentionally not reported yet because a meaningful shrink result requires
 an explicit consumer entry-point and keep-rule policy.

--- a/jvm-package-build-stats/README.md
+++ b/jvm-package-build-stats/README.md
@@ -109,13 +109,26 @@ java -jar jvm-package-build-stats-cli.jar stats \
 
 Only the exact selected `platforms;android-N` and `build-tools;VERSION` packages
 are passed to `sdkmanager`. Installation uses a small SDK-root lock, has a hard
-timeout, and discards tool output. The preflight is the compatibility gate for
-DEX measurement; DEX method counts are not yet part of this result schema.
+timeout, and discards tool output.
+
+When the selected platform and Build Tools are ready, Android analysis runs the
+pinned D8 executable over the complete resolved runtime closure. JSON and
+`--pretty` output report unshrunk DEX bytes, DEX file count, total and largest
+per-DEX method references, field references, and defined classes. Nested
+`classes.jar` and `libs/*.jar` inputs are extracted only into the analysis
+temporary directory with count and byte limits, and generated DEX files are
+deleted after their bounded headers are read. Use `--android-dex-timeout` to
+override the D8 timeout.
+
+These are canonical unshrunk D8 measurements, not an estimate. R8-shrunk counts
+are intentionally not reported yet because a meaningful shrink result requires
+an explicit consumer entry-point and keep-rule policy.
 
 The library does not persist artifacts or results; service callers own caching
 and retention policy. Library callers can supply a Gradle wrapper, resolution
 timeout, temporary root, diagnostic-output bound, Android profiles, SDK root,
-and optional `sdkmanager` provisioning through `PackageBuildStatsConfig`.
+optional `sdkmanager` provisioning, and D8 timeout through
+`PackageBuildStatsConfig`.
 
 Resolution runs in a temporary empty Gradle build. It evaluates only the owned
 settings plugin and an empty build script: dependency-provided classes, tests,

--- a/jvm-package-build-stats/classfile-analyzer/src/main/kotlin/com/bundlephobia/jvm/classfile/JarClassfileAnalyzer.kt
+++ b/jvm-package-build-stats/classfile-analyzer/src/main/kotlin/com/bundlephobia/jvm/classfile/JarClassfileAnalyzer.kt
@@ -237,6 +237,9 @@ public class JarClassfileAnalyzer(
             stats =
                 ClassfileStats(
                     analyzedClasses = types.size,
+                    definedMethods = types.sumOf(ParsedClass::definedMethods),
+                    definedFields = types.sumOf(ParsedClass::definedFields),
+                    classfileBytes = types.sumOf(ParsedClass::classBytes),
                     implementationClasses = types.count { it.visibility == TypeVisibility.IMPLEMENTATION },
                     publicTypes = types.count { it.visibility == TypeVisibility.PUBLIC },
                     protectedTypes = types.count { it.visibility == TypeVisibility.PROTECTED },
@@ -310,6 +313,8 @@ private class InspectingClassVisitor(
     private var innerClassAccess: Int? = null
     private var publicMembers: Int = 0
     private var protectedMembers: Int = 0
+    private var definedMethods: Int = 0
+    private var definedFields: Int = 0
     private var kotlinMetadata: Boolean = false
     private var kotlinVisibility: TypeVisibility? = null
     private var reflectionIndicator: Boolean = false
@@ -427,6 +432,7 @@ private class InspectingClassVisitor(
         signature: String?,
         value: Any?,
     ): FieldVisitor? {
+        definedFields++
         countMember(access)
         return null
     }
@@ -438,6 +444,7 @@ private class InspectingClassVisitor(
         signature: String?,
         exceptions: Array<out String>?,
     ): MethodVisitor? {
+        definedMethods++
         if (name == "<clinit>") staticInitializer = true
         if (name != "<clinit>") {
             countMember(access)
@@ -471,6 +478,8 @@ private class InspectingClassVisitor(
             visibility = visibility,
             publicMembers = if (apiVisible) publicMembers else 0,
             protectedMembers = if (apiVisible) protectedMembers else 0,
+            definedMethods = definedMethods,
+            definedFields = definedFields,
             kotlinMetadata = kotlinMetadata,
             reflectionIndicator = reflectionIndicator,
             serviceLoaderIndicator = serviceLoaderIndicator,
@@ -539,6 +548,8 @@ private data class ParsedClass(
     val visibility: TypeVisibility,
     val publicMembers: Int,
     val protectedMembers: Int,
+    val definedMethods: Int,
+    val definedFields: Int,
     val kotlinMetadata: Boolean,
     val reflectionIndicator: Boolean,
     val serviceLoaderIndicator: Boolean,

--- a/jvm-package-build-stats/classfile-analyzer/src/test/kotlin/com/bundlephobia/jvm/classfile/JarClassfileAnalyzerTest.kt
+++ b/jvm-package-build-stats/classfile-analyzer/src/test/kotlin/com/bundlephobia/jvm/classfile/JarClassfileAnalyzerTest.kt
@@ -56,6 +56,9 @@ class JarClassfileAnalyzerTest {
         assertEquals(
             ClassfileStats(
                 analyzedClasses = 3,
+                definedMethods = 2,
+                definedFields = 5,
+                classfileBytes = (publicApi.size + internal.size + protectedNested.size).toLong(),
                 implementationClasses = 1,
                 publicTypes = 1,
                 protectedTypes = 1,

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
@@ -92,6 +92,26 @@ private class AnalyzeCommand(
     @Option(names = ["--resolution-timeout"], paramLabel = "MILLISECONDS", description = ["Resolution timeout in milliseconds."])
     private var resolutionTimeoutMilliseconds: Long? = null
 
+    @Option(names = ["--android-sdk-root"], paramLabel = "DIRECTORY", description = ["Android SDK root used for tooling checks."])
+    private var androidSdkRoot: Path? = null
+
+    @Option(names = ["--sdkmanager"], paramLabel = "FILE", description = ["sdkmanager executable used for opt-in SDK provisioning."])
+    private var sdkManagerExecutable: Path? = null
+
+    @Option(
+        names = ["--install-missing-android-tooling"],
+        description = ["Install only the platform and Build Tools selected by Android preflight."],
+    )
+    private var installMissingAndroidTooling: Boolean = false
+
+    @Option(
+        names = ["--android-min-sdk"],
+        defaultValue = "23",
+        paramLabel = "API",
+        description = ["Baseline minSdk; metadata may raise it."],
+    )
+    private var androidBaselineMinSdk: Int = 23
+
     @Mixin private lateinit var outputOptions: OutputOptions
 
     override fun call(): Int {
@@ -99,6 +119,9 @@ private class AnalyzeCommand(
         val target = parseTarget(targetValue)
         if (javaVersion < 8) {
             throw CommandLine.ParameterException(spec.commandLine(), "Java version must be at least 8")
+        }
+        if (target != TargetProfile.ANDROID_RUNTIME && androidOptionsPresent()) {
+            throw CommandLine.ParameterException(spec.commandLine(), "Android tooling options require --target android-runtime")
         }
         val result = configuredAnalyzer().analyze(AnalyzeRequest(coordinate, target, javaVersion))
         outputOptions.write(
@@ -125,7 +148,7 @@ private class AnalyzeCommand(
         }
 
     private fun configuredAnalyzer(): PackageBuildStatsAnalyzer {
-        if (gradleExecutable == null && resolutionTimeoutMilliseconds == null) {
+        if (gradleExecutable == null && resolutionTimeoutMilliseconds == null && !androidOptionsPresent()) {
             return analyzer ?: PackageBuildStatsAnalyzer()
         }
         val defaults = PackageBuildStatsConfig()
@@ -137,9 +160,19 @@ private class AnalyzeCommand(
             PackageBuildStatsConfig(
                 gradleExecutable = gradleExecutable,
                 resolutionTimeoutMilliseconds = timeout,
+                androidBaselineMinSdk = androidBaselineMinSdk,
+                androidSdkRoot = androidSdkRoot,
+                androidSdkManagerExecutable = sdkManagerExecutable,
+                installMissingAndroidTooling = installMissingAndroidTooling,
             ),
         )
     }
+
+    private fun androidOptionsPresent(): Boolean =
+        androidSdkRoot != null ||
+            sdkManagerExecutable != null ||
+            installMissingAndroidTooling ||
+            androidBaselineMinSdk != PackageBuildStatsConfig().androidBaselineMinSdk
 }
 
 @Command(

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCli.kt
@@ -112,6 +112,9 @@ private class AnalyzeCommand(
     )
     private var androidBaselineMinSdk: Int = 23
 
+    @Option(names = ["--android-dex-timeout"], paramLabel = "MILLISECONDS", description = ["D8 timeout in milliseconds."])
+    private var androidDexTimeoutMilliseconds: Long? = null
+
     @Mixin private lateinit var outputOptions: OutputOptions
 
     override fun call(): Int {
@@ -153,8 +156,12 @@ private class AnalyzeCommand(
         }
         val defaults = PackageBuildStatsConfig()
         val timeout = resolutionTimeoutMilliseconds ?: defaults.resolutionTimeoutMilliseconds
+        val dexTimeout = androidDexTimeoutMilliseconds ?: defaults.androidDexTimeoutMilliseconds
         if (timeout <= 0) {
             throw CommandLine.ParameterException(spec.commandLine(), "Resolution timeout must be positive")
+        }
+        if (dexTimeout <= 0) {
+            throw CommandLine.ParameterException(spec.commandLine(), "Android DEX timeout must be positive")
         }
         return PackageBuildStatsAnalyzer(
             PackageBuildStatsConfig(
@@ -164,6 +171,7 @@ private class AnalyzeCommand(
                 androidSdkRoot = androidSdkRoot,
                 androidSdkManagerExecutable = sdkManagerExecutable,
                 installMissingAndroidTooling = installMissingAndroidTooling,
+                androidDexTimeoutMilliseconds = dexTimeout,
             ),
         )
     }
@@ -172,6 +180,7 @@ private class AnalyzeCommand(
         androidSdkRoot != null ||
             sdkManagerExecutable != null ||
             installMissingAndroidTooling ||
+            androidDexTimeoutMilliseconds != null ||
             androidBaselineMinSdk != PackageBuildStatsConfig().androidBaselineMinSdk
 }
 

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/TerminalRenderer.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/TerminalRenderer.kt
@@ -5,6 +5,7 @@ import com.bundlephobia.jvm.model.AndroidDexStatus
 import com.bundlephobia.jvm.model.AndroidPreflightStats
 import com.bundlephobia.jvm.model.ApiSurfaceStats
 import com.bundlephobia.jvm.model.ArtifactAnalysis
+import com.bundlephobia.jvm.model.ClassfileStats
 import com.bundlephobia.jvm.model.DependencySizeStats
 import com.bundlephobia.jvm.model.Diagnostic
 import com.bundlephobia.jvm.model.DiagnosticSeverity
@@ -35,6 +36,9 @@ internal class TerminalRenderer(
             metric("Dependencies", bytes(result.sizes.transitiveArtifactArchiveBytes))
 
             result.androidPreflight?.let { preflight -> androidPreflight(preflight) }
+            if (result.target == TargetProfile.ANDROID_RUNTIME) {
+                result.directArtifact?.classfiles?.let { classfiles -> directAndroidCode(classfiles) }
+            }
             result.androidDex?.let { dex -> androidDex(dex) }
 
             section("RUNTIME CLOSURE")
@@ -91,6 +95,14 @@ internal class TerminalRenderer(
         metric("Build Tools", dex.buildToolsVersion)
     }
 
+    private fun StringBuilder.directAndroidCode(classfiles: ClassfileStats) {
+        section("DIRECT LIBRARY CODE")
+        metric("Defined classes", classfiles.analyzedClasses.toString())
+        metric("Defined methods", classfiles.definedMethods.toString())
+        metric("Defined fields", classfiles.definedFields.toString())
+        metric("Classfile bytes", bytes(classfiles.classfileBytes))
+    }
+
     fun render(result: ArtifactAnalysis): String =
         buildString {
             title("JVM ARTIFACT STATS")
@@ -112,6 +124,9 @@ internal class TerminalRenderer(
             result.classfiles?.let { classfiles ->
                 section("CLASSFILES")
                 metric("Analyzed classes", classfiles.analyzedClasses.toString())
+                metric("Defined methods", classfiles.definedMethods.toString())
+                metric("Defined fields", classfiles.definedFields.toString())
+                metric("Classfile bytes", bytes(classfiles.classfileBytes))
                 metric("Implementation", classfiles.implementationClasses.toString())
                 metric("Kotlin metadata", classfiles.kotlinMetadataClasses.toString())
             }

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/TerminalRenderer.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/TerminalRenderer.kt
@@ -1,5 +1,7 @@
 package com.bundlephobia.jvm.cli
 
+import com.bundlephobia.jvm.model.AndroidDexStats
+import com.bundlephobia.jvm.model.AndroidDexStatus
 import com.bundlephobia.jvm.model.AndroidPreflightStats
 import com.bundlephobia.jvm.model.ApiSurfaceStats
 import com.bundlephobia.jvm.model.ArtifactAnalysis
@@ -33,6 +35,7 @@ internal class TerminalRenderer(
             metric("Dependencies", bytes(result.sizes.transitiveArtifactArchiveBytes))
 
             result.androidPreflight?.let { preflight -> androidPreflight(preflight) }
+            result.androidDex?.let { dex -> androidDex(dex) }
 
             section("RUNTIME CLOSURE")
             metric("Artifacts", count(result.runtimeClosure.artifacts, result.artifactsTruncated))
@@ -69,6 +72,23 @@ internal class TerminalRenderer(
         if (preflight.missingToolingPackages.isNotEmpty()) {
             metric("Missing", preflight.missingToolingPackages.joinToString())
         }
+    }
+
+    private fun StringBuilder.androidDex(dex: AndroidDexStats) {
+        section("DEX · D8 UNSHRUNK")
+        metric("Status", dex.status.name.lowercase(Locale.ROOT))
+        if (dex.status == AndroidDexStatus.COMPLETE) {
+            dex.dexBytes?.let { metric("DEX size", bytes(it)) }
+            metric("DEX files", dex.dexFiles.toString())
+            dex.referencedMethods?.let { metric("Method references", it.toString()) }
+            dex.maxReferencedMethodsPerDex?.let { metric("Largest DEX methods", it.toString()) }
+            dex.referencedFields?.let { metric("Field references", it.toString()) }
+            dex.definedClasses?.let { metric("Defined classes", it.toString()) }
+        } else if (dex.status == AndroidDexStatus.SKIPPED) {
+            metric("Method references", "not measured")
+        }
+        metric("minSdk", dex.minSdk.toString())
+        metric("Build Tools", dex.buildToolsVersion)
     }
 
     fun render(result: ArtifactAnalysis): String =

--- a/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/TerminalRenderer.kt
+++ b/jvm-package-build-stats/cli/src/main/kotlin/com/bundlephobia/jvm/cli/TerminalRenderer.kt
@@ -1,5 +1,6 @@
 package com.bundlephobia.jvm.cli
 
+import com.bundlephobia.jvm.model.AndroidPreflightStats
 import com.bundlephobia.jvm.model.ApiSurfaceStats
 import com.bundlephobia.jvm.model.ArtifactAnalysis
 import com.bundlephobia.jvm.model.DependencySizeStats
@@ -7,6 +8,7 @@ import com.bundlephobia.jvm.model.Diagnostic
 import com.bundlephobia.jvm.model.DiagnosticSeverity
 import com.bundlephobia.jvm.model.PackageBuildStatsResult
 import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.TargetProfile
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -16,15 +18,21 @@ internal class TerminalRenderer(
 ) {
     fun render(result: PackageBuildStatsResult): String =
         buildString {
-            title("JVM PACKAGE STATS")
+            title(if (result.target == TargetProfile.ANDROID_RUNTIME) "ANDROID PACKAGE STATS" else "JVM PACKAGE STATS")
             appendLine(style(BOLD_CYAN, result.coordinate.notation))
-            appendLine("${status(result.status)}  ${dim("JVM runtime · Java ${result.javaVersion}")}")
+            val target = if (result.target == TargetProfile.ANDROID_RUNTIME) "Android runtime" else "JVM runtime"
+            appendLine("${status(result.status)}  ${dim("$target · Java ${result.javaVersion}")}")
 
             section("SIZE")
-            metric("Published JARs", bytes(result.sizes.runtimeArchiveBytes))
+            metric(
+                if (result.target == TargetProfile.ANDROID_RUNTIME) "Runtime archives" else "Published JARs",
+                bytes(result.sizes.runtimeArchiveBytes),
+            )
             metric("Expanded contents", bytes(result.sizes.runtimeExpandedBytes))
             metric("Requested package", bytes(result.sizes.directArtifactArchiveBytes))
             metric("Dependencies", bytes(result.sizes.transitiveArtifactArchiveBytes))
+
+            result.androidPreflight?.let { preflight -> androidPreflight(preflight) }
 
             section("RUNTIME CLOSURE")
             metric("Artifacts", count(result.runtimeClosure.artifacts, result.artifactsTruncated))
@@ -45,6 +53,23 @@ internal class TerminalRenderer(
             metric("Total", duration(result.timings.totalMilliseconds))
             result.timings.stagesMilliseconds.forEach { (stage, milliseconds) -> metric(stage, duration(milliseconds)) }
         }.trimEnd()
+
+    private fun StringBuilder.androidPreflight(preflight: AndroidPreflightStats) {
+        section("ANDROID PREFLIGHT")
+        metric("Required minSdk", preflight.requiredMinSdk.toString())
+        metric("Required compileSdk", preflight.requiredCompileSdk.toString())
+        if (preflight.requiredCompileSdkExtension > 0) {
+            metric("SDK extension", preflight.requiredCompileSdkExtension.toString())
+        }
+        preflight.requiredCompileSdkPreview?.let { metric("SDK preview", it) }
+        preflight.requiredAgpVersion?.let { metric("Minimum AGP", it) }
+        metric("Profile", preflight.selectedProfile?.id ?: "unsupported")
+        metric("Tooling", preflight.toolingStatus.name.lowercase(Locale.ROOT))
+        metric("Confidence", preflight.confidence.name.lowercase(Locale.ROOT))
+        if (preflight.missingToolingPackages.isNotEmpty()) {
+            metric("Missing", preflight.missingToolingPackages.joinToString())
+        }
+    }
 
     fun render(result: ArtifactAnalysis): String =
         buildString {

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -119,12 +119,21 @@ class JvmPackageBuildStatsCliTest {
     }
 
     @Test
-    fun `Android targets are rejected`() {
+    fun `unknown targets are rejected`() {
         val execution = execute("analyze", "g:a:1", "--target", "android-release")
 
         assertEquals(ExitCode.USAGE, execution.exitCode)
         assertEquals("", execution.stdout)
         assertTrue(execution.stderr.contains("Unsupported target profile"))
+    }
+
+    @Test
+    fun `Android tooling options require the Android target`() {
+        val execution = execute("analyze", "g:a:1", "--android-sdk-root", tempDir.toString())
+
+        assertEquals(ExitCode.USAGE, execution.exitCode)
+        assertEquals("", execution.stdout)
+        assertTrue(execution.stderr.contains("require --target android-runtime"))
     }
 
     @Test

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -2,8 +2,15 @@ package com.bundlephobia.jvm.cli
 
 import com.bundlephobia.jvm.PackageBuildStatsAnalyzer
 import com.bundlephobia.jvm.PackageBuildStatsConfig
+import com.bundlephobia.jvm.model.AndroidDexStats
+import com.bundlephobia.jvm.model.AndroidDexStatus
+import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.PackageBuildStatsResult
+import com.bundlephobia.jvm.model.ResolutionSummary
 import com.bundlephobia.jvm.model.ResultJson
 import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.TargetProfile
+import com.bundlephobia.jvm.model.ToolchainManifest
 import org.junit.jupiter.api.io.TempDir
 import java.io.PrintWriter
 import java.io.StringWriter
@@ -74,6 +81,45 @@ class JvmPackageBuildStatsCliTest {
         val result = PackageBuildStatsAnalyzer().inspect(fixtureJar())
 
         assertTrue(TerminalRenderer(color = true).render(result).contains("\u001B["))
+    }
+
+    @Test
+    fun `Android pretty output includes unshrunk DEX statistics`() {
+        val coordinate = MavenCoordinate.parse("androidx.example:fixture:1.0")
+        val result =
+            PackageBuildStatsResult(
+                status = ResultStatus.COMPLETE,
+                coordinate = coordinate,
+                target = TargetProfile.ANDROID_RUNTIME,
+                toolchain =
+                    ToolchainManifest(
+                        generation = "test",
+                        analyzerVersion = "test",
+                        jdkVersion = "21",
+                        jdkVendor = "test",
+                        kotlinVersion = "test",
+                        gradleVersion = "9.5.1",
+                    ),
+                resolution = ResolutionSummary(coordinate),
+                androidDex =
+                    AndroidDexStats(
+                        status = AndroidDexStatus.COMPLETE,
+                        dexBytes = 4_096,
+                        dexFiles = 2,
+                        referencedMethods = 70_000,
+                        maxReferencedMethodsPerDex = 60_000,
+                        referencedFields = 12_000,
+                        definedClasses = 800,
+                        minSdk = 23,
+                        buildToolsVersion = "36.0.0",
+                    ),
+            )
+
+        val output = TerminalRenderer(color = false).render(result)
+
+        assertTrue(output.contains("DEX · D8 UNSHRUNK"))
+        assertTrue(output.contains("Method references      70000"))
+        assertTrue(output.contains("DEX files              2"))
     }
 
     @Test

--- a/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
+++ b/jvm-package-build-stats/cli/src/test/kotlin/com/bundlephobia/jvm/cli/JvmPackageBuildStatsCliTest.kt
@@ -4,6 +4,8 @@ import com.bundlephobia.jvm.PackageBuildStatsAnalyzer
 import com.bundlephobia.jvm.PackageBuildStatsConfig
 import com.bundlephobia.jvm.model.AndroidDexStats
 import com.bundlephobia.jvm.model.AndroidDexStatus
+import com.bundlephobia.jvm.model.ArtifactAnalysis
+import com.bundlephobia.jvm.model.ClassfileStats
 import com.bundlephobia.jvm.model.MavenCoordinate
 import com.bundlephobia.jvm.model.PackageBuildStatsResult
 import com.bundlephobia.jvm.model.ResolutionSummary
@@ -101,6 +103,18 @@ class JvmPackageBuildStatsCliTest {
                         gradleVersion = "9.5.1",
                     ),
                 resolution = ResolutionSummary(coordinate),
+                directArtifact =
+                    ArtifactAnalysis(
+                        status = ResultStatus.COMPLETE,
+                        displayName = "fixture.aar",
+                        classfiles =
+                            ClassfileStats(
+                                analyzedClasses = 120,
+                                definedMethods = 1_200,
+                                definedFields = 240,
+                                classfileBytes = 524_288,
+                            ),
+                    ),
                 androidDex =
                     AndroidDexStats(
                         status = AndroidDexStatus.COMPLETE,
@@ -117,6 +131,8 @@ class JvmPackageBuildStatsCliTest {
 
         val output = TerminalRenderer(color = false).render(result)
 
+        assertTrue(output.contains("DIRECT LIBRARY CODE"))
+        assertTrue(output.contains("Defined methods        1200"))
         assertTrue(output.contains("DEX · D8 UNSHRUNK"))
         assertTrue(output.contains("Method references      70000"))
         assertTrue(output.contains("DEX files              2"))

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AndroidAarClassfileAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AndroidAarClassfileAnalyzer.kt
@@ -1,0 +1,118 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.classfile.JarClassfileAnalyzer
+import com.bundlephobia.jvm.model.ClassfileStats
+import com.bundlephobia.jvm.model.Diagnostic
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import java.util.zip.ZipFile
+
+internal data class AndroidAarClassfileResult(
+    val stats: ClassfileStats,
+    val diagnostics: List<Diagnostic>,
+)
+
+/** Attributes classfile definitions to bytecode physically embedded in one AAR. */
+internal class AndroidAarClassfileAnalyzer(
+    private val config: PackageBuildStatsConfig,
+    private val javaVersion: Int,
+) {
+    fun analyze(path: Path): AndroidAarClassfileResult {
+        val workDirectory =
+            config.temporaryDirectory?.let { parent ->
+                Files.createDirectories(parent)
+                Files.createTempDirectory(parent, "jvm-aar-classfiles-")
+            } ?: Files.createTempDirectory("jvm-aar-classfiles-")
+        return try {
+            val analyses = extractNestedJars(path, workDirectory).map { JarClassfileAnalyzer(javaVersion).analyze(it) }
+            AndroidAarClassfileResult(
+                stats = analyses.map { it.stats }.fold(ClassfileStats()) { total, stats -> total.plus(stats) },
+                diagnostics = analyses.flatMap { it.diagnostics },
+            )
+        } finally {
+            deleteRecursively(workDirectory)
+        }
+    }
+
+    private fun extractNestedJars(
+        path: Path,
+        directory: Path,
+    ): List<Path> =
+        ZipFile(path.toFile()).use { archive ->
+            val entries =
+                archive
+                    .entries()
+                    .asSequence()
+                    .filter { entry ->
+                        !entry.isDirectory &&
+                            (entry.name == "classes.jar" || (entry.name.startsWith("libs/") && entry.name.endsWith(".jar")))
+                    }.sortedBy { it.name }
+                    .take(MAX_NESTED_JARS + 1)
+                    .toList()
+            check(entries.size <= MAX_NESTED_JARS) { "AAR contains too many nested JARs" }
+
+            var totalBytes = 0L
+            entries.mapIndexed { index, entry ->
+                val target = directory.resolve("$index.jar")
+                archive.getInputStream(entry).use { input ->
+                    Files.newOutputStream(target).use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        var entryBytes = 0L
+                        while (true) {
+                            val read = input.read(buffer)
+                            if (read < 0) break
+                            entryBytes += read
+                            totalBytes += read
+                            check(entryBytes <= MAX_NESTED_JAR_BYTES) { "Nested JAR exceeds classfile input limit" }
+                            check(totalBytes <= MAX_TOTAL_NESTED_JAR_BYTES) { "AAR bytecode exceeds classfile input limit" }
+                            output.write(buffer, 0, read)
+                        }
+                    }
+                }
+                target
+            }
+        }
+
+    private fun ClassfileStats.plus(other: ClassfileStats): ClassfileStats =
+        ClassfileStats(
+            analyzedClasses = analyzedClasses + other.analyzedClasses,
+            definedMethods = definedMethods + other.definedMethods,
+            definedFields = definedFields + other.definedFields,
+            classfileBytes = classfileBytes + other.classfileBytes,
+            implementationClasses = implementationClasses + other.implementationClasses,
+            publicTypes = publicTypes + other.publicTypes,
+            protectedTypes = protectedTypes + other.protectedTypes,
+            publicMembers = publicMembers + other.publicMembers,
+            protectedMembers = protectedMembers + other.protectedMembers,
+            moduleInfoPresent = moduleInfoPresent || other.moduleInfoPresent,
+            moduleNames = (moduleNames + other.moduleNames).distinct().sorted(),
+            moduleExports = (moduleExports + other.moduleExports).distinct().sorted(),
+            multiReleaseVersions = (multiReleaseVersions + other.multiReleaseVersions).distinct().sorted(),
+            kotlinMetadataClasses = kotlinMetadataClasses + other.kotlinMetadataClasses,
+            reflectionIndicatorClasses = reflectionIndicatorClasses + other.reflectionIndicatorClasses,
+            serviceLoaderIndicatorClasses = serviceLoaderIndicatorClasses + other.serviceLoaderIndicatorClasses,
+            jniIndicatorClasses = jniIndicatorClasses + other.jniIndicatorClasses,
+            classesWithStaticInitializers = classesWithStaticInitializers + other.classesWithStaticInitializers,
+            nativeMethodClasses = nativeMethodClasses + other.nativeMethodClasses,
+            unsupportedBytecodeVersions =
+                (unsupportedBytecodeVersions + other.unsupportedBytecodeVersions).distinct().sorted(),
+        )
+
+    private fun deleteRecursively(directory: Path) {
+        try {
+            Files.walk(directory).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach { path -> Files.deleteIfExists(path) }
+            }
+        } catch (_: IOException) {
+            // Extracted bytecode is temporary evidence and is never returned to callers.
+        }
+    }
+
+    private companion object {
+        const val MAX_NESTED_JARS = 32
+        const val MAX_NESTED_JAR_BYTES = 256L * 1_024 * 1_024
+        const val MAX_TOTAL_NESTED_JAR_BYTES = 512L * 1_024 * 1_024
+    }
+}

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AndroidDexAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AndroidDexAnalyzer.kt
@@ -1,0 +1,388 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AnalysisStage
+import com.bundlephobia.jvm.model.AndroidDexStats
+import com.bundlephobia.jvm.model.AndroidDexStatus
+import com.bundlephobia.jvm.model.AndroidPreflightStats
+import com.bundlephobia.jvm.model.AndroidToolchainProfile
+import com.bundlephobia.jvm.model.AndroidToolingStatus
+import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.DiagnosticSeverity
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.RetryClassification
+import java.io.IOException
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Comparator
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipFile
+
+internal data class AndroidDexResult(
+    val stats: AndroidDexStats,
+    val diagnostics: List<Diagnostic> = emptyList(),
+)
+
+/** Runs pinned D8 over the selected runtime closure and reads only aggregate DEX header counts. */
+internal class AndroidDexAnalyzer(
+    private val config: PackageBuildStatsConfig,
+) {
+    fun analyze(
+        resolution: ResolutionStats,
+        preflight: AndroidPreflightStats,
+        cancellation: AnalysisCancellation,
+    ): AndroidDexResult {
+        val profile = preflight.selectedProfile ?: return skipped(preflight)
+        if (preflight.toolingStatus !in setOf(AndroidToolingStatus.READY, AndroidToolingStatus.INSTALLED)) {
+            return skipped(preflight, profile)
+        }
+        val sdkRoot = config.androidSdkRoot ?: return skipped(preflight, profile)
+        val workDirectory =
+            config.temporaryDirectory?.let { parent ->
+                Files.createDirectories(parent)
+                Files.createTempDirectory(parent, "jvm-android-dex-")
+            } ?: Files.createTempDirectory("jvm-android-dex-")
+        return try {
+            analyze(workDirectory, sdkRoot, profile, preflight, resolution, cancellation)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            failed(preflight, profile, "DEX analysis was cancelled", RetryClassification.RETRYABLE)
+        } catch (_: Exception) {
+            failed(preflight, profile, "D8 could not measure the selected Android runtime closure")
+        } finally {
+            deleteRecursively(workDirectory)
+        }
+    }
+
+    private fun analyze(
+        workDirectory: Path,
+        sdkRoot: Path,
+        profile: AndroidToolchainProfile,
+        preflight: AndroidPreflightStats,
+        resolution: ResolutionStats,
+        cancellation: AnalysisCancellation,
+    ): AndroidDexResult {
+        val d8 = d8Executable(sdkRoot, profile)
+        val androidJar = sdkRoot.resolve("platforms/android-${profile.platformName}/android.jar")
+        check(Files.isRegularFile(d8)) { "D8 executable is missing" }
+        check(Files.isRegularFile(androidJar)) { "Android platform is missing" }
+        val inputs = prepareInputs(workDirectory.resolve("inputs"), resolution)
+        check(inputs.isNotEmpty()) { "No JVM bytecode was selected" }
+        if (cancellation.isCancelled()) {
+            return failed(preflight, profile, "DEX analysis was cancelled", RetryClassification.RETRYABLE)
+        }
+
+        val output = workDirectory.resolve("output")
+        Files.createDirectories(output)
+        val command =
+            buildList {
+                add(d8.toAbsolutePath().normalize().toString())
+                add("--release")
+                add("--min-api")
+                add(preflight.effectiveMinSdk.toString())
+                add("--lib")
+                add(androidJar.toAbsolutePath().normalize().toString())
+                add("--output")
+                add(output.toAbsolutePath().normalize().toString())
+                inputs.forEach { add(it.toAbsolutePath().normalize().toString()) }
+            }
+        val processBuilder =
+            ProcessBuilder(command)
+                .directory(workDirectory.toFile())
+                .redirectErrorStream(true)
+        processBuilder.environment()["JAVA_HOME"] =
+            Path
+                .of(System.getProperty("java.home"))
+                .toAbsolutePath()
+                .normalize()
+                .toString()
+        val process = processBuilder.start()
+        val processOutput = BoundedProcessOutput(process.inputStream, config.diagnosticOutputLimitBytes)
+        val outputThread =
+            Thread(processOutput, "jvm-android-d8-output").apply {
+                isDaemon = true
+                start()
+            }
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(config.androidDexTimeoutMilliseconds)
+        while (process.isAlive && System.nanoTime() < deadline && !cancellation.isCancelled()) {
+            process.waitFor(PROCESS_POLL_MILLISECONDS, TimeUnit.MILLISECONDS)
+        }
+        val timedOut = process.isAlive && System.nanoTime() >= deadline
+        if (process.isAlive) stop(process)
+        outputThread.join(PROCESS_OUTPUT_JOIN_MILLISECONDS)
+        if (cancellation.isCancelled()) {
+            return failed(preflight, profile, "DEX analysis was cancelled", RetryClassification.RETRYABLE)
+        }
+        if (timedOut) {
+            return failed(
+                preflight,
+                profile,
+                "DEX analysis exceeded ${config.androidDexTimeoutMilliseconds} ms",
+                RetryClassification.RETRYABLE,
+            )
+        }
+        if (process.exitValue() != 0) {
+            val boundedOutput = if (outputThread.isAlive) "" else processOutput.text()
+            val detail =
+                boundedOutput
+                    .takeIf(String::isNotEmpty)
+                    ?.let { ": $it" }
+                    .orEmpty()
+            return failed(preflight, profile, "D8 exited with status ${process.exitValue()}$detail")
+        }
+        return complete(preflight, profile, readDexFiles(output))
+    }
+
+    private fun prepareInputs(
+        directory: Path,
+        resolution: ResolutionStats,
+    ): List<Path> {
+        Files.createDirectories(directory)
+        val result = mutableListOf<Path>()
+        var extractedBytes = 0L
+        resolution.artifacts
+            .distinctBy { it.digest.value }
+            .sortedBy { it.digest.value }
+            .forEachIndexed { artifactIndex, artifact ->
+                val path = Path.of(artifact.path)
+                when (artifact.extension) {
+                    "jar" -> {
+                        result.add(path)
+                    }
+
+                    "aar" -> {
+                        ZipFile(path.toFile()).use { archive ->
+                            val nestedJars =
+                                archive
+                                    .entries()
+                                    .asSequence()
+                                    .filter { entry ->
+                                        !entry.isDirectory &&
+                                            (
+                                                entry.name == "classes.jar" ||
+                                                    (entry.name.startsWith("libs/") && entry.name.endsWith(".jar"))
+                                            )
+                                    }.sortedBy { it.name }
+                                    .take(MAX_NESTED_JARS_PER_AAR + 1)
+                                    .toList()
+                            check(nestedJars.size <= MAX_NESTED_JARS_PER_AAR) { "AAR contains too many nested JARs" }
+                            nestedJars.forEachIndexed { nestedIndex, entry ->
+                                val target = directory.resolve("$artifactIndex-$nestedIndex.jar")
+                                archive.getInputStream(entry).use { input ->
+                                    Files.newOutputStream(target).use { output ->
+                                        extractedBytes += copyBounded(input, output)
+                                    }
+                                }
+                                check(extractedBytes <= MAX_TOTAL_EXTRACTED_JAR_BYTES) {
+                                    "Extracted AAR bytecode exceeds D8 input limit"
+                                }
+                                result.add(target)
+                            }
+                        }
+                    }
+                }
+                check(result.size <= MAX_DEX_INPUTS) { "Runtime closure contains too many D8 inputs" }
+            }
+        return result
+    }
+
+    private fun copyBounded(
+        input: java.io.InputStream,
+        output: java.io.OutputStream,
+    ): Long {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var total = 0L
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            total += read
+            check(total <= MAX_NESTED_JAR_BYTES) { "Nested JAR exceeds D8 input limit" }
+            output.write(buffer, 0, read)
+        }
+        return total
+    }
+
+    private fun readDexFiles(directory: Path): List<DexHeaderStats> {
+        val paths =
+            Files.list(directory).use { stream ->
+                stream
+                    .filter { path -> path.fileName.toString().matches(DEX_FILE_PATTERN) }
+                    .sorted()
+                    .limit(MAX_DEX_FILES.toLong() + 1)
+                    .toList()
+            }
+        check(paths.isNotEmpty()) { "D8 produced no DEX files" }
+        check(paths.size <= MAX_DEX_FILES) { "D8 produced too many DEX files" }
+        return paths.map(::readDexHeader)
+    }
+
+    private fun readDexHeader(path: Path): DexHeaderStats {
+        val fileBytes = Files.size(path)
+        check(fileBytes >= DEX_HEADER_BYTES) { "DEX header is truncated" }
+        val bytes = Files.newInputStream(path).use { it.readNBytes(DEX_HEADER_BYTES) }
+        check(bytes.copyOfRange(0, DEX_MAGIC_PREFIX.size).contentEquals(DEX_MAGIC_PREFIX)) { "DEX magic is invalid" }
+        val header = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        val declaredBytes = Integer.toUnsignedLong(header.getInt(FILE_SIZE_OFFSET))
+        check(declaredBytes == fileBytes) { "DEX file size does not match its header" }
+        return DexHeaderStats(
+            bytes = fileBytes,
+            methods = Integer.toUnsignedLong(header.getInt(METHOD_IDS_SIZE_OFFSET)),
+            fields = Integer.toUnsignedLong(header.getInt(FIELD_IDS_SIZE_OFFSET)),
+            classes = Integer.toUnsignedLong(header.getInt(CLASS_DEFS_SIZE_OFFSET)),
+        )
+    }
+
+    private fun complete(
+        preflight: AndroidPreflightStats,
+        profile: AndroidToolchainProfile,
+        files: List<DexHeaderStats>,
+    ): AndroidDexResult =
+        AndroidDexResult(
+            AndroidDexStats(
+                status = AndroidDexStatus.COMPLETE,
+                dexBytes = files.sumOf(DexHeaderStats::bytes),
+                dexFiles = files.size,
+                referencedMethods = files.sumOf(DexHeaderStats::methods),
+                maxReferencedMethodsPerDex = files.maxOf(DexHeaderStats::methods),
+                referencedFields = files.sumOf(DexHeaderStats::fields),
+                definedClasses = files.sumOf(DexHeaderStats::classes),
+                minSdk = preflight.effectiveMinSdk,
+                buildToolsVersion = profile.buildToolsVersion,
+            ),
+        )
+
+    private fun skipped(
+        preflight: AndroidPreflightStats,
+        profile: AndroidToolchainProfile? = preflight.selectedProfile,
+    ): AndroidDexResult =
+        AndroidDexResult(
+            AndroidDexStats(
+                status = AndroidDexStatus.SKIPPED,
+                minSdk = preflight.effectiveMinSdk,
+                buildToolsVersion = profile?.buildToolsVersion ?: "unavailable",
+            ),
+        )
+
+    private fun failed(
+        preflight: AndroidPreflightStats,
+        profile: AndroidToolchainProfile,
+        summary: String,
+        retry: RetryClassification = RetryClassification.UNKNOWN,
+    ): AndroidDexResult =
+        AndroidDexResult(
+            stats =
+                AndroidDexStats(
+                    status = AndroidDexStatus.FAILED,
+                    minSdk = preflight.effectiveMinSdk,
+                    buildToolsVersion = profile.buildToolsVersion,
+                ),
+            diagnostics =
+                listOf(
+                    Diagnostic(
+                        code = "ANDROID_DEX_ANALYSIS_FAILED",
+                        summary = summary,
+                        stage = AnalysisStage.DEX_ANALYSIS,
+                        severity = DiagnosticSeverity.ERROR,
+                        retry = retry,
+                    ),
+                ),
+        )
+
+    private fun d8Executable(
+        sdkRoot: Path,
+        profile: AndroidToolchainProfile,
+    ): Path {
+        val directory = sdkRoot.resolve("build-tools/${profile.buildToolsVersion}")
+        val executable = directory.resolve("d8")
+        return if (Files.isRegularFile(executable)) executable else directory.resolve("d8.bat")
+    }
+
+    private fun stop(process: Process) {
+        process.destroy()
+        if (!process.waitFor(PROCESS_SHUTDOWN_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor()
+        }
+    }
+
+    private fun deleteRecursively(directory: Path) {
+        if (!Files.exists(directory)) return
+        try {
+            Files.walk(directory).use { paths ->
+                paths.sorted(Comparator.reverseOrder()).forEach { path -> Files.deleteIfExists(path) }
+            }
+        } catch (_: IOException) {
+            // Temporary evidence is best-effort cleanup and is never returned to callers.
+        }
+    }
+
+    private data class DexHeaderStats(
+        val bytes: Long,
+        val methods: Long,
+        val fields: Long,
+        val classes: Long,
+    )
+
+    private class BoundedProcessOutput(
+        private val input: InputStream,
+        limit: Int,
+    ) : Runnable {
+        private val tail = ByteArray(limit)
+        private var totalBytes = 0L
+
+        override fun run() {
+            try {
+                input.use { stream ->
+                    val chunk = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = stream.read(chunk)
+                        if (read < 0) break
+                        repeat(read) { index ->
+                            if (tail.isNotEmpty()) tail[(totalBytes % tail.size).toInt()] = chunk[index]
+                            totalBytes++
+                        }
+                    }
+                }
+            } catch (_: IOException) {
+                // Process termination may close the pipe while the collector is draining it.
+            }
+        }
+
+        fun text(): String {
+            if (tail.isEmpty() || totalBytes == 0L) return ""
+            val size = minOf(totalBytes, tail.size.toLong()).toInt()
+            val bytes = ByteArray(size)
+            val start = if (totalBytes <= tail.size.toLong()) 0 else (totalBytes % tail.size).toInt()
+            repeat(size) { index -> bytes[index] = tail[(start + index) % tail.size] }
+            return bytes
+                .toString(Charsets.UTF_8)
+                .lineSequence()
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .joinToString(" | ")
+        }
+    }
+
+    private companion object {
+        const val PROCESS_POLL_MILLISECONDS = 100L
+        const val PROCESS_SHUTDOWN_SECONDS = 5L
+        const val PROCESS_OUTPUT_JOIN_MILLISECONDS = 1_000L
+        const val DEX_HEADER_BYTES = 112
+        const val FILE_SIZE_OFFSET = 32
+        const val FIELD_IDS_SIZE_OFFSET = 80
+        const val METHOD_IDS_SIZE_OFFSET = 88
+        const val CLASS_DEFS_SIZE_OFFSET = 96
+        const val MAX_NESTED_JARS_PER_AAR = 32
+        const val MAX_NESTED_JAR_BYTES = 256L * 1024 * 1024
+        const val MAX_TOTAL_EXTRACTED_JAR_BYTES = 512L * 1024 * 1024
+        const val MAX_DEX_INPUTS = 1_024
+        const val MAX_DEX_FILES = 1_024
+        val DEX_MAGIC_PREFIX = byteArrayOf('d'.code.toByte(), 'e'.code.toByte(), 'x'.code.toByte(), '\n'.code.toByte())
+        val DEX_FILE_PATTERN = Regex("classes(?:\\d+)?\\.dex")
+    }
+}
+
+private val AndroidToolchainProfile.platformName: String
+    get() = compileSdkPreview ?: compileSdk.toString()

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AndroidPreflightAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/AndroidPreflightAnalyzer.kt
@@ -1,0 +1,385 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AnalysisStage
+import com.bundlephobia.jvm.model.AndroidArtifactRequirement
+import com.bundlephobia.jvm.model.AndroidPreflightStats
+import com.bundlephobia.jvm.model.AndroidRequirementConfidence
+import com.bundlephobia.jvm.model.AndroidSdkChannel
+import com.bundlephobia.jvm.model.AndroidToolchainProfile
+import com.bundlephobia.jvm.model.AndroidToolingStatus
+import com.bundlephobia.jvm.model.Diagnostic
+import com.bundlephobia.jvm.model.DiagnosticSeverity
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResolvedArtifact
+import com.bundlephobia.jvm.model.RetryClassification
+import java.io.ByteArrayInputStream
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipFile
+
+internal data class AndroidPreflightResult(
+    val stats: AndroidPreflightStats,
+    val diagnostics: List<Diagnostic>,
+)
+
+/** Reads bounded AAR metadata before any Android compiler, D8, or R8 process starts. */
+internal class AndroidPreflightAnalyzer(
+    private val config: PackageBuildStatsConfig,
+) {
+    fun analyze(
+        resolution: ResolutionStats,
+        cancellation: AnalysisCancellation,
+    ): AndroidPreflightResult {
+        val aarArtifacts = resolution.artifacts.filter { it.extension == AAR_EXTENSION }
+        val requirements = aarArtifacts.mapNotNull(::inspect)
+        val baselineCompileSdk =
+            config.androidProfiles
+                .filter { it.channel == AndroidSdkChannel.STABLE }
+                .minOfOrNull(AndroidToolchainProfile::compileSdk)
+                ?: config.androidProfiles.minOf(AndroidToolchainProfile::compileSdk)
+        val requiredMinSdk = maxOf(config.androidBaselineMinSdk, requirements.mapNotNull { it.minSdk }.maxOrNull() ?: 0)
+        val requiredCompileSdk = maxOf(baselineCompileSdk, requirements.mapNotNull { it.minCompileSdk }.maxOrNull() ?: 0)
+        val requiredExtension = requirements.mapNotNull { it.minCompileSdkExtension }.maxOrNull() ?: 0
+        val requiredPreviews = requirements.mapNotNull { it.compileSdkPreview }.distinct().sorted()
+        val requiredPreview = requiredPreviews.singleOrNull()
+        val requiredAgp = requirements.mapNotNull { it.minAgpVersion }.maxWithOrNull(::compareVersions)
+        val selected =
+            config.androidProfiles
+                .sortedWith(compareBy<AndroidToolchainProfile>({ it.channel }, { it.compileSdk }, { it.compileSdkExtension }))
+                .firstOrNull { profile ->
+                    profile.compileSdk >= requiredCompileSdk &&
+                        profile.compileSdkExtension >= requiredExtension &&
+                        (requiredPreview == null || profile.compileSdkPreview == requiredPreview) &&
+                        (requiredPreview != null || profile.compileSdkPreview == null) &&
+                        requiredPreviews.size <= 1 &&
+                        (requiredAgp == null || compareVersions(profile.agpVersion, requiredAgp) >= 0)
+                }
+
+        val diagnostics = mutableListOf<Diagnostic>()
+        val tooling =
+            if (selected == null) {
+                ToolingResult(AndroidToolingStatus.UNSUPPORTED)
+            } else {
+                AndroidToolchainProvisioner(config).ensure(selected, cancellation)
+            }
+        diagnostics += tooling.diagnostics
+        if (selected == null) {
+            diagnostics +=
+                Diagnostic(
+                    code = "ANDROID_PROFILE_UNSUPPORTED",
+                    summary =
+                        "No configured Android profile satisfies compileSdk $requiredCompileSdk" +
+                            (if (requiredExtension > 0) " extension $requiredExtension" else "") +
+                            (requiredPreviews.takeIf { it.isNotEmpty() }?.joinToString(prefix = " preview ") ?: "") +
+                            (requiredAgp?.let { " and AGP $it" } ?: ""),
+                    stage = AnalysisStage.ANDROID_PREFLIGHT,
+                )
+        }
+        val inspectedCount = requirements.size
+        if (inspectedCount < aarArtifacts.size) {
+            diagnostics +=
+                Diagnostic(
+                    code = "ANDROID_METADATA_UNREADABLE",
+                    summary = "Could not inspect compatibility metadata in ${aarArtifacts.size - inspectedCount} AAR artifact(s)",
+                    stage = AnalysisStage.ANDROID_PREFLIGHT,
+                    severity = DiagnosticSeverity.WARNING,
+                    retry = RetryClassification.UNKNOWN,
+                )
+        }
+        val compact = requirements.sortedBy { it.coordinate.notation }.take(ARTIFACT_REQUIREMENT_LIMIT)
+        return AndroidPreflightResult(
+            stats =
+                AndroidPreflightStats(
+                    requiredMinSdk = requiredMinSdk,
+                    requiredCompileSdk = requiredCompileSdk,
+                    requiredCompileSdkExtension = requiredExtension,
+                    requiredCompileSdkPreview = requiredPreview,
+                    requiredAgpVersion = requiredAgp,
+                    confidence = confidence(aarArtifacts, requirements),
+                    selectedProfile = selected,
+                    effectiveMinSdk = requiredMinSdk,
+                    toolingStatus = tooling.status,
+                    missingToolingPackages = tooling.missingPackages,
+                    artifactRequirements = compact,
+                    artifactRequirementCount = requirements.size,
+                    artifactRequirementsTruncated = requirements.size > compact.size,
+                ),
+            diagnostics = diagnostics,
+        )
+    }
+
+    private fun inspect(artifact: ResolvedArtifact): AndroidArtifactRequirement? =
+        runCatching {
+            ZipFile(Path.of(artifact.path).toFile()).use { archive ->
+                val metadataEntry = archive.getEntry(AAR_METADATA_PATH)
+                val metadata =
+                    metadataEntry?.let { entry ->
+                        val bytes = archive.getInputStream(entry).use { it.readNBytes(MAX_METADATA_BYTES + 1) }
+                        check(bytes.size <= MAX_METADATA_BYTES) { "AAR metadata exceeds limit" }
+                        Properties().apply { load(ByteArrayInputStream(bytes)) }
+                    }
+                val manifestEntry = archive.getEntry(ANDROID_MANIFEST_PATH)
+                val minSdk =
+                    manifestEntry?.let { entry ->
+                        val bytes = archive.getInputStream(entry).use { it.readNBytes(MAX_MANIFEST_BYTES + 1) }
+                        check(bytes.size <= MAX_MANIFEST_BYTES) { "Android manifest exceeds limit" }
+                        MIN_SDK_PATTERN
+                            .find(bytes.toString(Charsets.UTF_8))
+                            ?.groupValues
+                            ?.get(1)
+                            ?.toIntOrNull()
+                    }
+                AndroidArtifactRequirement(
+                    coordinate = artifact.coordinate,
+                    fileName = artifact.fileName,
+                    minSdk = minSdk,
+                    minCompileSdk = metadata?.getProperty("minCompileSdk")?.toIntOrNull(),
+                    minCompileSdkExtension = metadata?.getProperty("minCompileSdkExtension")?.toIntOrNull(),
+                    compileSdkPreview = metadata?.getProperty("forceCompileSdkPreview")?.takeIf(String::isNotBlank),
+                    minAgpVersion = metadata?.getProperty("minAndroidGradlePluginVersion")?.takeIf(String::isNotBlank),
+                    metadataDeclared = metadata != null,
+                )
+            }
+        }.getOrNull()
+
+    private fun confidence(
+        artifacts: List<ResolvedArtifact>,
+        requirements: List<AndroidArtifactRequirement>,
+    ): AndroidRequirementConfidence =
+        when {
+            artifacts.isEmpty() -> {
+                AndroidRequirementConfidence.INFERRED
+            }
+
+            requirements.size == artifacts.size && requirements.all(AndroidArtifactRequirement::metadataDeclared) -> {
+                AndroidRequirementConfidence.DECLARED
+            }
+
+            requirements.isNotEmpty() -> {
+                AndroidRequirementConfidence.INFERRED
+            }
+
+            else -> {
+                AndroidRequirementConfidence.UNKNOWN
+            }
+        }
+
+    private companion object {
+        const val AAR_EXTENSION = "aar"
+        const val AAR_METADATA_PATH = "META-INF/com/android/build/gradle/aar-metadata.properties"
+        const val ANDROID_MANIFEST_PATH = "AndroidManifest.xml"
+        const val MAX_METADATA_BYTES = 64 * 1024
+        const val MAX_MANIFEST_BYTES = 1024 * 1024
+        const val ARTIFACT_REQUIREMENT_LIMIT = 20
+        val MIN_SDK_PATTERN = Regex("""minSdkVersion\s*=\s*[\"'](\d+)[\"']""")
+    }
+}
+
+internal data class ToolingResult(
+    val status: AndroidToolingStatus,
+    val missingPackages: List<String> = emptyList(),
+    val diagnostics: List<Diagnostic> = emptyList(),
+)
+
+/** Installs only the two immutable SDK packages selected by an allowlisted profile. */
+internal class AndroidToolchainProvisioner(
+    private val config: PackageBuildStatsConfig,
+) {
+    fun ensure(
+        profile: AndroidToolchainProfile,
+        cancellation: AnalysisCancellation,
+    ): ToolingResult =
+        try {
+            ensureInstalled(profile, cancellation)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            cancelled(packageIds(profile))
+        } catch (_: Exception) {
+            failure(packageIds(profile), "Could not inspect or provision the selected Android SDK packages")
+        }
+
+    private fun ensureInstalled(
+        profile: AndroidToolchainProfile,
+        cancellation: AnalysisCancellation,
+    ): ToolingResult {
+        val packages = packageIds(profile)
+        val sdkRoot =
+            config.androidSdkRoot
+                ?: return missing(packages, "Android SDK root is not configured")
+        var missing = missingPackages(sdkRoot, profile)
+        if (missing.isEmpty()) return ToolingResult(AndroidToolingStatus.READY)
+        if (!config.installMissingAndroidTooling) return missing(missing, "Selected Android SDK packages are not installed")
+        val sdkManager =
+            config.androidSdkManagerExecutable
+                ?: return missing(missing, "sdkmanager executable is not configured")
+        if (!Files.isRegularFile(sdkManager)) return missing(missing, "Configured sdkmanager executable does not exist")
+
+        Files.createDirectories(sdkRoot)
+        val lockDirectory = sdkRoot.resolve(".bundlephobia")
+        Files.createDirectories(lockDirectory)
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(config.androidToolingInstallTimeoutMilliseconds)
+        FileChannel
+            .open(
+                lockDirectory.resolve("sdk-install.lock"),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+            ).use { channel ->
+                var installLock: FileLock? = null
+                while (installLock == null && !cancellation.isCancelled() && System.nanoTime() < deadline) {
+                    installLock =
+                        try {
+                            channel.tryLock()
+                        } catch (_: OverlappingFileLockException) {
+                            null
+                        }
+                    if (installLock == null) {
+                        try {
+                            Thread.sleep(PROCESS_POLL_MILLISECONDS)
+                        } catch (_: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            return cancelled(missing)
+                        }
+                    }
+                }
+                if (installLock == null) {
+                    return if (cancellation.isCancelled()) {
+                        cancelled(missing)
+                    } else {
+                        failure(missing, "Timed out waiting for the SDK install lock")
+                    }
+                }
+                installLock.use {
+                    missing = missingPackages(sdkRoot, profile)
+                    if (missing.isEmpty()) return ToolingResult(AndroidToolingStatus.READY)
+                    if (cancellation.isCancelled()) return cancelled(missing)
+                    val process =
+                        ProcessBuilder(
+                            listOf(
+                                sdkManager.toAbsolutePath().normalize().toString(),
+                                "--sdk_root=${sdkRoot.toAbsolutePath().normalize()}",
+                            ) + missing,
+                        ).redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                            .redirectError(ProcessBuilder.Redirect.DISCARD)
+                            .start()
+                    while (process.isAlive && System.nanoTime() < deadline && !cancellation.isCancelled()) {
+                        process.waitFor(PROCESS_POLL_MILLISECONDS, TimeUnit.MILLISECONDS)
+                    }
+                    if (process.isAlive) {
+                        process.destroy()
+                        if (!process.waitFor(PROCESS_SHUTDOWN_SECONDS, TimeUnit.SECONDS)) {
+                            process.destroyForcibly()
+                            process.waitFor()
+                        }
+                    }
+                    if (cancellation.isCancelled()) return cancelled(missing)
+                    missing = missingPackages(sdkRoot, profile)
+                    if (process.exitValue() != 0 || missing.isNotEmpty()) {
+                        return failure(missing.ifEmpty { packages }, "sdkmanager could not install the selected Android SDK packages")
+                    }
+                }
+            }
+        return ToolingResult(AndroidToolingStatus.INSTALLED)
+    }
+
+    private fun packageIds(profile: AndroidToolchainProfile): List<String> =
+        listOf("platforms;android-${profile.platformName}", "build-tools;${profile.buildToolsVersion}")
+
+    private fun missingPackages(
+        root: Path,
+        profile: AndroidToolchainProfile,
+    ): List<String> =
+        buildList {
+            if (!Files.isRegularFile(root.resolve("platforms/android-${profile.platformName}/android.jar"))) {
+                add("platforms;android-${profile.platformName}")
+            }
+            val buildTools = root.resolve("build-tools/${profile.buildToolsVersion}")
+            if (!Files.isRegularFile(buildTools.resolve("d8")) && !Files.isRegularFile(buildTools.resolve("d8.bat"))) {
+                add("build-tools;${profile.buildToolsVersion}")
+            }
+        }
+
+    private fun missing(
+        packages: List<String>,
+        summary: String,
+    ): ToolingResult =
+        ToolingResult(
+            status = AndroidToolingStatus.MISSING,
+            missingPackages = packages,
+            diagnostics = listOf(diagnostic("ANDROID_TOOLING_MISSING", summary, DiagnosticSeverity.WARNING)),
+        )
+
+    private fun failure(
+        packages: List<String>,
+        summary: String,
+    ): ToolingResult =
+        ToolingResult(
+            status = AndroidToolingStatus.MISSING,
+            missingPackages = packages,
+            diagnostics = listOf(diagnostic("ANDROID_TOOLING_INSTALL_FAILED", summary, DiagnosticSeverity.ERROR)),
+        )
+
+    private fun cancelled(packages: List<String>): ToolingResult =
+        ToolingResult(
+            status = AndroidToolingStatus.MISSING,
+            missingPackages = packages,
+            diagnostics =
+                listOf(
+                    Diagnostic(
+                        code = "ANDROID_TOOLING_INSTALL_CANCELLED",
+                        summary = "Android SDK package installation was cancelled",
+                        stage = AnalysisStage.TOOLCHAIN_PROVISIONING,
+                        severity = DiagnosticSeverity.WARNING,
+                        retry = RetryClassification.RETRYABLE,
+                    ),
+                ),
+        )
+
+    private fun diagnostic(
+        code: String,
+        summary: String,
+        severity: DiagnosticSeverity,
+    ): Diagnostic =
+        Diagnostic(
+            code = code,
+            summary = summary,
+            stage = AnalysisStage.TOOLCHAIN_PROVISIONING,
+            severity = severity,
+            retry = RetryClassification.UNKNOWN,
+        )
+
+    private companion object {
+        const val PROCESS_POLL_MILLISECONDS = 100L
+        const val PROCESS_SHUTDOWN_SECONDS = 5L
+    }
+}
+
+private val AndroidToolchainProfile.platformName: String
+    get() = compileSdkPreview ?: compileSdk.toString()
+
+private fun compareVersions(
+    left: String,
+    right: String,
+): Int {
+    val leftParts = VERSION_NUMBER.findAll(left).map { it.value.toInt() }.toList()
+    val rightParts = VERSION_NUMBER.findAll(right).map { it.value.toInt() }.toList()
+    repeat(maxOf(leftParts.size, rightParts.size)) { index ->
+        val comparison = (leftParts.getOrNull(index) ?: 0).compareTo(rightParts.getOrNull(index) ?: 0)
+        if (comparison != 0) return comparison
+    }
+    val leftQualifier = VERSION_QUALIFIER.find(left)?.value.orEmpty()
+    val rightQualifier = VERSION_QUALIFIER.find(right)?.value.orEmpty()
+    return when {
+        leftQualifier.isEmpty() && rightQualifier.isNotEmpty() -> 1
+        leftQualifier.isNotEmpty() && rightQualifier.isEmpty() -> -1
+        else -> leftQualifier.compareTo(rightQualifier)
+    }
+}
+
+private val VERSION_NUMBER = Regex("\\d+")
+private val VERSION_QUALIFIER = Regex("[A-Za-z].*$")

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/GradleResolverClient.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/GradleResolverClient.kt
@@ -8,6 +8,7 @@ import com.bundlephobia.jvm.model.ResolutionStats
 import com.bundlephobia.jvm.model.ResultJson
 import com.bundlephobia.jvm.model.ResultStatus
 import com.bundlephobia.jvm.model.RetryClassification
+import com.bundlephobia.jvm.model.TargetProfile
 import com.bundlephobia.jvm.resolver.ResolverPluginClasspathAnchor
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
@@ -19,6 +20,7 @@ import java.util.concurrent.TimeUnit
 internal fun interface ResolverClient {
     fun resolve(
         coordinate: MavenCoordinate,
+        target: TargetProfile,
         javaVersion: Int,
         cancellation: AnalysisCancellation,
     ): JvmResolutionResult
@@ -30,6 +32,7 @@ internal class GradleResolverClient(
 ) : ResolverClient {
     override fun resolve(
         coordinate: MavenCoordinate,
+        target: TargetProfile,
         javaVersion: Int,
         cancellation: AnalysisCancellation,
     ): JvmResolutionResult {
@@ -40,13 +43,14 @@ internal class GradleResolverClient(
             } ?: Files.createTempDirectory("jvm-package-build-stats-")
         return try {
             writeBuild(directory)
-            runGradle(directory, coordinate, javaVersion, cancellation)
+            runGradle(directory, coordinate, target, javaVersion, cancellation)
         } catch (_: InterruptedException) {
             Thread.currentThread().interrupt()
-            failure(coordinate, javaVersion, "RESOLUTION_CANCELLED", "Resolution was cancelled", RetryClassification.RETRYABLE)
+            failure(coordinate, target, javaVersion, "RESOLUTION_CANCELLED", "Resolution was cancelled", RetryClassification.RETRYABLE)
         } catch (_: Exception) {
             failure(
                 coordinate,
+                target,
                 javaVersion,
                 "RESOLVER_PROCESS_FAILED",
                 "The sealed Gradle resolver could not start or return a result",
@@ -104,6 +108,7 @@ internal class GradleResolverClient(
     private fun runGradle(
         directory: Path,
         coordinate: MavenCoordinate,
+        target: TargetProfile,
         javaVersion: Int,
         cancellation: AnalysisCancellation,
     ): JvmResolutionResult {
@@ -114,6 +119,7 @@ internal class GradleResolverClient(
                 "--console=plain",
                 ResolverPluginClasspathAnchor.RESOLVE_TASK_NAME,
                 "-P${ResolverPluginClasspathAnchor.COORDINATE_PROPERTY}=${coordinate.notation}",
+                "-P${ResolverPluginClasspathAnchor.TARGET_PROPERTY}=${target.serializedValue}",
                 "-P${ResolverPluginClasspathAnchor.JAVA_VERSION_PROPERTY}=$javaVersion",
             ).directory(directory.toFile())
                 .redirectOutput(directory.resolve("gradle.stdout").toFile())
@@ -139,6 +145,7 @@ internal class GradleResolverClient(
             stop(process)
             return failure(
                 coordinate,
+                target,
                 javaVersion,
                 "RESOLUTION_CANCELLED",
                 "Resolution was cancelled",
@@ -149,6 +156,7 @@ internal class GradleResolverClient(
             stop(process)
             return failure(
                 coordinate,
+                target,
                 javaVersion,
                 "RESOLUTION_TIMEOUT",
                 "Resolution exceeded ${config.resolutionTimeoutMilliseconds} ms",
@@ -162,6 +170,7 @@ internal class GradleResolverClient(
         val detail = if (stderr.isEmpty()) "" else ": $stderr"
         return failure(
             coordinate,
+            target,
             javaVersion,
             "RESOLVER_PROCESS_FAILED",
             "The sealed Gradle resolver exited with status ${process.exitValue()} without a result$detail",
@@ -187,6 +196,7 @@ internal class GradleResolverClient(
 
     private fun failure(
         coordinate: MavenCoordinate,
+        target: TargetProfile,
         javaVersion: Int,
         code: String,
         summary: String,
@@ -194,6 +204,7 @@ internal class GradleResolverClient(
     ): JvmResolutionResult =
         JvmResolutionResult(
             status = ResultStatus.FAILED,
+            target = target,
             javaVersion = javaVersion,
             resolution = ResolutionStats(coordinate),
             diagnostics =

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -180,7 +180,7 @@ public class PackageBuildStatsAnalyzer
             try {
                 val analysis =
                     if (artifact.extension == "aar") {
-                        archiveAnalyzer.analyze(Path.of(artifact.path)).copy(displayName = artifact.fileName)
+                        inspectAndroidArchive(Path.of(artifact.path), javaVersion).copy(displayName = artifact.fileName)
                     } else {
                         inspect(Path.of(artifact.path), javaVersion).copy(displayName = artifact.fileName)
                     }
@@ -199,6 +199,21 @@ public class PackageBuildStatsAnalyzer
                     )
                 null
             }
+
+        private fun inspectAndroidArchive(
+            path: Path,
+            javaVersion: Int,
+        ): ArtifactAnalysis {
+            val archive = archiveAnalyzer.analyze(path)
+            if (archive.status != ResultStatus.COMPLETE) return archive
+
+            val classfiles = AndroidAarClassfileAnalyzer(config, javaVersion).analyze(path)
+            return archive.copy(
+                status = if (classfiles.diagnostics.isEmpty()) ResultStatus.COMPLETE else ResultStatus.PARTIAL,
+                classfiles = classfiles.stats,
+                diagnostics = classfiles.diagnostics,
+            )
+        }
 
         private fun assemble(
             request: AnalyzeRequest,

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -4,6 +4,7 @@ import com.bundlephobia.jvm.archive.JarArchiveAnalyzer
 import com.bundlephobia.jvm.classfile.JarClassfileAnalyzer
 import com.bundlephobia.jvm.model.AnalysisStage
 import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.AndroidDexStats
 import com.bundlephobia.jvm.model.AndroidPreflightStats
 import com.bundlephobia.jvm.model.ArtifactAnalysis
 import com.bundlephobia.jvm.model.DependencyPath
@@ -84,6 +85,21 @@ public class PackageBuildStatsAnalyzer
                 stageTimings["android-preflight"] = preflightTimed.duration.inWholeMilliseconds
             }
 
+            val dexTimed =
+                measureTimedValue {
+                    androidPreflight?.let { preflight ->
+                        AndroidDexAnalyzer(config)
+                            .analyze(resolverResult.resolution, preflight, cancellation)
+                            .also {
+                                diagnostics += it.diagnostics
+                            }.stats
+                    }
+                }
+            val androidDex = dexTimed.value
+            if (request.target == TargetProfile.ANDROID_RUNTIME) {
+                stageTimings["dex-analysis"] = dexTimed.duration.inWholeMilliseconds
+            }
+
             val evidence = mutableListOf<ArtifactEvidence>()
             val analysisTimed =
                 measureTimedValue {
@@ -111,6 +127,7 @@ public class PackageBuildStatsAnalyzer
                         resolverResult = resolverResult,
                         evidence = evidence,
                         androidPreflight = androidPreflight,
+                        androidDex = androidDex,
                         diagnostics = diagnostics,
                     )
                 }
@@ -188,6 +205,7 @@ public class PackageBuildStatsAnalyzer
             resolverResult: JvmResolutionResult,
             evidence: List<ArtifactEvidence>,
             androidPreflight: AndroidPreflightStats?,
+            androidDex: AndroidDexStats?,
             diagnostics: MutableList<Diagnostic>,
         ): PackageBuildStatsResult {
             diagnostics += conflictDiagnostics(resolverResult.resolution)
@@ -264,6 +282,7 @@ public class PackageBuildStatsAnalyzer
                 directArtifact = directArtifact,
                 runtimeClosure = closure,
                 androidPreflight = androidPreflight,
+                androidDex = androidDex,
                 diagnostics = compactDiagnostics,
                 diagnosticCount = distinctDiagnostics.size,
                 diagnosticsTruncated = distinctDiagnostics.size > compactDiagnostics.size,

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzer.kt
@@ -4,6 +4,7 @@ import com.bundlephobia.jvm.archive.JarArchiveAnalyzer
 import com.bundlephobia.jvm.classfile.JarClassfileAnalyzer
 import com.bundlephobia.jvm.model.AnalysisStage
 import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.AndroidPreflightStats
 import com.bundlephobia.jvm.model.ArtifactAnalysis
 import com.bundlephobia.jvm.model.DependencyPath
 import com.bundlephobia.jvm.model.DependencySizeStats
@@ -22,6 +23,7 @@ import com.bundlephobia.jvm.model.ResultStatus
 import com.bundlephobia.jvm.model.RetryClassification
 import com.bundlephobia.jvm.model.RuntimeArtifactSummary
 import com.bundlephobia.jvm.model.RuntimeClosureStats
+import com.bundlephobia.jvm.model.TargetProfile
 import com.bundlephobia.jvm.model.TimingStats
 import com.bundlephobia.jvm.model.ToolchainManifest
 import java.nio.file.Path
@@ -56,18 +58,41 @@ public class PackageBuildStatsAnalyzer
             val stageTimings = linkedMapOf<String, Long>()
             val diagnostics = mutableListOf<Diagnostic>()
 
-            val resolutionTimed = measureTimedValue { resolverClient.resolve(request.coordinate, request.javaVersion, cancellation) }
+            val resolutionTimed =
+                measureTimedValue {
+                    resolverClient.resolve(request.coordinate, request.target, request.javaVersion, cancellation)
+                }
             stageTimings["resolution"] = resolutionTimed.duration.inWholeMilliseconds
             val resolverResult = resolutionTimed.value
             diagnostics += resolverResult.diagnostics
+
+            val androidPreflight: AndroidPreflightStats?
+            val preflightTimed =
+                measureTimedValue {
+                    if (request.target == TargetProfile.ANDROID_RUNTIME && resolverResult.resolution.artifacts.isNotEmpty()) {
+                        AndroidPreflightAnalyzer(config)
+                            .analyze(resolverResult.resolution, cancellation)
+                            .also {
+                                diagnostics += it.diagnostics
+                            }.stats
+                    } else {
+                        null
+                    }
+                }
+            androidPreflight = preflightTimed.value
+            if (request.target == TargetProfile.ANDROID_RUNTIME) {
+                stageTimings["android-preflight"] = preflightTimed.duration.inWholeMilliseconds
+            }
 
             val evidence = mutableListOf<ArtifactEvidence>()
             val analysisTimed =
                 measureTimedValue {
                     resolverResult.resolution.artifacts
                         .asSequence()
-                        .filter { artifact -> artifact.extension == "jar" }
-                        .distinctBy { artifact -> artifact.digest.value }
+                        .filter { artifact ->
+                            artifact.extension == "jar" ||
+                                (request.target == TargetProfile.ANDROID_RUNTIME && artifact.extension == "aar")
+                        }.distinctBy { artifact -> artifact.digest.value }
                         .sortedBy { artifact -> artifact.digest.value }
                         .forEach { artifact ->
                             if (cancellation.isCancelled()) {
@@ -85,6 +110,7 @@ public class PackageBuildStatsAnalyzer
                         request = request,
                         resolverResult = resolverResult,
                         evidence = evidence,
+                        androidPreflight = androidPreflight,
                         diagnostics = diagnostics,
                     )
                 }
@@ -135,7 +161,12 @@ public class PackageBuildStatsAnalyzer
             diagnostics: MutableList<Diagnostic>,
         ): ArtifactEvidence? =
             try {
-                val analysis = inspect(Path.of(artifact.path), javaVersion).copy(displayName = artifact.fileName)
+                val analysis =
+                    if (artifact.extension == "aar") {
+                        archiveAnalyzer.analyze(Path.of(artifact.path)).copy(displayName = artifact.fileName)
+                    } else {
+                        inspect(Path.of(artifact.path), javaVersion).copy(displayName = artifact.fileName)
+                    }
                 check(analysis.digest == null || analysis.digest == artifact.digest) {
                     "Artifact digest changed after resolution"
                 }
@@ -156,6 +187,7 @@ public class PackageBuildStatsAnalyzer
             request: AnalyzeRequest,
             resolverResult: JvmResolutionResult,
             evidence: List<ArtifactEvidence>,
+            androidPreflight: AndroidPreflightStats?,
             diagnostics: MutableList<Diagnostic>,
         ): PackageBuildStatsResult {
             diagnostics += conflictDiagnostics(resolverResult.resolution)
@@ -171,7 +203,7 @@ public class PackageBuildStatsAnalyzer
                 diagnostics +=
                     Diagnostic(
                         code = "REQUESTED_ARTIFACT_NOT_ANALYZED",
-                        summary = "No analyzable JVM JAR was selected for ${request.coordinate.notation}",
+                        summary = "No analyzable runtime archive was selected for ${request.coordinate.notation}",
                         stage = AnalysisStage.ASSEMBLY,
                         severity = DiagnosticSeverity.ERROR,
                     )
@@ -231,6 +263,7 @@ public class PackageBuildStatsAnalyzer
                 artifactsTruncated = uniqueAnalyses.size > compactArtifacts.size,
                 directArtifact = directArtifact,
                 runtimeClosure = closure,
+                androidPreflight = androidPreflight,
                 diagnostics = compactDiagnostics,
                 diagnosticCount = distinctDiagnostics.size,
                 diagnosticsTruncated = distinctDiagnostics.size > compactDiagnostics.size,

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsConfig.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsConfig.kt
@@ -1,5 +1,7 @@
 package com.bundlephobia.jvm
 
+import com.bundlephobia.jvm.model.AndroidSdkChannel
+import com.bundlephobia.jvm.model.AndroidToolchainProfile
 import java.nio.file.Path
 
 /** Runtime controls for coordinate resolution. Result caching belongs to the calling service. */
@@ -14,9 +16,59 @@ public data class PackageBuildStatsConfig
         public val temporaryDirectory: Path? = null,
         /** Maximum resolver stderr included in a structured failure diagnostic. */
         public val diagnosticOutputLimitBytes: Int = 4_096,
+        /** Android profiles available for metadata-driven selection, ordered only for display. */
+        public val androidProfiles: List<AndroidToolchainProfile> = DEFAULT_ANDROID_PROFILES,
+        /** Comparable Android floor; dependencies may raise this value during preflight. */
+        public val androidBaselineMinSdk: Int = 23,
+        /** Existing Android SDK root used to check or provision selected packages. */
+        public val androidSdkRoot: Path? = null,
+        /** Official Android CLI executable. Required only when installation is enabled and tooling is missing. */
+        public val androidSdkManagerExecutable: Path? = null,
+        /** Opt-in installation of missing allowlisted SDK platform and Build Tools packages. */
+        public val installMissingAndroidTooling: Boolean = false,
+        /** Hard wall-clock limit for one Android CLI SDK installation. */
+        public val androidToolingInstallTimeoutMilliseconds: Long = 180_000,
     ) {
         init {
             require(resolutionTimeoutMilliseconds > 0) { "resolutionTimeoutMilliseconds must be positive" }
             require(diagnosticOutputLimitBytes >= 0) { "diagnosticOutputLimitBytes must not be negative" }
+            require(androidProfiles.isNotEmpty()) { "At least one Android profile is required" }
+            require(androidProfiles.map(AndroidToolchainProfile::id).distinct().size == androidProfiles.size) {
+                "Android profile ids must be unique"
+            }
+            require(androidBaselineMinSdk > 0) { "Android baseline minSdk must be positive" }
+            require(androidToolingInstallTimeoutMilliseconds > 0) {
+                "Android tooling install timeout must be positive"
+            }
+            require(!installMissingAndroidTooling || androidSdkRoot != null) {
+                "androidSdkRoot is required when Android tooling installation is enabled"
+            }
+            require(!installMissingAndroidTooling || androidSdkManagerExecutable != null) {
+                "androidSdkManagerExecutable is required when Android tooling installation is enabled"
+            }
+        }
+
+        public companion object {
+            @JvmField
+            public val DEFAULT_ANDROID_PROFILES: List<AndroidToolchainProfile> =
+                listOf(
+                    AndroidToolchainProfile(
+                        id = "android-36-stable",
+                        compileSdk = 36,
+                        targetSdk = 36,
+                        buildToolsVersion = "36.0.0",
+                        agpVersion = "9.3.1",
+                        gradleVersion = "9.5.0",
+                    ),
+                    AndroidToolchainProfile(
+                        id = "android-37-preview",
+                        compileSdk = 37,
+                        targetSdk = 36,
+                        buildToolsVersion = "36.0.0",
+                        agpVersion = "9.3.1",
+                        gradleVersion = "9.5.0",
+                        channel = AndroidSdkChannel.PREVIEW,
+                    ),
+                )
         }
     }

--- a/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsConfig.kt
+++ b/jvm-package-build-stats/core/src/main/kotlin/com/bundlephobia/jvm/PackageBuildStatsConfig.kt
@@ -28,6 +28,8 @@ public data class PackageBuildStatsConfig
         public val installMissingAndroidTooling: Boolean = false,
         /** Hard wall-clock limit for one Android CLI SDK installation. */
         public val androidToolingInstallTimeoutMilliseconds: Long = 180_000,
+        /** Hard wall-clock limit for unshrunk D8 measurement. */
+        public val androidDexTimeoutMilliseconds: Long = 120_000,
     ) {
         init {
             require(resolutionTimeoutMilliseconds > 0) { "resolutionTimeoutMilliseconds must be positive" }
@@ -40,6 +42,7 @@ public data class PackageBuildStatsConfig
             require(androidToolingInstallTimeoutMilliseconds > 0) {
                 "Android tooling install timeout must be positive"
             }
+            require(androidDexTimeoutMilliseconds > 0) { "Android DEX timeout must be positive" }
             require(!installMissingAndroidTooling || androidSdkRoot != null) {
                 "androidSdkRoot is required when Android tooling installation is enabled"
             }

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/AndroidDexAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/AndroidDexAnalyzerTest.kt
@@ -1,0 +1,183 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AndroidDexStatus
+import com.bundlephobia.jvm.model.AndroidPreflightStats
+import com.bundlephobia.jvm.model.AndroidRequirementConfidence
+import com.bundlephobia.jvm.model.AndroidToolingStatus
+import com.bundlephobia.jvm.model.ArtifactDigest
+import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResolvedArtifact
+import org.junit.jupiter.api.io.TempDir
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AndroidDexAnalyzerTest {
+    @TempDir lateinit var tempDir: Path
+
+    @Test
+    fun `reports bounded aggregate counts from D8 output`() {
+        val sdkRoot = fakeSdk()
+        val profile = PackageBuildStatsConfig.DEFAULT_ANDROID_PROFILES.first()
+        val result =
+            AndroidDexAnalyzer(PackageBuildStatsConfig(androidSdkRoot = sdkRoot)).analyze(
+                resolution = resolution(aar()),
+                preflight =
+                    AndroidPreflightStats(
+                        requiredMinSdk = 23,
+                        requiredCompileSdk = 36,
+                        confidence = AndroidRequirementConfidence.DECLARED,
+                        selectedProfile = profile,
+                        toolingStatus = AndroidToolingStatus.READY,
+                    ),
+                cancellation = AnalysisCancellation.NONE,
+            )
+
+        assertEquals(AndroidDexStatus.COMPLETE, result.stats.status)
+        assertEquals(224L, result.stats.dexBytes)
+        assertEquals(2, result.stats.dexFiles)
+        assertEquals(1_734L, result.stats.referencedMethods)
+        assertEquals(1_234L, result.stats.maxReferencedMethodsPerDex)
+        assertEquals(334L, result.stats.referencedFields)
+        assertEquals(66L, result.stats.definedClasses)
+        assertTrue(result.stats.multidex)
+        assertTrue(result.diagnostics.isEmpty())
+    }
+
+    @Test
+    fun `retains only bounded D8 failure output`() {
+        val sdkRoot = fakeSdk()
+        val d8 = sdkRoot.resolve("build-tools/36.0.0/d8")
+        Files.writeString(
+            d8,
+            "#!/bin/sh\ni=0\nwhile [ \"${'$'}i\" -lt 200 ]; do echo 'discarded diagnostic line'; i=${'$'}((i + 1)); done\n" +
+                "echo 'final useful detail'\nexit 7\n",
+        )
+        executable(d8)
+        val profile = PackageBuildStatsConfig.DEFAULT_ANDROID_PROFILES.first()
+        val result =
+            AndroidDexAnalyzer(
+                PackageBuildStatsConfig(
+                    androidSdkRoot = sdkRoot,
+                    diagnosticOutputLimitBytes = 64,
+                ),
+            ).analyze(
+                resolution = resolution(aar()),
+                preflight =
+                    AndroidPreflightStats(
+                        requiredMinSdk = 23,
+                        requiredCompileSdk = 36,
+                        confidence = AndroidRequirementConfidence.DECLARED,
+                        selectedProfile = profile,
+                        toolingStatus = AndroidToolingStatus.READY,
+                    ),
+                cancellation = AnalysisCancellation.NONE,
+            )
+
+        assertEquals(AndroidDexStatus.FAILED, result.stats.status)
+        assertTrue(
+            result.diagnostics
+                .single()
+                .summary
+                .contains("final useful detail"),
+        )
+        assertTrue(
+            result.diagnostics
+                .single()
+                .summary.length < 160,
+        )
+    }
+
+    private fun fakeSdk(): Path {
+        val sdkRoot = tempDir.resolve("sdk")
+        val platform = sdkRoot.resolve("platforms/android-36")
+        val buildTools = sdkRoot.resolve("build-tools/36.0.0")
+        Files.createDirectories(platform)
+        Files.createDirectories(buildTools)
+        Files.write(platform.resolve("android.jar"), byteArrayOf())
+        val primaryDex = dex("primary.dex", methods = 1_234, fields = 234, classes = 56)
+        val secondaryDex = dex("secondary.dex", methods = 500, fields = 100, classes = 10)
+        val d8 = buildTools.resolve("d8")
+        Files.writeString(
+            d8,
+            "#!/bin/sh\n" +
+                "while [ \"${'$'}#\" -gt 0 ]; do\n" +
+                "  if [ \"${'$'}1\" = \"--output\" ]; then shift; " +
+                "cp '$primaryDex' \"${'$'}1/classes.dex\"; cp '$secondaryDex' \"${'$'}1/classes2.dex\"; exit 0; fi\n" +
+                "  shift\n" +
+                "done\nexit 1\n",
+        )
+        executable(d8)
+        return sdkRoot
+    }
+
+    private fun executable(path: Path) {
+        Files.setPosixFilePermissions(
+            path,
+            setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+            ),
+        )
+    }
+
+    private fun dex(
+        name: String,
+        methods: Int,
+        fields: Int,
+        classes: Int,
+    ): Path {
+        val path = tempDir.resolve(name)
+        val header = ByteBuffer.allocate(112).order(ByteOrder.LITTLE_ENDIAN)
+        header.put("dex\n035\u0000".toByteArray())
+        header.putInt(32, 112)
+        header.putInt(80, fields)
+        header.putInt(88, methods)
+        header.putInt(96, classes)
+        Files.write(path, header.array())
+        return path
+    }
+
+    private fun resolution(archive: Path): ResolutionStats {
+        val coordinate = MavenCoordinate.parse("androidx.example:dex-fixture:1.0")
+        return ResolutionStats(
+            requested = coordinate,
+            artifacts =
+                listOf(
+                    ResolvedArtifact(
+                        coordinate = coordinate,
+                        fileName = archive.fileName.toString(),
+                        path = archive.toString(),
+                        extension = "aar",
+                        variant = "releaseRuntimeElements",
+                        digest = ArtifactDigest(value = "fixture"),
+                    ),
+                ),
+        )
+    }
+
+    private fun aar(): Path {
+        val archive = tempDir.resolve("fixture.aar")
+        val classes = tempDir.resolve("classes.jar")
+        ZipOutputStream(Files.newOutputStream(classes)).use { output ->
+            output.putNextEntry(ZipEntry("fixture.txt"))
+            output.write(byteArrayOf(1))
+            output.closeEntry()
+        }
+        ZipOutputStream(Files.newOutputStream(archive)).use { output ->
+            output.putNextEntry(ZipEntry("classes.jar"))
+            output.write(Files.readAllBytes(classes))
+            output.closeEntry()
+        }
+        return archive
+    }
+}

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/AndroidPreflightAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/AndroidPreflightAnalyzerTest.kt
@@ -1,0 +1,119 @@
+package com.bundlephobia.jvm
+
+import com.bundlephobia.jvm.model.AndroidSdkChannel
+import com.bundlephobia.jvm.model.AndroidToolingStatus
+import com.bundlephobia.jvm.model.ArtifactDigest
+import com.bundlephobia.jvm.model.MavenCoordinate
+import com.bundlephobia.jvm.model.ResolutionStats
+import com.bundlephobia.jvm.model.ResolvedArtifact
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AndroidPreflightAnalyzerTest {
+    @TempDir lateinit var tempDir: Path
+
+    @Test
+    fun `selects preview only when declared metadata exceeds stable profile`() {
+        val result = analyze(aar(minSdk = 26, minCompileSdk = 37, minAgp = "8.9.0"))
+
+        assertEquals(26, result.stats.requiredMinSdk)
+        assertEquals(37, result.stats.requiredCompileSdk)
+        assertEquals("android-37-preview", result.stats.selectedProfile?.id)
+        assertEquals(AndroidSdkChannel.PREVIEW, result.stats.selectedProfile?.channel)
+        assertEquals(AndroidToolingStatus.MISSING, result.stats.toolingStatus)
+        assertEquals(listOf("platforms;android-37", "build-tools;36.0.0"), result.stats.missingToolingPackages)
+    }
+
+    @Test
+    fun `reports unsupported requirements before Android tooling runs`() {
+        val result = analyze(aar(minSdk = 21, minCompileSdk = 38, minAgp = "10.0.0"))
+
+        assertNull(result.stats.selectedProfile)
+        assertEquals(AndroidToolingStatus.UNSUPPORTED, result.stats.toolingStatus)
+        assertTrue(result.diagnostics.any { it.code == "ANDROID_PROFILE_UNSUPPORTED" })
+    }
+
+    @Test
+    fun `provisions only selected immutable sdk packages`() {
+        val sdkRoot = tempDir.resolve("sdk")
+        val sdkManager = tempDir.resolve("sdkmanager")
+        Files.writeString(
+            sdkManager,
+            "#!/bin/sh\nmkdir -p '${sdkRoot.resolve("platforms/android-36")}' '${sdkRoot.resolve("build-tools/36.0.0")}'\n" +
+                "touch '${sdkRoot.resolve("platforms/android-36/android.jar")}' '${sdkRoot.resolve("build-tools/36.0.0/d8")}'\n",
+        )
+        Files.setPosixFilePermissions(
+            sdkManager,
+            setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+            ),
+        )
+        val result =
+            AndroidPreflightAnalyzer(
+                PackageBuildStatsConfig(
+                    androidSdkRoot = sdkRoot,
+                    androidSdkManagerExecutable = sdkManager,
+                    installMissingAndroidTooling = true,
+                ),
+            ).analyze(resolution(aar(minSdk = 24, minCompileSdk = 35, minAgp = "8.0.0")), AnalysisCancellation.NONE)
+
+        assertEquals(AndroidToolingStatus.INSTALLED, result.stats.toolingStatus)
+        assertTrue(result.stats.missingToolingPackages.isEmpty())
+        assertTrue(Files.isRegularFile(sdkRoot.resolve("platforms/android-36/android.jar")))
+        assertTrue(Files.isRegularFile(sdkRoot.resolve("build-tools/36.0.0/d8")))
+    }
+
+    private fun analyze(path: Path): AndroidPreflightResult =
+        AndroidPreflightAnalyzer(PackageBuildStatsConfig()).analyze(resolution(path), AnalysisCancellation.NONE)
+
+    private fun resolution(path: Path): ResolutionStats {
+        val coordinate = MavenCoordinate.parse("androidx.example:fixture:1.0")
+        return ResolutionStats(
+            requested = coordinate,
+            artifacts =
+                listOf(
+                    ResolvedArtifact(
+                        coordinate = coordinate,
+                        fileName = path.fileName.toString(),
+                        path = path.toString(),
+                        extension = "aar",
+                        variant = "releaseRuntimeElements",
+                        digest = ArtifactDigest(value = "fixture"),
+                    ),
+                ),
+        )
+    }
+
+    private fun aar(
+        minSdk: Int,
+        minCompileSdk: Int,
+        minAgp: String,
+    ): Path {
+        val path = tempDir.resolve("fixture-$minCompileSdk.aar")
+        ZipOutputStream(Files.newOutputStream(path)).use { output ->
+            output.putNextEntry(ZipEntry("AndroidManifest.xml"))
+            output.write(
+                """<manifest xmlns:android="http://schemas.android.com/apk/res/android"><uses-sdk android:minSdkVersion="$minSdk" /></manifest>"""
+                    .toByteArray(),
+            )
+            output.closeEntry()
+            output.putNextEntry(ZipEntry("META-INF/com/android/build/gradle/aar-metadata.properties"))
+            output.write(
+                "minCompileSdk=$minCompileSdk\nminCompileSdkExtension=0\nminAndroidGradlePluginVersion=$minAgp\n"
+                    .toByteArray(),
+            )
+            output.closeEntry()
+        }
+        return path
+    }
+}

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -412,6 +412,41 @@ class PackageBuildStatsAnalyzerTest {
         assertEquals(classBytes.size.toLong(), result.namespaces.single().classBytes)
     }
 
+    @Test
+    fun `assembles Android AAR size and preflight evidence`() {
+        val coordinate = MavenCoordinate.parse("androidx.example:fixture:1.0")
+        val archive = androidArchive()
+        val resolution =
+            JvmResolutionResult(
+                status = ResultStatus.COMPLETE,
+                target = TargetProfile.ANDROID_RUNTIME,
+                resolution =
+                    ResolutionStats(
+                        requested = coordinate,
+                        components = listOf(ResolvedComponent(coordinate, requested = true)),
+                        artifacts =
+                            listOf(
+                                ResolvedArtifact(
+                                    coordinate = coordinate,
+                                    fileName = archive.fileName.toString(),
+                                    path = archive.toString(),
+                                    extension = "aar",
+                                    variant = "releaseRuntimeElements",
+                                    digest = ArtifactDigest(value = sha256(archive)),
+                                ),
+                            ),
+                    ),
+            )
+
+        val result = analyzer(resolution).analyze(AnalyzeRequest(coordinate, TargetProfile.ANDROID_RUNTIME))
+
+        assertEquals(ResultStatus.COMPLETE, result.status)
+        assertEquals("fixture.aar", result.directArtifact?.displayName)
+        assertEquals(26, result.androidPreflight?.requiredMinSdk)
+        assertEquals("android-36-stable", result.androidPreflight?.selectedProfile?.id)
+        assertTrue(result.sizes.runtimeArchiveBytes > 0)
+    }
+
     private fun analyzer(resolution: JvmResolutionResult): PackageBuildStatsAnalyzer =
         PackageBuildStatsAnalyzer(
             config = PackageBuildStatsConfig(),
@@ -459,6 +494,22 @@ class PackageBuildStatsAnalyzerTest {
             output.closeEntry()
         }
         return jar
+    }
+
+    private fun androidArchive(): Path {
+        val archive = tempDir.resolve("fixture.aar")
+        ZipOutputStream(Files.newOutputStream(archive)).use { output ->
+            output.putNextEntry(ZipEntry("AndroidManifest.xml"))
+            output.write(
+                """<manifest xmlns:android="http://schemas.android.com/apk/res/android"><uses-sdk android:minSdkVersion="26" /></manifest>"""
+                    .toByteArray(),
+            )
+            output.closeEntry()
+            output.putNextEntry(ZipEntry("META-INF/com/android/build/gradle/aar-metadata.properties"))
+            output.write("minCompileSdk=35\nminAndroidGradlePluginVersion=8.0.0\n".toByteArray())
+            output.closeEntry()
+        }
+        return archive
     }
 
     private fun sha256(path: Path): String = HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path)))

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -443,6 +443,9 @@ class PackageBuildStatsAnalyzerTest {
 
         assertEquals(ResultStatus.COMPLETE, result.status)
         assertEquals("fixture.aar", result.directArtifact?.displayName)
+        assertEquals(1, result.directArtifact?.classfiles?.analyzedClasses)
+        assertTrue(requireNotNull(result.directArtifact?.classfiles?.definedMethods) > 0)
+        assertTrue(requireNotNull(result.directArtifact?.classfiles?.classfileBytes) > 0)
         assertEquals(26, result.androidPreflight?.requiredMinSdk)
         assertEquals("android-36-stable", result.androidPreflight?.selectedProfile?.id)
         assertEquals(AndroidDexStatus.SKIPPED, result.androidDex?.status)
@@ -500,6 +503,17 @@ class PackageBuildStatsAnalyzerTest {
 
     private fun androidArchive(): Path {
         val archive = tempDir.resolve("fixture.aar")
+        val resourceName = PackageBuildStatsAnalyzerTest::class.java.name.replace('.', '/') + ".class"
+        val classBytes = requireNotNull(javaClass.classLoader.getResourceAsStream(resourceName)).use { it.readAllBytes() }
+        val classesJar =
+            java.io.ByteArrayOutputStream().use { bytes ->
+                ZipOutputStream(bytes).use { output ->
+                    output.putNextEntry(ZipEntry(resourceName))
+                    output.write(classBytes)
+                    output.closeEntry()
+                }
+                bytes.toByteArray()
+            }
         ZipOutputStream(Files.newOutputStream(archive)).use { output ->
             output.putNextEntry(ZipEntry("AndroidManifest.xml"))
             output.write(
@@ -509,6 +523,9 @@ class PackageBuildStatsAnalyzerTest {
             output.closeEntry()
             output.putNextEntry(ZipEntry("META-INF/com/android/build/gradle/aar-metadata.properties"))
             output.write("minCompileSdk=35\nminAndroidGradlePluginVersion=8.0.0\n".toByteArray())
+            output.closeEntry()
+            output.putNextEntry(ZipEntry("classes.jar"))
+            output.write(classesJar)
             output.closeEntry()
         }
         return archive

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -1,6 +1,7 @@
 package com.bundlephobia.jvm
 
 import com.bundlephobia.jvm.model.AnalyzeRequest
+import com.bundlephobia.jvm.model.AndroidDexStatus
 import com.bundlephobia.jvm.model.ArtifactDigest
 import com.bundlephobia.jvm.model.DependencyEdge
 import com.bundlephobia.jvm.model.Diagnostic
@@ -444,6 +445,7 @@ class PackageBuildStatsAnalyzerTest {
         assertEquals("fixture.aar", result.directArtifact?.displayName)
         assertEquals(26, result.androidPreflight?.requiredMinSdk)
         assertEquals("android-36-stable", result.androidPreflight?.selectedProfile?.id)
+        assertEquals(AndroidDexStatus.SKIPPED, result.androidDex?.status)
         assertTrue(result.sizes.runtimeArchiveBytes > 0)
     }
 

--- a/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
+++ b/jvm-package-build-stats/core/src/test/kotlin/com/bundlephobia/jvm/PackageBuildStatsAnalyzerTest.kt
@@ -11,6 +11,7 @@ import com.bundlephobia.jvm.model.ResolvedArtifact
 import com.bundlephobia.jvm.model.ResolvedComponent
 import com.bundlephobia.jvm.model.ResultJson
 import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.TargetProfile
 import com.bundlephobia.jvm.model.TimingStats
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
@@ -281,7 +282,7 @@ class PackageBuildStatsAnalyzerTest {
                     gradleExecutable = executable,
                     resolutionTimeoutMilliseconds = 25,
                 ),
-            ).resolve(coordinate, 21, AnalysisCancellation.NONE)
+            ).resolve(coordinate, TargetProfile.JVM_RUNTIME, 21, AnalysisCancellation.NONE)
 
         assertEquals(ResultStatus.FAILED, result.status)
         assertEquals("RESOLUTION_TIMEOUT", result.diagnostics.single().code)
@@ -308,7 +309,12 @@ class PackageBuildStatsAnalyzerTest {
                 PackageBuildStatsConfig(
                     gradleExecutable = executable,
                 ),
-            ).resolve(coordinate, 21, AnalysisCancellation { System.nanoTime() - started > 50_000_000 })
+            ).resolve(
+                coordinate,
+                TargetProfile.JVM_RUNTIME,
+                21,
+                AnalysisCancellation { System.nanoTime() - started > 50_000_000 },
+            )
 
         assertEquals(ResultStatus.FAILED, result.status)
         assertEquals("RESOLUTION_CANCELLED", result.diagnostics.single().code)
@@ -336,7 +342,7 @@ class PackageBuildStatsAnalyzerTest {
                     temporaryDirectory = temporaryDirectory,
                     diagnosticOutputLimitBytes = 128,
                 ),
-            ).resolve(coordinate, 21, AnalysisCancellation.NONE)
+            ).resolve(coordinate, TargetProfile.JVM_RUNTIME, 21, AnalysisCancellation.NONE)
 
         assertEquals(ResultStatus.FAILED, result.status)
         assertTrue(
@@ -368,7 +374,7 @@ class PackageBuildStatsAnalyzerTest {
                     gradleExecutable = executable,
                     diagnosticOutputLimitBytes = 1_024,
                 ),
-            ).resolve(coordinate, 21, AnalysisCancellation.NONE)
+            ).resolve(coordinate, TargetProfile.JVM_RUNTIME, 21, AnalysisCancellation.NONE)
 
         assertTrue(
             result.diagnostics
@@ -409,7 +415,7 @@ class PackageBuildStatsAnalyzerTest {
     private fun analyzer(resolution: JvmResolutionResult): PackageBuildStatsAnalyzer =
         PackageBuildStatsAnalyzer(
             config = PackageBuildStatsConfig(),
-            resolverClient = ResolverClient { _, _, _ -> resolution },
+            resolverClient = ResolverClient { _, _, _, _ -> resolution },
         )
 
     private fun resolution(

--- a/jvm-package-build-stats/docs/JAVASCRIPT-JVM-CONCEPTS.md
+++ b/jvm-package-build-stats/docs/JAVASCRIPT-JVM-CONCEPTS.md
@@ -99,8 +99,11 @@ stdout is redirected; `--pretty` and `--json` make that choice explicit.
 - Android runtime selection and compatibility preflight are package-level
   operations. Declared AAR requirements select a pinned stable or preview SDK
   profile before any compiler, D8, or R8 process is started.
+- With that profile ready, unshrunk DEX bytes and reference counts are measured
+  by D8 over the complete runtime closure. This is the Android analogue of a
+  reproducible package-level bundled measurement, not reachability analysis.
 
 Per-member marginal byte size, whole-program reachability, ProGuard/R8 shrinker
-simulation and DEX counts, native-image reachability, and runtime memory are
-not claimed by the current schema. Those require an explicit consumer program
-and toolchain policy rather than package-only static analysis.
+simulation, native-image reachability, and runtime memory are not claimed by
+the current schema. Those require an explicit consumer program and toolchain
+policy rather than package-only static analysis.

--- a/jvm-package-build-stats/docs/JAVASCRIPT-JVM-CONCEPTS.md
+++ b/jvm-package-build-stats/docs/JAVASCRIPT-JVM-CONCEPTS.md
@@ -6,19 +6,19 @@ different ecosystems into the same measurement model.
 
 ## Concept map
 
-| Developer question | Node/package-build-stats | JVM equivalent | JVM result field |
-| --- | --- | --- | --- |
-| What is the package's headline weight? | Built main asset after bundling | Selected runtime JARs as published | `sizes.runtimeArchiveBytes` |
-| What belongs to the requested package? | Main package contribution | JARs selected for the requested coordinate | `sizes.directArtifactArchiveBytes` |
-| What do dependencies add? | Bundler dependency contribution | Selected transitive runtime JARs | `sizes.transitiveArtifactArchiveBytes` |
-| What is the expanded payload? | Bundler/module output | Uncompressed entries inside selected JARs | `sizes.runtimeExpandedBytes` |
-| Which dependency contributes each byte total? | Dependency size tree | Exact selected-component totals and shortest paths | `dependencySizes` |
-| What can consumers call? | ESM/CommonJS exports | Aggregate public/protected JVM types and members | `apiSurface.publicTypes`, `apiSurface.publicMembers` |
-| Which API types are physically largest? | Independently tree-shaken export bundle | Largest visible classfiles, not marginal export sizes | `apiSurface.largestTypes[].classfileBytes` |
-| Which module boundary applies? | ESM/CommonJS package entry points | Explicit, automatic, or unnamed JPMS module | `module.kind` |
-| Which namespaces are exported? | Package export map | JPMS exports, including qualified exports | `module.exports` |
-| Which runtime variant was selected? | Conditional exports and bundler target | Gradle attributes, capabilities, Java target, and multi-release view | `resolution.components[].variants`, `javaVersion` |
-| Is unused code removable? | Bundler tree shaking | No general JVM equivalent; report API versus implementation classes and dynamic-linkage evidence | `classfiles`, `apiSurface` |
+| Developer question                            | Node/package-build-stats                | JVM equivalent                                                                                   | JVM result field                                     |
+| --------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
+| What is the package's headline weight?        | Built main asset after bundling         | Selected runtime JARs as published                                                               | `sizes.runtimeArchiveBytes`                          |
+| What belongs to the requested package?        | Main package contribution               | JARs selected for the requested coordinate                                                       | `sizes.directArtifactArchiveBytes`                   |
+| What do dependencies add?                     | Bundler dependency contribution         | Selected transitive runtime JARs                                                                 | `sizes.transitiveArtifactArchiveBytes`               |
+| What is the expanded payload?                 | Bundler/module output                   | Uncompressed entries inside selected JARs                                                        | `sizes.runtimeExpandedBytes`                         |
+| Which dependency contributes each byte total? | Dependency size tree                    | Exact selected-component totals and shortest paths                                               | `dependencySizes`                                    |
+| What can consumers call?                      | ESM/CommonJS exports                    | Aggregate public/protected JVM types and members                                                 | `apiSurface.publicTypes`, `apiSurface.publicMembers` |
+| Which API types are physically largest?       | Independently tree-shaken export bundle | Largest visible classfiles, not marginal export sizes                                            | `apiSurface.largestTypes[].classfileBytes`           |
+| Which module boundary applies?                | ESM/CommonJS package entry points       | Explicit, automatic, or unnamed JPMS module                                                      | `module.kind`                                        |
+| Which namespaces are exported?                | Package export map                      | JPMS exports, including qualified exports                                                        | `module.exports`                                     |
+| Which runtime variant was selected?           | Conditional exports and bundler target  | Gradle attributes, capabilities, Java target, and multi-release view                             | `resolution.components[].variants`, `javaVersion`    |
+| Is unused code removable?                     | Bundler tree shaking                    | No general JVM equivalent; report API versus implementation classes and dynamic-linkage evidence | `classfiles`, `apiSurface`                           |
 
 ## Size terminology
 
@@ -96,8 +96,11 @@ stdout is redirected; `--pretty` and `--json` make that choice explicit.
   diagnostic.
 - Persistent caching and result retention belong to the calling service, not
   this analysis library.
+- Android runtime selection and compatibility preflight are package-level
+  operations. Declared AAR requirements select a pinned stable or preview SDK
+  profile before any compiler, D8, or R8 process is started.
 
 Per-member marginal byte size, whole-program reachability, ProGuard/R8 shrinker
-simulation, Android variants, native-image reachability, and runtime memory are
+simulation and DEX counts, native-image reachability, and runtime memory are
 not claimed by the current schema. Those require an explicit consumer program
 and toolchain policy rather than package-only static analysis.

--- a/jvm-package-build-stats/docs/JAVASCRIPT-JVM-CONCEPTS.md
+++ b/jvm-package-build-stats/docs/JAVASCRIPT-JVM-CONCEPTS.md
@@ -102,6 +102,10 @@ stdout is redirected; `--pretty` and `--json` make that choice explicit.
 - With that profile ready, unshrunk DEX bytes and reference counts are measured
   by D8 over the complete runtime closure. This is the Android analogue of a
   reproducible package-level bundled measurement, not reachability analysis.
+- For Android AARs, classes, methods, fields, and classfile bytes physically
+  defined by the requested artifact are reported separately from the complete
+  closure. This is the package-attributable headline; DEX references remain the
+  deployable closure context.
 
 Per-member marginal byte size, whole-program reachability, ProGuard/R8 shrinker
 simulation, native-image reachability, and runtime memory are not claimed by

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
@@ -19,13 +19,24 @@ public enum class ResultStatus {
 public enum class TargetProfile {
     @SerialName("jvm-runtime")
     JVM_RUNTIME,
+
+    @SerialName("android-runtime")
+    ANDROID_RUNTIME,
     ;
+
+    public val serializedValue: String
+        get() =
+            when (this) {
+                JVM_RUNTIME -> "jvm-runtime"
+                ANDROID_RUNTIME -> "android-runtime"
+            }
 
     public companion object {
         @JvmStatic
         public fun parse(value: String): TargetProfile =
             when (value) {
                 "jvm-runtime" -> JVM_RUNTIME
+                "android-runtime" -> ANDROID_RUNTIME
                 else -> throw IllegalArgumentException("Unsupported target profile: $value")
             }
     }
@@ -56,6 +67,12 @@ public enum class AnalysisStage {
 
     @SerialName("classfile-analysis")
     CLASSFILE_ANALYSIS,
+
+    @SerialName("android-preflight")
+    ANDROID_PREFLIGHT,
+
+    @SerialName("toolchain-provisioning")
+    TOOLCHAIN_PROVISIONING,
 
     @SerialName("assembly")
     ASSEMBLY,
@@ -107,6 +124,104 @@ public data class ToolchainManifest(
     public val jdkVendor: String,
     public val kotlinVersion: String,
     public val gradleVersion: String,
+)
+
+@Serializable
+public enum class AndroidSdkChannel {
+    @SerialName("stable")
+    STABLE,
+
+    @SerialName("preview")
+    PREVIEW,
+}
+
+/** One immutable Android build environment supported by the analyzer. */
+@Serializable
+public data class AndroidToolchainProfile
+    @JvmOverloads
+    constructor(
+        public val id: String,
+        public val compileSdk: Int,
+        public val targetSdk: Int,
+        public val buildToolsVersion: String,
+        public val agpVersion: String,
+        public val gradleVersion: String,
+        public val compileSdkExtension: Int = 0,
+        public val compileSdkPreview: String? = null,
+        public val jdkVersion: Int = 17,
+        public val channel: AndroidSdkChannel = AndroidSdkChannel.STABLE,
+    ) {
+        init {
+            require(id.isNotBlank()) { "Android profile id must not be blank" }
+            require(compileSdk > 0) { "compileSdk must be positive" }
+            require(compileSdkExtension >= 0) { "compileSdkExtension must not be negative" }
+            require(compileSdkPreview == null || compileSdkPreview.matches(Regex("[A-Za-z][A-Za-z0-9_]*"))) {
+                "compileSdkPreview is invalid"
+            }
+            require(targetSdk > 0) { "targetSdk must be positive" }
+            require(buildToolsVersion.matches(Regex("\\d+\\.\\d+\\.\\d+"))) { "Build Tools version must be numeric" }
+            require(agpVersion.matches(Regex("\\d+(?:\\.\\d+)+(?:[-.][A-Za-z0-9]+)*"))) { "AGP version is invalid" }
+            require(gradleVersion.matches(Regex("\\d+(?:\\.\\d+)+(?:[-.][A-Za-z0-9]+)*"))) { "Gradle version is invalid" }
+            require(jdkVersion >= 17) { "Android toolchains require JDK 17 or newer" }
+        }
+    }
+
+@Serializable
+public enum class AndroidRequirementConfidence {
+    @SerialName("declared")
+    DECLARED,
+
+    @SerialName("inferred")
+    INFERRED,
+
+    @SerialName("unknown")
+    UNKNOWN,
+}
+
+@Serializable
+public enum class AndroidToolingStatus {
+    @SerialName("ready")
+    READY,
+
+    @SerialName("missing")
+    MISSING,
+
+    @SerialName("installed")
+    INSTALLED,
+
+    @SerialName("unsupported")
+    UNSUPPORTED,
+}
+
+/** Bounded compatibility evidence from one selected Android runtime artifact. */
+@Serializable
+public data class AndroidArtifactRequirement(
+    public val coordinate: MavenCoordinate,
+    public val fileName: String,
+    public val minSdk: Int? = null,
+    public val minCompileSdk: Int? = null,
+    public val minCompileSdkExtension: Int? = null,
+    public val compileSdkPreview: String? = null,
+    public val minAgpVersion: String? = null,
+    public val metadataDeclared: Boolean = false,
+)
+
+/** Requirements calculated before any Android compilation, D8, or R8 work starts. */
+@Serializable
+public data class AndroidPreflightStats(
+    public val requiredMinSdk: Int,
+    public val requiredCompileSdk: Int,
+    public val requiredCompileSdkExtension: Int = 0,
+    public val requiredCompileSdkPreview: String? = null,
+    public val requiredAgpVersion: String? = null,
+    public val confidence: AndroidRequirementConfidence,
+    public val selectedProfile: AndroidToolchainProfile? = null,
+    public val effectiveMinSdk: Int = requiredMinSdk,
+    public val toolingStatus: AndroidToolingStatus,
+    public val missingToolingPackages: List<String> = emptyList(),
+    public val artifactRequirements: List<AndroidArtifactRequirement> = emptyList(),
+    public val artifactRequirementCount: Int = artifactRequirements.size,
+    public val artifactRequirementsTruncated: Boolean = false,
 )
 
 @Serializable
@@ -363,9 +478,9 @@ public data class JvmResolutionResult(
 
 @Serializable
 public data class RuntimeClosureStats(
-    /** Bytes occupied by every unique runtime JAR, including the requested artifact. */
+    /** Bytes occupied by every unique runtime archive, including the requested artifact. */
     public val archiveBytes: Long = 0,
-    /** Sum of uncompressed entry bytes across every unique runtime JAR. */
+    /** Sum of uncompressed entry bytes across every unique runtime archive. */
     public val expandedBytes: Long = 0,
     /** Archive bytes belonging to the requested component. */
     public val directArtifactBytes: Long = 0,
@@ -379,16 +494,16 @@ public data class RuntimeClosureStats(
     public val shortestPaths: List<DependencyPath> = emptyList(),
     public val shortestPathCount: Int = shortestPaths.size,
     public val shortestPathsTruncated: Boolean = false,
-    /** Up to ten largest transitive runtime JARs, ordered by archive bytes. */
+    /** Up to ten largest transitive runtime archives, ordered by archive bytes. */
     public val largestTransitiveArtifacts: List<RuntimeArtifactSummary> = emptyList(),
 )
 
 /** Headline package-size measurements for the selected JVM runtime closure. */
 @Serializable
 public data class PackageSizeStats(
-    /** Complete bytes of every unique selected runtime JAR. */
+    /** Complete bytes of every unique selected runtime archive. */
     public val runtimeArchiveBytes: Long = 0,
-    /** Sum of uncompressed entry bytes across every unique selected runtime JAR. */
+    /** Sum of uncompressed entry bytes across every unique selected runtime archive. */
     public val runtimeExpandedBytes: Long = 0,
     /** Complete archive bytes belonging to the requested coordinate. */
     public val directArtifactArchiveBytes: Long = 0,
@@ -452,6 +567,7 @@ public data class PackageBuildStatsResult(
     public val artifactsTruncated: Boolean = false,
     public val directArtifact: ArtifactAnalysis? = null,
     public val runtimeClosure: RuntimeClosureStats = RuntimeClosureStats(),
+    public val androidPreflight: AndroidPreflightStats? = null,
     public val diagnostics: List<Diagnostic> = emptyList(),
     public val diagnosticCount: Int = diagnostics.size,
     public val diagnosticsTruncated: Boolean = false,

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
@@ -74,6 +74,9 @@ public enum class AnalysisStage {
     @SerialName("toolchain-provisioning")
     TOOLCHAIN_PROVISIONING,
 
+    @SerialName("dex-analysis")
+    DEX_ANALYSIS,
+
     @SerialName("assembly")
     ASSEMBLY,
 }
@@ -223,6 +226,51 @@ public data class AndroidPreflightStats(
     public val artifactRequirementCount: Int = artifactRequirements.size,
     public val artifactRequirementsTruncated: Boolean = false,
 )
+
+@Serializable
+public enum class AndroidDexStatus {
+    @SerialName("complete")
+    COMPLETE,
+
+    @SerialName("skipped")
+    SKIPPED,
+
+    @SerialName("failed")
+    FAILED,
+}
+
+/** Whole-runtime-closure D8 output. Counts are unshrunk and summed across generated DEX files. */
+@Serializable
+public data class AndroidDexStats(
+    public val status: AndroidDexStatus,
+    public val dexBytes: Long? = null,
+    public val dexFiles: Int = 0,
+    public val referencedMethods: Long? = null,
+    public val maxReferencedMethodsPerDex: Long? = null,
+    public val referencedFields: Long? = null,
+    public val definedClasses: Long? = null,
+    public val multidex: Boolean = dexFiles > 1,
+    public val minSdk: Int,
+    public val buildToolsVersion: String,
+) {
+    init {
+        require(dexFiles >= 0) { "dexFiles must not be negative" }
+        require(listOfNotNull(dexBytes, referencedMethods, maxReferencedMethodsPerDex, referencedFields, definedClasses).all { it >= 0 }) {
+            "DEX measurements must not be negative"
+        }
+        require(multidex == (dexFiles > 1)) { "multidex must match dexFiles" }
+        require(minSdk > 0) { "DEX minSdk must be positive" }
+        require(buildToolsVersion.isNotBlank()) { "DEX Build Tools version must not be blank" }
+        if (status == AndroidDexStatus.COMPLETE) {
+            require(dexFiles > 0) { "Complete DEX statistics require at least one DEX file" }
+            requireNotNull(dexBytes) { "Complete DEX statistics require dexBytes" }
+            requireNotNull(referencedMethods) { "Complete DEX statistics require referencedMethods" }
+            requireNotNull(maxReferencedMethodsPerDex) { "Complete DEX statistics require maxReferencedMethodsPerDex" }
+            requireNotNull(referencedFields) { "Complete DEX statistics require referencedFields" }
+            requireNotNull(definedClasses) { "Complete DEX statistics require definedClasses" }
+        }
+    }
+}
 
 @Serializable
 public data class ArtifactDigest(
@@ -568,6 +616,7 @@ public data class PackageBuildStatsResult(
     public val directArtifact: ArtifactAnalysis? = null,
     public val runtimeClosure: RuntimeClosureStats = RuntimeClosureStats(),
     public val androidPreflight: AndroidPreflightStats? = null,
+    public val androidDex: AndroidDexStats? = null,
     public val diagnostics: List<Diagnostic> = emptyList(),
     public val diagnosticCount: Int = diagnostics.size,
     public val diagnosticsTruncated: Boolean = false,

--- a/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
+++ b/jvm-package-build-stats/model/src/main/kotlin/com/bundlephobia/jvm/model/ResultModels.kt
@@ -308,6 +308,9 @@ public data class NamespaceStats(
 @Serializable
 public data class ClassfileStats(
     public val analyzedClasses: Int = 0,
+    public val definedMethods: Int = 0,
+    public val definedFields: Int = 0,
+    public val classfileBytes: Long = 0,
     public val implementationClasses: Int = 0,
     public val publicTypes: Int = 0,
     public val protectedTypes: Int = 0,

--- a/jvm-package-build-stats/model/src/test/kotlin/com/bundlephobia/jvm/model/ResultJsonTest.kt
+++ b/jvm-package-build-stats/model/src/test/kotlin/com/bundlephobia/jvm/model/ResultJsonTest.kt
@@ -43,6 +43,29 @@ class ResultJsonTest {
         assertEquals(result, ResultJson.decodeResolution(ResultJson.encode(result)))
     }
 
+    @Test
+    fun `round trips Android DEX statistics`() {
+        val result =
+            fixtureResult().copy(
+                target = TargetProfile.ANDROID_RUNTIME,
+                androidDex =
+                    AndroidDexStats(
+                        status = AndroidDexStatus.COMPLETE,
+                        dexBytes = 4_096,
+                        dexFiles = 2,
+                        referencedMethods = 70_000,
+                        maxReferencedMethodsPerDex = 60_000,
+                        referencedFields = 12_000,
+                        definedClasses = 800,
+                        minSdk = 23,
+                        buildToolsVersion = "36.0.0",
+                    ),
+            )
+
+        assertEquals(result, ResultJson.decodeResult(ResultJson.encode(result)))
+        assertTrue(ResultJson.encode(result).contains("\"referencedMethods\":70000"))
+    }
+
     private fun fixtureResult(): PackageBuildStatsResult {
         val coordinate = MavenCoordinate.parse("com.google.code.gson:gson:2.13.1")
         return PackageBuildStatsResult(

--- a/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/JvmRuntimeResolutionTask.kt
+++ b/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/JvmRuntimeResolutionTask.kt
@@ -13,6 +13,7 @@ import com.bundlephobia.jvm.model.ResolvedVariant
 import com.bundlephobia.jvm.model.ResultJson
 import com.bundlephobia.jvm.model.ResultStatus
 import com.bundlephobia.jvm.model.RetryClassification
+import com.bundlephobia.jvm.model.TargetProfile
 import org.gradle.api.DefaultTask
 import org.gradle.api.Named
 import org.gradle.api.artifacts.Configuration
@@ -50,6 +51,10 @@ public abstract class JvmRuntimeResolutionTask : DefaultTask() {
     /** Consumer Java feature version used for Gradle variant selection. */
     @get:Input
     public abstract val javaVersion: Property<Int>
+
+    /** Consumer ecosystem used for Gradle variant and artifact selection. */
+    @get:Input
+    public abstract val target: Property<String>
 
     /** Project repositories observed after the settings plugin sealed repository resolution. */
     @get:Input
@@ -116,6 +121,7 @@ public abstract class JvmRuntimeResolutionTask : DefaultTask() {
     }
 
     private fun resolveWithGradle(requested: MavenCoordinate): JvmResolutionResult {
+        val targetProfile = TargetProfile.parse(target.get())
         val configuration = resolutionConfiguration
         val resolution = configuration.incoming.resolutionResult
         val artifactCollection = configuration.incoming.artifactView { it.lenient(true) }.artifacts
@@ -153,7 +159,7 @@ public abstract class JvmRuntimeResolutionTask : DefaultTask() {
                     retry = RetryClassification.UNKNOWN,
                 )
         }
-        artifacts.filter { it.extension != JAR_EXTENSION }.forEach { artifact ->
+        artifacts.filterNot { targetProfile.supports(it.extension) }.forEach { artifact ->
             diagnostics +=
                 diagnostic(
                     "UNSUPPORTED_RUNTIME_ARTIFACT",
@@ -163,6 +169,7 @@ public abstract class JvmRuntimeResolutionTask : DefaultTask() {
 
         return JvmResolutionResult(
             status = if (diagnostics.isEmpty()) ResultStatus.COMPLETE else ResultStatus.FAILED,
+            target = targetProfile,
             javaVersion = javaVersion.get(),
             resolution =
                 ResolutionStats(
@@ -291,6 +298,7 @@ public abstract class JvmRuntimeResolutionTask : DefaultTask() {
     ): JvmResolutionResult =
         JvmResolutionResult(
             status = ResultStatus.FAILED,
+            target = target.orNull?.let(TargetProfile::parse) ?: TargetProfile.JVM_RUNTIME,
             javaVersion = javaVersion.getOrElse(21),
             resolution = ResolutionStats(requested = requested, repositories = REPOSITORY_IDS),
             diagnostics = listOf(diagnostic(code, summary, retry)),
@@ -316,6 +324,11 @@ public abstract class JvmRuntimeResolutionTask : DefaultTask() {
 
     private companion object {
         const val JAR_EXTENSION: String = "jar"
+        const val AAR_EXTENSION: String = "aar"
+
+        fun TargetProfile.supports(extension: String): Boolean =
+            extension == JAR_EXTENSION || (this == TargetProfile.ANDROID_RUNTIME && extension == AAR_EXTENSION)
+
         val REPOSITORY_IDS: List<String> =
             listOf(
                 JvmRuntimeResolverPlugin.MAVEN_CENTRAL_ID,

--- a/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/JvmRuntimeResolverPlugin.kt
+++ b/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/JvmRuntimeResolverPlugin.kt
@@ -1,5 +1,6 @@
 package com.bundlephobia.jvm.resolver
 
+import com.bundlephobia.jvm.model.TargetProfile
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -61,10 +62,13 @@ public class JvmRuntimeResolverPlugin : Plugin<Settings> {
                 .gradleProperty(JAVA_VERSION_PROPERTY)
                 .map(String::toInt)
                 .orElse(DEFAULT_TARGET_JVM_VERSION)
-        val runtimeConfiguration = runtimeConfiguration(project, coordinate, javaVersion)
+        val target = project.providers.gradleProperty(TARGET_PROPERTY).orElse(TargetProfile.JVM_RUNTIME.serializedValue)
+        val parsedTarget = TargetProfile.parse(target.get())
+        val runtimeConfiguration = runtimeConfiguration(project, coordinate, javaVersion, parsedTarget)
         project.tasks.register(RESOLVE_TASK_NAME, JvmRuntimeResolutionTask::class.java) { task ->
             task.coordinate.convention(coordinate)
             task.javaVersion.convention(javaVersion)
+            task.target.convention(target)
             task.forbiddenRepositories.convention(state.forbiddenRepositories)
             task.outputFile.convention(project.layout.buildDirectory.file("jvm-resolver/result.json"))
             task.resolutionConfiguration = runtimeConfiguration
@@ -75,6 +79,7 @@ public class JvmRuntimeResolverPlugin : Plugin<Settings> {
         project: Project,
         coordinate: Provider<String>,
         javaVersion: Provider<Int>,
+        target: TargetProfile,
     ): Configuration =
         project.configurations
             .resolvable("jvmResolverRuntime") { configuration ->
@@ -87,17 +92,26 @@ public class JvmRuntimeResolverPlugin : Plugin<Settings> {
                 configuration.attributes {
                     it.attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
                     it.attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category::class.java, Category.LIBRARY))
-                    it.attribute(
-                        LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                        project.objects.named(LibraryElements::class.java, LibraryElements.JAR),
-                    )
+                    if (target == TargetProfile.JVM_RUNTIME) {
+                        it.attribute(
+                            LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                            project.objects.named(LibraryElements::class.java, LibraryElements.JAR),
+                        )
+                    }
                     it.attribute(
                         Bundling.BUNDLING_ATTRIBUTE,
                         project.objects.named(Bundling::class.java, Bundling.EXTERNAL),
                     )
                     it.attribute(
                         TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
-                        project.objects.named(TargetJvmEnvironment::class.java, TargetJvmEnvironment.STANDARD_JVM),
+                        project.objects.named(
+                            TargetJvmEnvironment::class.java,
+                            if (target == TargetProfile.ANDROID_RUNTIME) {
+                                TargetJvmEnvironment.ANDROID
+                            } else {
+                                TargetJvmEnvironment.STANDARD_JVM
+                            },
+                        ),
                     )
                     it.attributeProvider(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, javaVersion)
                 }
@@ -108,6 +122,7 @@ public class JvmRuntimeResolverPlugin : Plugin<Settings> {
         public const val RESOLVE_TASK_NAME: String = "resolveJvmRuntime"
         public const val COORDINATE_PROPERTY: String = "jvmResolver.coordinate"
         public const val JAVA_VERSION_PROPERTY: String = "jvmResolver.javaVersion"
+        public const val TARGET_PROPERTY: String = "jvmResolver.target"
         public const val MAVEN_CENTRAL_ID: String = "maven-central"
         public const val GOOGLE_MAVEN_ID: String = "google-maven"
         private const val DEFAULT_TARGET_JVM_VERSION: Int = 21

--- a/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/ResolverPluginClasspathAnchor.kt
+++ b/jvm-package-build-stats/resolver/src/main/kotlin/com/bundlephobia/jvm/resolver/ResolverPluginClasspathAnchor.kt
@@ -9,5 +9,6 @@ public object ResolverPluginClasspathAnchor {
     public const val PLUGIN_CLASS: String = "com.bundlephobia.jvm.resolver.JvmRuntimeResolverPlugin"
     public const val RESOLVE_TASK_NAME: String = "resolveJvmRuntime"
     public const val COORDINATE_PROPERTY: String = "jvmResolver.coordinate"
+    public const val TARGET_PROPERTY: String = "jvmResolver.target"
     public const val JAVA_VERSION_PROPERTY: String = "jvmResolver.javaVersion"
 }

--- a/jvm-package-build-stats/resolver/src/test/kotlin/com/bundlephobia/jvm/resolver/JvmRuntimeResolverPluginTest.kt
+++ b/jvm-package-build-stats/resolver/src/test/kotlin/com/bundlephobia/jvm/resolver/JvmRuntimeResolverPluginTest.kt
@@ -3,6 +3,7 @@ package com.bundlephobia.jvm.resolver
 import com.bundlephobia.jvm.model.JvmResolutionResult
 import com.bundlephobia.jvm.model.ResultJson
 import com.bundlephobia.jvm.model.ResultStatus
+import com.bundlephobia.jvm.model.TargetProfile
 import org.gradle.testkit.runner.GradleRunner
 import java.nio.file.Files
 import java.nio.file.Path
@@ -65,6 +66,16 @@ class JvmRuntimeResolverPluginTest {
     }
 
     @Test
+    fun `accepts AARs for an Android runtime target`() {
+        val result = resolve("androidx.recyclerview:recyclerview:1.4.0", TargetProfile.ANDROID_RUNTIME)
+
+        assertEquals(ResultStatus.COMPLETE, result.status, result.diagnostics.toString())
+        assertEquals(TargetProfile.ANDROID_RUNTIME, result.target)
+        assertTrue(result.resolution.artifacts.any { it.extension == "aar" })
+        assertTrue(result.diagnostics.none { it.code == "UNSUPPORTED_RUNTIME_ARTIFACT" })
+    }
+
+    @Test
     fun `returns stable diagnostics for an unresolved dependency`() {
         val result = resolve("com.bundlephobia.missing:definitely-not-published:1.0.0")
 
@@ -105,6 +116,7 @@ class JvmRuntimeResolverPluginTest {
 
     private fun resolve(
         coordinate: String,
+        target: TargetProfile = TargetProfile.JVM_RUNTIME,
         buildScript: String = "",
     ): JvmResolutionResult {
         val projectDirectory = Files.createTempDirectory("jvm-resolver-test-")
@@ -133,6 +145,7 @@ class JvmRuntimeResolverPluginTest {
             .withArguments(
                 JvmRuntimeResolverPlugin.RESOLVE_TASK_NAME,
                 "-P${JvmRuntimeResolverPlugin.COORDINATE_PROPERTY}=$coordinate",
+                "-P${JvmRuntimeResolverPlugin.TARGET_PROPERTY}=${target.serializedValue}",
                 "--stacktrace",
             ).build()
 


### PR DESCRIPTION
## Summary

- add Android runtime variant resolution for AAR and JAR dependency closures
- inspect bounded AAR metadata and manifests before Android tooling runs
- derive effective minSdk, compileSdk, SDK extension, preview SDK, and minimum AGP requirements
- select pinned stable API 36 first, with API 37 preview as the narrow fallback
- optionally install only the selected platform and Build Tools packages through sdkmanager, with locking, cancellation, timeout, and bounded diagnostics
- attribute classes, methods, fields, and classfile bytes physically defined by the requested AAR, including embedded JARs
- run pinned D8 over the complete runtime closure when tooling is ready
- report unshrunk DEX bytes, DEX file count, method and field references, largest per-DEX method count, and defined classes in JSON and pretty CLI output
- show direct library code before closure-wide DEX statistics so package ownership is not confused with the 64K-per-DEX reference limit
- keep temporary bytecode and DEX evidence bounded and delete it after analysis; persist no package artifacts or results

## Product boundary

Direct method counts are exact classfile definitions owned by the requested artifact, including constructors, static initializers, and compiler-generated methods. Closure DEX values are real unshrunk D8 measurements. R8-shrunk and incremental-app counts remain intentionally absent because meaningful values require an explicit consumer entry-point and keep-rule policy; the CLI does not present synthetic estimates as canonical.

## Verification

- `yarn jvm:check`
- `yarn jvm:test`
- `yarn jvm:build`
- real analysis for `androidx.recyclerview:recyclerview:1.4.0`: requested AAR defines 205 classes, 2,146 methods, and 977 fields across 874 KiB of classfiles
- same closure through D8: 5.10 MiB DEX, 33,078 method references, 8,258 field references, and 3,530 defined classes
- RecyclerView timing: 9.46 s analyzer total, including 4.69 s resolution, 4.35 s D8, and 404 ms artifact analysis
- unit coverage for direct AAR bytecode attribution, stable/preview selection, unsupported requirements, opt-in SDK provisioning, DEX header aggregation, multidex totals, bounded failures, JSON round trips, and pretty output
- Gradle TestKit coverage for real AndroidX AAR resolution
