### PR TITLE
feat: add monitorEventLoopDelay telemetry to main server

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,24 @@ function getEnv(env: Record<string, string | undefined | null>) {
   }
 }
 
+import { monitorEventLoopDelay } from 'node:perf_hooks'
+
+const eventLoopDelay = monitorEventLoopDelay({ resolution: 10 })
+eventLoopDelay.enable()
+
+setInterval(() => {
+  const p99Ms = eventLoopDelay.percentile(99) / 1e6
+  const maxMs = eventLoopDelay.max / 1e6
+  if (p99Ms > 50) {
+    logger.info(
+      'EVENT_LOOP_LAG',
+      { p99Ms, maxMs },
+      `High event loop latency detected: p99=${p99Ms.toFixed(1)}ms max=${maxMs.toFixed(1)}ms`
+    )
+  }
+  eventLoopDelay.reset()
+}, 10000)
+
 const env = getEnv(process.env)
 
 const cache = new Cache()


### PR DESCRIPTION
## Summary

Adds real-time Node.js event loop delay monitoring to the `main` Koa application server (`index.ts`).

- Uses Node.js `perf_hooks` (`monitorEventLoopDelay`) with 10ms sampling resolution.
- Emits structured `logger.info('EVENT_LOOP_LAG', { p99Ms, maxMs }, ...)` telemetry whenever p99 event loop latency exceeds **50 ms** over a 10-second sampling window.
- Enables empirical diagnostic tracking for main server event loop bottlenecks.