### PR TITLE
Fix home search submit on first Enter

### DIFF
--- a/client/components/AutocompleteInput/AutocompleteInput.tsx
+++ b/client/components/AutocompleteInput/AutocompleteInput.tsx
@@ -63,6 +63,21 @@ export const AutocompleteInput = ({
     [value]
   )
 
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      event.key !== 'Enter' ||
+      event.nativeEvent.isComposing ||
+      highlightedIndex >= 0 ||
+      !value.trim()
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    onSearchSubmit(value)
+  }
+
   return (
     <form
       className={cx(containerClass, 'autocomplete-input__form')}
@@ -91,6 +106,7 @@ export const AutocompleteInput = ({
               autoCapitalize: 'off',
               spellCheck: false,
               style: { fontSize: searchFontSize! },
+              onKeyDown: handleInputKeyDown,
             })}
           />
           <div

--- a/e2e/package-analysis.spec.ts
+++ b/e2e/package-analysis.spec.ts
@@ -24,6 +24,34 @@ test('searches for and builds a real package', async ({
   await expect(packagePage.nextError).toHaveCount(0)
 })
 
+test('submits a typed package with one Enter while suggestions are open', async ({
+  homePage,
+  page,
+}) => {
+  await page.route('**/v2/search/suggestions?q=react', route =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          package: {
+            name: 'react',
+            description: 'A JavaScript library for building user interfaces.',
+          },
+          score: { detail: { popularity: 1 } },
+          searchScore: 1,
+        },
+      ]),
+    })
+  )
+
+  await homePage.goto()
+  await homePage.searchInput.fill('react')
+  await expect(page.getByRole('option').first()).toBeVisible()
+  await homePage.searchInput.press('Enter')
+
+  await expect(page).toHaveURL(/\/package\/react$/)
+})
+
 test('renders a real package-not-found response in the result shell', async ({
   packagePage,
   page,


### PR DESCRIPTION
## Summary
- submit a typed package when Enter would otherwise only close an open suggestion menu
- preserve Downshift suggestion selection when an item is highlighted
- add a browser regression test for one-Enter navigation

## Verification
- `yarn build`
- targeted Playwright regression test
- `yarn test --runInBand` (109 passed; 4 pre-existing `errors-cache` fixture/header mismatches)
- pre-commit checks
