### PR TITLE
chore: measure Firebase usage

### DIFF
--- a/cache-service/firebase-metrics.js
+++ b/cache-service/firebase-metrics.js
@@ -1,0 +1,32 @@
+const debug = require('debug')('bp:firebase-metrics')
+
+const metrics = new Map()
+
+function getPayloadBytes(value) {
+  if (value === undefined || value === null) return 0
+
+  return Buffer.byteLength(JSON.stringify(value), 'utf8')
+}
+
+function flush() {
+  if (metrics.size === 0) return
+
+  const summary = Object.fromEntries(
+    [...metrics.entries()].map(([key, value]) => [key, { ...value }])
+  )
+  metrics.clear()
+  debug('Firebase usage summary: %O', summary)
+}
+
+const flushTimer = setInterval(flush, 60_000)
+flushTimer.unref()
+
+function recordFirebaseOperation({ direction, path, value }) {
+  const key = `${direction}:${path}`
+  const current = metrics.get(key) || { calls: 0, payloadBytes: 0 }
+  current.calls += 1
+  current.payloadBytes += getPayloadBytes(value)
+  metrics.set(key, current)
+}
+
+module.exports = { recordFirebaseOperation }

--- a/cache-service/middlewares/exports-size.middleware.js
+++ b/cache-service/middlewares/exports-size.middleware.js
@@ -3,6 +3,7 @@ const LRU = require('lru-cache')
 const firebase = require('firebase')
 const debug = require('debug')('bp:cache')
 const { encodeFirebaseKey } = require('../cache.utils')
+const { recordFirebaseOperation } = require('../firebase-metrics')
 
 const LRUCache = new LRU({ max: 1500 })
 
@@ -28,7 +29,9 @@ async function getPackageResultFromKey(key, { name, version }) {
     .child(encodeFirebaseKey(version))
 
   const snapshot = await ref.once('value')
-  return snapshot.val()
+  const result = snapshot.val()
+  recordFirebaseOperation({ direction: 'read', path: key, value: result })
+  return result
 }
 
 async function getPackageResult({ name, version, readKey }) {
@@ -62,10 +65,16 @@ async function getPackageResult({ name, version, readKey }) {
 
 async function setPackageResult({ name, version, result }) {
   const modules = firebase.database().ref().child(FIREBASE_WRITE_KEY_EXPORTS)
-  return modules
+  const write = modules
     .child(encodeFirebaseKey(name))
     .child(encodeFirebaseKey(version))
     .set(result)
+  await write
+  recordFirebaseOperation({
+    direction: 'write',
+    path: FIREBASE_WRITE_KEY_EXPORTS,
+    value: result,
+  })
 }
 
 async function getExportsSizeMiddlware(req, res) {

--- a/cache-service/middlewares/package-size.middleware.js
+++ b/cache-service/middlewares/package-size.middleware.js
@@ -3,6 +3,7 @@ const firebase = require('firebase')
 const LRU = require('lru-cache')
 const debug = require('debug')('bp:cache')
 const { encodeFirebaseKey } = require('../cache.utils')
+const { recordFirebaseOperation } = require('../firebase-metrics')
 const LRUCache = new LRU({ max: 3000 })
 
 // Configurable Firebase keys for read/write operations
@@ -28,7 +29,9 @@ async function getPackageResultFromKey(key, { name, version }) {
     .child(encodeFirebaseKey(version))
 
   const snapshot = await ref.once('value')
-  return snapshot.val()
+  const result = snapshot.val()
+  recordFirebaseOperation({ direction: 'read', path: key, value: result })
+  return result
 }
 
 async function getPackageResult({ name, version, readKey }) {
@@ -62,10 +65,16 @@ async function getPackageResult({ name, version, readKey }) {
 
 async function setPackageResult({ name, version, result }) {
   const modules = firebase.database().ref().child(FIREBASE_WRITE_KEY)
-  return modules
+  const write = modules
     .child(encodeFirebaseKey(name))
     .child(encodeFirebaseKey(version))
     .set(result)
+  await write
+  recordFirebaseOperation({
+    direction: 'write',
+    path: FIREBASE_WRITE_KEY,
+    value: result,
+  })
 }
 
 async function getPackageSizeMiddlware(req, res) {

--- a/docs/firebase-metrics.md
+++ b/docs/firebase-metrics.md
@@ -1,0 +1,26 @@
+# Firebase usage metrics
+
+The application emits aggregated Firebase Realtime Database usage summaries
+through the `bp:firebase-metrics` debug namespace once per minute. Production
+already enables `DEBUG=bp:*`, so the summaries are written to the PM2 service
+logs without logging package names or Firebase credentials.
+
+Each summary contains the number of completed SDK calls and the approximate
+UTF-8 JSON payload bytes by direction and logical top-level path. The byte
+count represents the serialized data payload, not Firebase protocol, TLS, or
+HTTP overhead, so it should be treated as a lower-bound estimate of network
+traffic.
+
+Example:
+
+```text
+bp:firebase-metrics Firebase usage summary: {
+  'read:modules-v3': { calls: 120, payloadBytes: 456789 },
+  'write:searches-v2': { calls: 80, payloadBytes: 12345 }
+}
+```
+
+The cache service and the main application each emit their own summary. Add
+the values from all PM2 processes when comparing with Firebase or Cloudflare
+quotas. A Firebase history read can issue a second read to the legacy path
+when fallback is enabled; those calls are recorded separately.

--- a/utils/firebase.utils.ts
+++ b/utils/firebase.utils.ts
@@ -6,6 +6,38 @@ import semver from 'semver'
 import { decodeFirebaseKey, encodeFirebaseKey } from './index'
 
 const debug = createDebug('bp:firebase-util')
+const firebaseMetrics = new Map<
+  string,
+  { calls: number; payloadBytes: number }
+>()
+
+function recordFirebaseOperation(
+  direction: 'read' | 'write',
+  path: string,
+  value: unknown
+): void {
+  const key = `${direction}:${path}`
+  const current = firebaseMetrics.get(key) || { calls: 0, payloadBytes: 0 }
+  const payloadBytes =
+    value === undefined || value === null
+      ? 0
+      : Buffer.byteLength(JSON.stringify(value) ?? '', 'utf8')
+
+  current.calls += 1
+  current.payloadBytes += payloadBytes
+  firebaseMetrics.set(key, current)
+}
+
+function flushFirebaseMetrics(): void {
+  if (firebaseMetrics.size === 0) return
+
+  const summary = Object.fromEntries(firebaseMetrics.entries())
+  firebaseMetrics.clear()
+  debug('Firebase usage summary: %O', summary)
+}
+
+const firebaseMetricsTimer = setInterval(flushFirebaseMetrics, 60_000)
+firebaseMetricsTimer.unref()
 
 const FIREBASE_READ_KEY = process.env.FIREBASE_READ_KEY || 'modules-v2'
 
@@ -52,22 +84,36 @@ class FirebaseUtils {
     void searches
       .child(encodeFirebaseKey(name))
       .once('value')
-      .then(snapshot => snapshot.val() as SearchRecord | null)
+      .then(snapshot => {
+        const result = snapshot.val() as SearchRecord | null
+        recordFirebaseOperation('read', 'searches-v2', result)
+        return result
+      })
       .then(result => {
         if (result) {
-          return searches.child(encodeFirebaseKey(name)).update({
+          const value = {
             lastSearched: Date.now(),
             name: packageInfo.name,
             count: result.count + 1,
+          }
+          const update = searches.child(encodeFirebaseKey(name)).update(value)
+          return update.then(() => {
+            recordFirebaseOperation('write', 'searches-v2', value)
           })
         }
 
-        return searches.child(encodeFirebaseKey(name)).set({
+        const value = {
           lastSearched: Date.now(),
           name: packageInfo.name,
           version: packageInfo.version,
           count: 1,
-        })
+        }
+        return searches
+          .child(encodeFirebaseKey(name))
+          .set(value)
+          .then(() => {
+            recordFirebaseOperation('write', 'searches-v2', value)
+          })
       })
       .catch(error => console.log(error))
   }
@@ -89,7 +135,12 @@ class FirebaseUtils {
         .child(encodeFirebaseKey(name))
 
       return ref.once('value').then(snapshot => {
-        return snapshot.val() as Record<string, Record<string, unknown>> | null
+        const result = snapshot.val() as Record<
+          string,
+          Record<string, unknown>
+        > | null
+        recordFirebaseOperation('read', key, result)
+        return result
       })
     }
 
@@ -198,6 +249,10 @@ class FirebaseUtils {
       .once('value')
       .then(snapshot => snapshot.val() as Record<string, SearchRecord> | null)
       .then(result => {
+        recordFirebaseOperation('read', 'searches-v2', result)
+        return result
+      })
+      .then(result => {
         if (!result) {
           return recentSearches
         }
@@ -224,6 +279,7 @@ class FirebaseUtils {
       .once('value')
 
     const packages = snapshot.val() as Record<string, SearchRecord> | null
+    recordFirebaseOperation('read', 'searches-v2', packages)
 
     if (packages) {
       Object.keys(packages).forEach(packageName => {


### PR DESCRIPTION
## Summary

- record completed Firebase Realtime Database reads and writes by logical top-level path
- record approximate UTF-8 JSON payload bytes without logging package names or credentials
- emit one aggregated `bp:firebase-metrics` summary per minute from the main and cache services
- document how to combine PM2 process summaries and interpret the byte estimate

## Live estimate from production

A read-only sample of the live Realtime Database found approximately:

- 911,842 `modules-v3` package entries
- 36,870 `exports-v3` package entries
- 1,012,702 `searches-v2` records
- ~1.60 GB of estimated serialized data across those roots

Across 20 evenly distributed samples, the serialized payload estimates were:

- package history: mean 1.61 KB, median 587 B, p95 2.98 KB
- individual package-size result: mean 1.46 KB, median 509 B
- individual export-size result: mean 1.17 KB, median 404 B
- search record: mean 87 B

The current retained PM2 log window covers about 95 seconds and showed 166 history reads, 55 cache reads, 142 recorded-search operations, and 40 cache writes. Using the sample means, those operations exchanged approximately 418 KB of serialized payload. This is a burst snapshot, not a safe 24-hour extrapolation.

At the current estimated storage size, Firebase Realtime Database storage alone is roughly $3/month after the 1 GB free allowance; read/download charges likely remain within Firebase's roughly 10 GB/month free allowance unless traffic reaches several million reads per month. The instrumentation is needed to replace this estimate with a full-day measurement.

## Why

The current production logs show Firebase call activity but not payload sizes, so they cannot support a reliable Firebase-versus-Cloudflare quota estimate. This adds the missing measurements at the SDK boundary.

## Validation

- `node --check` passed for changed JavaScript files
- Prettier check passed
- repository tests: 15 suites passed, 1 existing suite failed with 3 unrelated fixture/cache-control mismatches (106 passed, 3 failed)
- full TypeScript validation reaches unrelated existing test and SVG declaration errors; no changed-file errors were reported

## Production follow-up

After deployment, aggregate `Firebase usage summary` lines across all PM2 processes over a representative 24-hour period. The payload byte count excludes Firebase protocol, TLS, and HTTP overhead and should be treated as a lower-bound estimate.
