### PR TITLE
refactor: move cache client into server clients

### DIFF
--- a/__tests__/build-cancellation.test.ts
+++ b/__tests__/build-cancellation.test.ts
@@ -12,7 +12,7 @@ jest.mock('../server/api/BuildService', () => ({
   })),
 }))
 
-jest.mock('../utils/cache.utils', () => ({
+jest.mock('../server/clients/cacheService', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation(() => ({
     setPackageSize: jest.fn(),

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import auth from 'koa-basic-auth'
 import bodyParser from 'koa-bodyparser'
 import invariant from 'ts-invariant'
 
-import Cache from './utils/cache.utils'
+import CacheServiceClient from './server/clients/cacheService'
 import { parsePackageString } from './utils/common.utils'
 import firebaseUtils from './utils/firebase.utils'
 import logger from './server/Logger'
@@ -78,7 +78,7 @@ setInterval(() => {
 
 const env = getEnv(process.env)
 
-const cache = new Cache()
+const cache = new CacheServiceClient()
 const port = env.port
 const dev = env.nodeEnv !== 'production'
 const app = next({ dev })

--- a/server/clients/cacheService.ts
+++ b/server/clients/cacheService.ts
@@ -1,9 +1,9 @@
 import 'dotenv-defaults/config'
 
-import axios, { AxiosError } from 'axios'
+import axios from 'axios'
 import createDebug from 'debug'
 
-import logger from '../server/Logger'
+import logger from '../Logger'
 
 const debug = createDebug('bp:cache')
 
@@ -21,16 +21,15 @@ function getAxiosErrorData(error: unknown): unknown {
   return axios.isAxiosError(error) ? error.response?.data : undefined
 }
 
-export default class Cache {
+export default class CacheServiceClient {
   async getPackageSize<T>(key: CacheKey): Promise<T | undefined> {
     try {
-      const result = await API.get<T>('/package-cache', {
-        params: key,
-      })
+      const result = await API.get<T>('/package-cache', { params: key })
       return result.data
     } catch (error) {
-      const axiosError = error as AxiosError
-      console.error(axiosError.response?.statusText)
+      console.error(
+        axios.isAxiosError(error) ? error.response?.statusText : undefined,
+      )
       return undefined
     }
   }
@@ -40,14 +39,9 @@ export default class Cache {
     try {
       await API.post('/package-cache', { ...key, result })
     } catch (error) {
-      const errorData = getAxiosErrorData(error)
-      console.error(errorData)
-      logger.error(
-        'CACHE_SET_ERROR',
-        {
-          ...key,
-          error: errorData,
-        },
+      this.logSetError(
+        key,
+        error,
         `CACHE ERROR for package ${key.name}@${key.version}`,
       )
     }
@@ -56,9 +50,7 @@ export default class Cache {
   async getExportsSize<T>(key: CacheKey): Promise<T | undefined> {
     debug('get exports %s@%s', key.name, key.version)
     try {
-      const result = await API.get<T>('/exports-cache', {
-        params: key,
-      })
+      const result = await API.get<T>('/exports-cache', { params: key })
       debug('cache hit')
       return result.data
     } catch {
@@ -71,16 +63,17 @@ export default class Cache {
     try {
       await API.post('/exports-cache', { ...key, result })
     } catch (error) {
-      const errorData = getAxiosErrorData(error)
-      console.error(errorData)
-      logger.error(
-        'CACHE_SET_ERROR',
-        {
-          ...key,
-          error: errorData,
-        },
+      this.logSetError(
+        key,
+        error,
         `CACHE ERROR for package exports ${key.name}@${key.version}`,
       )
     }
+  }
+
+  private logSetError(key: CacheKey, error: unknown, message: string): void {
+    const errorData = getAxiosErrorData(error)
+    console.error(errorData)
+    logger.error('CACHE_SET_ERROR', { ...key, error: errorData }, message)
   }
 }

--- a/server/middlewares/exportsSizes.middleware.ts
+++ b/server/middlewares/exportsSizes.middleware.ts
@@ -2,14 +2,14 @@ import type { Middleware } from 'koa'
 import now from 'performance-now'
 
 import { createJavaScriptPackageReference } from '../../languages/javascript'
-import Cache from '../../utils/cache.utils'
+import CacheServiceClient from '../clients/cacheService'
 import { getRequestPriority } from '../../utils/server.utils'
 import { packageAnalysisGateway } from '../analysis'
 import { BUILD_DURATION_HEADER } from '../api/BuildService'
 import config from '../config'
 import logger from '../Logger'
 
-const cache = new Cache()
+const cache = new CacheServiceClient()
 const exportSizesMiddleware: Middleware = async ctx => {
   const priority = getRequestPriority(ctx)
   const { name, version, packageString } = ctx.state.resolved

--- a/server/middlewares/generateImg.middleware.ts
+++ b/server/middlewares/generateImg.middleware.ts
@@ -3,7 +3,7 @@ import send from 'koa-send'
 import queryString from 'query-string'
 
 import { createJavaScriptPackageReference } from '../../languages/javascript'
-import Cache from '../../utils/cache.utils'
+import CacheServiceClient from '../clients/cacheService'
 import { drawStatsImg } from '../../utils/draw.utils'
 import { packageAnalysisGateway } from '../analysis'
 
@@ -18,7 +18,7 @@ function isThemeName(value: string | undefined): value is 'dark' | 'light' {
   return value === 'dark' || value === 'light'
 }
 
-const cache = new Cache()
+const cache = new CacheServiceClient()
 
 const generateImgMiddleware: Middleware = async ctx => {
   const url = ctx.url.replace(/&amp;/g, '&')

--- a/server/middlewares/results/build.middleware.ts
+++ b/server/middlewares/results/build.middleware.ts
@@ -2,7 +2,7 @@ import type { Middleware } from 'koa'
 import now from 'performance-now'
 
 import { createJavaScriptPackageReference } from '../../../languages/javascript'
-import Cache from '../../../utils/cache.utils'
+import CacheServiceClient from '../../clients/cacheService'
 import firebaseUtils from '../../../utils/firebase.utils'
 import { getRequestPriority } from '../../../utils/server.utils'
 import { packageAnalysisGateway } from '../../analysis'
@@ -11,7 +11,7 @@ import config from '../../config'
 import logger from '../../Logger'
 import type { PackageBuildResult } from '../../types'
 
-const cache = new Cache()
+const cache = new CacheServiceClient()
 const buildMiddleware: Middleware = async ctx => {
   const priority = getRequestPriority(ctx)
   const { scoped, name, version, description, repository, packageString } =


### PR DESCRIPTION
## Summary

- move the existing cache-service HTTP client from `utils/cache.utils.ts` into `server/clients/cacheService.ts`
- update the application middleware callers and cancellation-test mock
- preserve package-size and exports-size cache behavior and error logging

## Validation

- `yarn typecheck`
- `yarn test --runInBand __tests__/build-cancellation.test.ts`
- `yarn lint` (existing repository warnings only)

This is the first focused base slice for the follow-up trends data-source work.