### PR TITLE
Add multi-language domain foundation

### DIFF
--- a/__tests__/language-foundation.test.ts
+++ b/__tests__/language-foundation.test.ts
@@ -1,0 +1,155 @@
+import {
+  formatJavaScriptPackageSpecifier,
+  parseJavaScriptPackageSpecifier,
+} from '../languages/javascript'
+import {
+  getExplicitPackagePagePath,
+  getPackagePagePath,
+  parsePackagePageRoute,
+} from '../languages/package-route'
+import {
+  LANGUAGE_DESCRIPTORS,
+  createLanguageRegistry,
+  languageRegistry,
+} from '../languages/registry'
+import type {
+  LanguageDescriptor,
+  PackageReport,
+} from '../types/language-domain'
+
+describe('package report model', () => {
+  it('keeps JavaScript analysis typed behind the language discriminant', () => {
+    const report: PackageReport = {
+      schemaVersion: 1,
+      language: 'javascript',
+      identity: {
+        language: 'javascript',
+        specifier: 'react',
+        name: 'react',
+        version: '19.2.0',
+        displayName: 'react',
+        canonicalSpecifier: 'react@19.2.0',
+      },
+      status: 'complete',
+      diagnostics: [],
+      analysis: {
+        size: 7_500,
+        gzip: 2_900,
+        dependencyCount: 0,
+        hasSideEffects: true,
+        hasJSModule: false,
+        hasJSNext: false,
+        isModuleType: false,
+      },
+    }
+
+    expect(report.language).toBe('javascript')
+    expect(report.analysis.gzip).toBe(2_900)
+  })
+})
+
+describe('JavaScript package specifier adapter', () => {
+  it.each([
+    ['react', 'react', null, undefined, false],
+    ['react@19.2.0', 'react', '19.2.0', undefined, false],
+    ['@babel/core', '@babel/core', null, 'babel', true],
+    ['@babel/core@9.8.0', '@babel/core', '9.8.0', 'babel', true],
+    ['chart.js@0.7.0-beta', 'chart.js', '0.7.0-beta', undefined, false],
+  ])('parses and formats %s', (specifier, name, version, scope, scoped) => {
+    const parsed = parseJavaScriptPackageSpecifier(specifier)
+
+    expect(parsed).toEqual({ name, version, scope, scoped })
+    expect(formatJavaScriptPackageSpecifier(parsed)).toBe(specifier)
+  })
+})
+
+describe('language registry', () => {
+  it('registers only JavaScript as enabled and visible', () => {
+    expect(languageRegistry.enabled().map(language => language.id)).toEqual([
+      'javascript',
+    ])
+    expect(languageRegistry.visible().map(language => language.id)).toEqual([
+      'javascript',
+    ])
+  })
+
+  it.each(['java', 'kotlin'] as const)(
+    'keeps %s disabled, hidden, and without capabilities',
+    languageId => {
+      expect(languageRegistry.get(languageId)).toMatchObject({
+        state: 'disabled',
+        visibility: 'hidden',
+        capabilities: [],
+      })
+    }
+  )
+
+  it('rejects duplicate descriptors', () => {
+    expect(() =>
+      createLanguageRegistry([...LANGUAGE_DESCRIPTORS, LANGUAGE_DESCRIPTORS[0]])
+    ).toThrow('Duplicate language descriptor: javascript')
+  })
+
+  it('rejects an incomplete registry', () => {
+    const javascriptOnly: readonly LanguageDescriptor[] = [
+      LANGUAGE_DESCRIPTORS[0],
+    ]
+
+    expect(() => createLanguageRegistry(javascriptOnly)).toThrow(
+      'Missing language descriptors: java, kotlin'
+    )
+  })
+})
+
+describe('package page routes', () => {
+  it('parses legacy unscoped and scoped JavaScript routes', () => {
+    expect(parsePackagePageRoute('react@19.2.0')).toEqual({
+      kind: 'legacy-javascript',
+      reference: { language: 'javascript', specifier: 'react@19.2.0' },
+    })
+    expect(parsePackagePageRoute(['@babel', 'core@9.8.0'])).toEqual({
+      kind: 'legacy-javascript',
+      reference: {
+        language: 'javascript',
+        specifier: '@babel/core@9.8.0',
+      },
+    })
+  })
+
+  it.each([
+    ['javascript', 'react@19.2.0'],
+    ['java', 'com.google.code.gson:gson:2.14.0'],
+    ['kotlin', 'org.jetbrains.kotlin:kotlin-stdlib:2.4.10'],
+  ] as const)('parses an explicit %s route', (language, specifier) => {
+    expect(parsePackagePageRoute([language, specifier])).toEqual({
+      kind: 'language-explicit',
+      reference: { language, specifier },
+    })
+  })
+
+  it('continues generating legacy JavaScript paths', () => {
+    expect(
+      getPackagePagePath({
+        language: 'javascript',
+        specifier: '@babel/core@9.8.0',
+      })
+    ).toBe('/package/@babel/core@9.8.0')
+  })
+
+  it('generates explicit paths for other languages and on request', () => {
+    expect(
+      getPackagePagePath({
+        language: 'java',
+        specifier: 'com.google.code.gson:gson:2.14.0',
+      })
+    ).toBe('/package/java/com.google.code.gson:gson:2.14.0')
+    expect(getExplicitPackagePagePath('javascript', 'react@19.2.0')).toBe(
+      '/package/javascript/react@19.2.0'
+    )
+  })
+
+  it('returns null for a missing route value', () => {
+    expect(parsePackagePageRoute(undefined)).toBeNull()
+    expect(parsePackagePageRoute([])).toBeNull()
+  })
+})

--- a/languages/index.ts
+++ b/languages/index.ts
@@ -1,0 +1,3 @@
+export * from './javascript'
+export * from './package-route'
+export * from './registry'

--- a/languages/javascript.ts
+++ b/languages/javascript.ts
@@ -1,0 +1,54 @@
+import type { PackageReference } from '../types/language-domain'
+
+export interface ParsedJavaScriptPackageSpecifier {
+  name: string
+  version: string | null
+  scope?: string
+  scoped: boolean
+}
+
+/** Parse npm's name, scoped-name, and optional version syntax. */
+export function parseJavaScriptPackageSpecifier(
+  packageSpecifier: string
+): ParsedJavaScriptPackageSpecifier {
+  let name: string
+  let version: string | null
+  let scope: string | undefined
+  let scoped = false
+  const lastAtIndex = packageSpecifier.lastIndexOf('@')
+  const firstSlashIndex = packageSpecifier.indexOf('/')
+
+  if (packageSpecifier.startsWith('@')) {
+    scoped = true
+    scope = packageSpecifier.substring(1, firstSlashIndex)
+    if (lastAtIndex === 0) {
+      name = packageSpecifier
+      version = null
+    } else {
+      name = packageSpecifier.substring(0, lastAtIndex)
+      version = packageSpecifier.substring(lastAtIndex + 1)
+    }
+  } else if (lastAtIndex === -1) {
+    name = packageSpecifier
+    version = null
+  } else {
+    name = packageSpecifier.substring(0, lastAtIndex)
+    version = packageSpecifier.substring(lastAtIndex + 1)
+  }
+
+  return { name, version, scope, scoped }
+}
+
+export function formatJavaScriptPackageSpecifier(
+  parsed: Pick<ParsedJavaScriptPackageSpecifier, 'name' | 'version'>
+): string {
+  return parsed.version === null
+    ? parsed.name
+    : `${parsed.name}@${parsed.version}`
+}
+
+export function createJavaScriptPackageReference(
+  specifier: string
+): PackageReference {
+  return { language: 'javascript', specifier }
+}

--- a/languages/package-route.ts
+++ b/languages/package-route.ts
@@ -1,0 +1,58 @@
+import type { LanguageId, PackageReference } from '../types/language-domain'
+import { createJavaScriptPackageReference } from './javascript'
+import { languageRegistry } from './registry'
+
+export type PackageRouteKind = 'legacy-javascript' | 'language-explicit'
+
+export interface ParsedPackagePageRoute {
+  kind: PackageRouteKind
+  reference: PackageReference
+}
+
+type PackageRouteValue = string | readonly string[] | undefined
+
+function routeSegments(value: PackageRouteValue): string[] {
+  if (value === undefined) return []
+  return typeof value === 'string' ? value.split('/') : [...value]
+}
+
+export function parsePackagePageRoute(
+  value: PackageRouteValue
+): ParsedPackagePageRoute | null {
+  const segments = routeSegments(value)
+  if (segments.length === 0) return null
+
+  const [possibleLanguage, ...specifierSegments] = segments
+  if (
+    specifierSegments.length > 0 &&
+    languageRegistry.isLanguageId(possibleLanguage)
+  ) {
+    return {
+      kind: 'language-explicit',
+      reference: {
+        language: possibleLanguage,
+        specifier: specifierSegments.join('/'),
+      },
+    }
+  }
+
+  return {
+    kind: 'legacy-javascript',
+    reference: createJavaScriptPackageReference(segments.join('/')),
+  }
+}
+
+export function getPackagePagePath(reference: PackageReference): string {
+  if (reference.language === 'javascript') {
+    return `/package/${reference.specifier}`
+  }
+
+  return `/package/${reference.language}/${reference.specifier}`
+}
+
+export function getExplicitPackagePagePath(
+  language: LanguageId,
+  specifier: string
+): string {
+  return `/package/${language}/${specifier}`
+}

--- a/languages/registry.ts
+++ b/languages/registry.ts
@@ -1,0 +1,76 @@
+import {
+  LANGUAGE_CAPABILITIES,
+  LANGUAGE_IDS,
+  type LanguageDescriptor,
+  type LanguageId,
+} from '../types/language-domain'
+
+export const LANGUAGE_DESCRIPTORS = [
+  {
+    id: 'javascript',
+    label: 'JavaScript',
+    state: 'enabled',
+    visibility: 'public',
+    capabilities: LANGUAGE_CAPABILITIES,
+  },
+  {
+    id: 'java',
+    label: 'Java',
+    state: 'disabled',
+    visibility: 'hidden',
+    capabilities: [],
+  },
+  {
+    id: 'kotlin',
+    label: 'Kotlin',
+    state: 'disabled',
+    visibility: 'hidden',
+    capabilities: [],
+  },
+] as const satisfies readonly LanguageDescriptor[]
+
+export interface LanguageRegistry {
+  all(): readonly LanguageDescriptor[]
+  get(id: LanguageId): LanguageDescriptor
+  isLanguageId(value: string): value is LanguageId
+  enabled(): readonly LanguageDescriptor[]
+  visible(): readonly LanguageDescriptor[]
+}
+
+export function createLanguageRegistry(
+  descriptors: readonly LanguageDescriptor[]
+): LanguageRegistry {
+  const byId = new Map<LanguageId, LanguageDescriptor>()
+
+  descriptors.forEach(descriptor => {
+    if (byId.has(descriptor.id)) {
+      throw new Error(`Duplicate language descriptor: ${descriptor.id}`)
+    }
+    byId.set(descriptor.id, descriptor)
+  })
+
+  const missingIds = LANGUAGE_IDS.filter(id => !byId.has(id))
+  if (missingIds.length > 0) {
+    throw new Error(`Missing language descriptors: ${missingIds.join(', ')}`)
+  }
+
+  const all = Object.freeze([...descriptors])
+
+  return Object.freeze({
+    all: () => all,
+    get(id: LanguageId) {
+      const descriptor = byId.get(id)
+      if (!descriptor) {
+        throw new Error(`Unknown language descriptor: ${id}`)
+      }
+      return descriptor
+    },
+    isLanguageId(value: string): value is LanguageId {
+      return byId.has(value as LanguageId)
+    },
+    enabled: () => all.filter(descriptor => descriptor.state === 'enabled'),
+    visible: () => all.filter(descriptor => descriptor.visibility === 'public'),
+  })
+}
+
+export const languageRegistry = createLanguageRegistry(LANGUAGE_DESCRIPTORS)

--- a/types/language-domain.ts
+++ b/types/language-domain.ts
@@ -1,0 +1,93 @@
+export const LANGUAGE_IDS = ['javascript', 'java', 'kotlin'] as const
+
+export type LanguageId = (typeof LANGUAGE_IDS)[number]
+
+export const LANGUAGE_CAPABILITIES = [
+  'analysis',
+  'suggestions',
+  'history',
+  'recent-searches',
+  'similar-packages',
+  'exports',
+  'export-sizes',
+  'stats-image',
+  'compare',
+  'dependency-graph',
+  'manifest-scan',
+] as const
+
+export type LanguageCapability = (typeof LANGUAGE_CAPABILITIES)[number]
+
+export type LanguageState = 'enabled' | 'disabled'
+export type LanguageVisibility = 'public' | 'hidden'
+
+export interface LanguageDescriptor {
+  id: LanguageId
+  label: string
+  state: LanguageState
+  visibility: LanguageVisibility
+  capabilities: readonly LanguageCapability[]
+}
+
+/** A package specifier before a language adapter resolves it to a version. */
+export interface PackageReference<L extends LanguageId = LanguageId> {
+  language: L
+  specifier: string
+}
+
+/** Stable identity shared by package reports after language-specific resolution. */
+export interface ResolvedPackageIdentity<L extends LanguageId = LanguageId>
+  extends PackageReference<L> {
+  name: string
+  version: string
+  displayName: string
+  canonicalSpecifier: string
+}
+
+export type PackageReportStatus = 'complete' | 'partial' | 'failed'
+export type PackageDiagnosticSeverity = 'info' | 'warning' | 'error'
+
+export interface PackageDiagnostic {
+  code: string
+  message: string
+  severity: PackageDiagnosticSeverity
+  retryable?: boolean
+}
+
+export interface PackageReportBase<L extends LanguageId = LanguageId> {
+  schemaVersion: 1
+  language: L
+  identity: ResolvedPackageIdentity<L>
+  status: PackageReportStatus
+  description?: string
+  repository?: string
+  diagnostics: readonly PackageDiagnostic[]
+}
+
+export interface JavaScriptDependencySize {
+  name: string
+  approximateSize: number
+}
+
+export interface JavaScriptPackageAnalysis {
+  size: number
+  gzip: number
+  dependencyCount: number
+  hasSideEffects: boolean | string[]
+  hasJSModule: boolean
+  hasJSNext: boolean
+  isModuleType: boolean
+  ignoredMissingDependencies?: readonly string[]
+  dependencySizes?: readonly JavaScriptDependencySize[]
+}
+
+export interface JavaScriptPackageReport
+  extends PackageReportBase<'javascript'> {
+  analysis: JavaScriptPackageAnalysis
+}
+
+/**
+ * The report union contains only implemented languages. Java and Kotlin stay
+ * descriptor-only until their website result contracts are designed.
+ */
+export type PackageReport = JavaScriptPackageReport

--- a/utils/common.utils.ts
+++ b/utils/common.utils.ts
@@ -1,41 +1,15 @@
 import DOMPurify from 'dompurify'
+import {
+  parseJavaScriptPackageSpecifier,
+  type ParsedJavaScriptPackageSpecifier,
+} from '../languages/javascript'
 
-export interface ParsedPackageString {
-  name: string
-  version: string | null
-  scope?: string
-  scoped: boolean
-}
-
-// Used by the server as well as the client.
-export function parsePackageString(packageString: string): ParsedPackageString {
-  let name: string
-  let version: string | null
-  let scope: string | undefined
-  let scoped = false
-  const lastAtIndex = packageString.lastIndexOf('@')
-  const firstSlashIndex = packageString.indexOf('/')
-
-  if (packageString.startsWith('@')) {
-    scoped = true
-    scope = packageString.substring(1, firstSlashIndex)
-    if (lastAtIndex === 0) {
-      name = packageString
-      version = null
-    } else {
-      name = packageString.substring(0, lastAtIndex)
-      version = packageString.substring(lastAtIndex + 1)
-    }
-  } else if (lastAtIndex === -1) {
-    name = packageString
-    version = null
-  } else {
-    name = packageString.substring(0, lastAtIndex)
-    version = packageString.substring(lastAtIndex + 1)
-  }
-
-  return { name, version, scope, scoped }
-}
+/**
+ * @deprecated JavaScript-only compatibility alias. New language-aware code
+ * should import the adapter-specific parser directly.
+ */
+export type ParsedPackageString = ParsedJavaScriptPackageSpecifier
+export const parsePackageString = parseJavaScriptPackageSpecifier
 
 export function daysFromToday(date: string | number | Date): number {
   const date1 = new Date()


### PR DESCRIPTION
## Summary
- add shared language, package identity, diagnostic, and capability contracts
- model results as a small generic base plus a concrete JavaScript report discriminated by language; Java/Kotlin result bodies remain undefined until implemented
- register JavaScript as enabled while keeping Java and Kotlin disabled and hidden
- move npm specifier parsing/formatting behind the JavaScript adapter with a compatibility alias
- add tested helpers for legacy and explicit-language package routes

## Scope
This is PR 1 only. It does not change APIs, storage, backends, or visible UI behavior.

## Verification
- focused language/parser tests: 37 passed
- self-contained repository tests: 92 passed
- ESLint: 0 errors (5 existing warnings)
- production build and Next.js TypeScript check: passed
- browser smoke: homepage and legacy /package/react rendered; React resolved to 19.2.8

## Existing test drift
The server-dependent errors-cache suite was also run against a live local service: 4/7 passed. The remaining current-branch assertions expect older package-build-stats output for react@16.5.0 and older cache-header behavior for two unversioned scoped fixture requests; this PR does not alter either behavior.