### PR TITLE
feat: add trends cache service endpoints

### DIFF
--- a/cache-service/index.ts
+++ b/cache-service/index.ts
@@ -30,15 +30,15 @@ fastify.post('/package-cache', postPackageSizeMiddlware)
 fastify.get('/exports-cache', getExportsSizeMiddlware)
 fastify.post('/exports-cache', postExportsSizeMiddleware)
 
-const trendsCacheNames: TrendsCacheName[] = [
-  'downloads',
-  'github-history',
-  'releases',
-  'size-history',
-]
+const trendsCacheConfig: Record<TrendsCacheName, number> = {
+  downloads: 24 * 60 * 60 * 1000,
+  'github-history': 24 * 60 * 60 * 1000,
+  releases: 24 * 60 * 60 * 1000,
+  'size-history': 24 * 60 * 60 * 1000,
+}
 
-for (const cacheName of trendsCacheNames) {
-  const middleware = createTrendsCacheMiddleware()
+for (const [cacheName, ttlMs] of Object.entries(trendsCacheConfig)) {
+  const middleware = createTrendsCacheMiddleware(ttlMs)
   fastify.get(`/trends-cache/${cacheName}`, middleware.get)
   fastify.post(`/trends-cache/${cacheName}`, middleware.post)
 }

--- a/cache-service/index.ts
+++ b/cache-service/index.ts
@@ -12,7 +12,15 @@ import {
   getPackageSizeMiddlware,
   postPackageSizeMiddlware,
 } from './middlewares/package-size.middleware.ts'
-import { createTrendsCacheMiddleware } from './middlewares/trends-cache.middleware.ts'
+import {
+  createDownloadsCache,
+  createGithubHistoryCache,
+  createReleasesCache,
+  createSizeHistoryCache,
+  type DownloadsPayload,
+  type GithubHistoryPayload,
+  type PackagePayload,
+} from './middlewares/trends-cache.middleware.ts'
 
 const fastify = createFastify()
 
@@ -37,11 +45,49 @@ const trendsCacheConfig: Record<TrendsCacheName, number> = {
   'size-history': 24 * 60 * 60 * 1000,
 }
 
-for (const [cacheName, ttlMs] of Object.entries(trendsCacheConfig)) {
-  const middleware = createTrendsCacheMiddleware(ttlMs)
-  fastify.get(`/trends-cache/${cacheName}`, middleware.get)
-  fastify.post(`/trends-cache/${cacheName}`, middleware.post)
-}
+const downloadsCache = createDownloadsCache(trendsCacheConfig.downloads)
+fastify.get<{
+  Querystring: DownloadsPayload
+  Body: DownloadsPayload
+}>('/trends-cache/downloads', downloadsCache.get)
+fastify.post<{
+  Querystring: DownloadsPayload
+  Body: DownloadsPayload
+}>('/trends-cache/downloads', downloadsCache.post)
+
+const githubHistoryCache = createGithubHistoryCache(
+  trendsCacheConfig['github-history'],
+)
+fastify.get<{
+  Querystring: GithubHistoryPayload
+  Body: GithubHistoryPayload
+}>('/trends-cache/github-history', githubHistoryCache.get)
+fastify.post<{
+  Querystring: GithubHistoryPayload
+  Body: GithubHistoryPayload
+}>('/trends-cache/github-history', githubHistoryCache.post)
+
+const releasesCache = createReleasesCache(trendsCacheConfig.releases)
+fastify.get<{ Querystring: PackagePayload; Body: PackagePayload }>(
+  '/trends-cache/releases',
+  releasesCache.get,
+)
+fastify.post<{ Querystring: PackagePayload; Body: PackagePayload }>(
+  '/trends-cache/releases',
+  releasesCache.post,
+)
+
+const sizeHistoryCache = createSizeHistoryCache(
+  trendsCacheConfig['size-history'],
+)
+fastify.get<{ Querystring: PackagePayload; Body: PackagePayload }>(
+  '/trends-cache/size-history',
+  sizeHistoryCache.get,
+)
+fastify.post<{ Querystring: PackagePayload; Body: PackagePayload }>(
+  '/trends-cache/size-history',
+  sizeHistoryCache.post,
+)
 
 fastify
   .listen({ port: 7001 })

--- a/cache-service/index.ts
+++ b/cache-service/index.ts
@@ -16,7 +16,6 @@ import {
   createDownloadsCache,
   createGithubHistoryCache,
   createReleasesCache,
-  createSizeHistoryCache,
   type DownloadsPayload,
   type GithubHistoryPayload,
   type PackagePayload,
@@ -42,7 +41,6 @@ const trendsCacheConfig: Record<TrendsCacheName, number> = {
   downloads: 24 * 60 * 60 * 1000,
   'github-history': 24 * 60 * 60 * 1000,
   releases: 24 * 60 * 60 * 1000,
-  'size-history': 24 * 60 * 60 * 1000,
 }
 
 const downloadsCache = createDownloadsCache(trendsCacheConfig.downloads)
@@ -75,18 +73,6 @@ fastify.get<{ Querystring: PackagePayload; Body: PackagePayload }>(
 fastify.post<{ Querystring: PackagePayload; Body: PackagePayload }>(
   '/trends-cache/releases',
   releasesCache.post,
-)
-
-const sizeHistoryCache = createSizeHistoryCache(
-  trendsCacheConfig['size-history'],
-)
-fastify.get<{ Querystring: PackagePayload; Body: PackagePayload }>(
-  '/trends-cache/size-history',
-  sizeHistoryCache.get,
-)
-fastify.post<{ Querystring: PackagePayload; Body: PackagePayload }>(
-  '/trends-cache/size-history',
-  sizeHistoryCache.post,
 )
 
 fastify

--- a/cache-service/index.ts
+++ b/cache-service/index.ts
@@ -3,6 +3,7 @@ import 'dotenv-defaults/config.js'
 import createFastify from 'fastify'
 import firebase from 'firebase'
 
+import type { TrendsCacheName } from '../types/cache-domain.ts'
 import {
   getExportsSizeMiddlware,
   postExportsSizeMiddleware,
@@ -11,6 +12,7 @@ import {
   getPackageSizeMiddlware,
   postPackageSizeMiddlware,
 } from './middlewares/package-size.middleware.ts'
+import { createTrendsCacheMiddleware } from './middlewares/trends-cache.middleware.ts'
 
 const fastify = createFastify()
 
@@ -27,6 +29,19 @@ fastify.post('/package-cache', postPackageSizeMiddlware)
 
 fastify.get('/exports-cache', getExportsSizeMiddlware)
 fastify.post('/exports-cache', postExportsSizeMiddleware)
+
+const trendsCacheNames: TrendsCacheName[] = [
+  'downloads',
+  'github-history',
+  'releases',
+  'size-history',
+]
+
+for (const cacheName of trendsCacheNames) {
+  const middleware = createTrendsCacheMiddleware()
+  fastify.get(`/trends-cache/${cacheName}`, middleware.get)
+  fastify.post(`/trends-cache/${cacheName}`, middleware.post)
+}
 
 fastify
   .listen({ port: 7001 })

--- a/cache-service/index.ts
+++ b/cache-service/index.ts
@@ -15,9 +15,12 @@ import {
 import {
   createDownloadsCache,
   createGithubHistoryCache,
+  createGithubSnapshotCache,
+  createGithubStarsCache,
   createReleasesCache,
   type DownloadsPayload,
-  type GithubHistoryPayload,
+  type GithubRepositoryPayload,
+  type GithubStarsPayload,
   type PackagePayload,
 } from './middlewares/trends-cache.middleware.ts'
 
@@ -37,10 +40,13 @@ fastify.post('/package-cache', postPackageSizeMiddlware)
 fastify.get('/exports-cache', getExportsSizeMiddlware)
 fastify.post('/exports-cache', postExportsSizeMiddleware)
 
+const HOUR_MS = 60 * 60 * 1000
 const trendsCacheConfig: Record<TrendsCacheName, number> = {
-  downloads: 24 * 60 * 60 * 1000,
-  'github-history': 24 * 60 * 60 * 1000,
-  releases: 24 * 60 * 60 * 1000,
+  downloads: 6 * HOUR_MS,
+  'github-history': 12 * HOUR_MS,
+  'github-stars': 12 * HOUR_MS,
+  'github-snapshot': HOUR_MS,
+  releases: 6 * HOUR_MS,
 }
 
 const downloadsCache = createDownloadsCache(trendsCacheConfig.downloads)
@@ -57,13 +63,37 @@ const githubHistoryCache = createGithubHistoryCache(
   trendsCacheConfig['github-history'],
 )
 fastify.get<{
-  Querystring: GithubHistoryPayload
-  Body: GithubHistoryPayload
+  Querystring: GithubRepositoryPayload
+  Body: GithubRepositoryPayload
 }>('/trends-cache/github-history', githubHistoryCache.get)
 fastify.post<{
-  Querystring: GithubHistoryPayload
-  Body: GithubHistoryPayload
+  Querystring: GithubRepositoryPayload
+  Body: GithubRepositoryPayload
 }>('/trends-cache/github-history', githubHistoryCache.post)
+
+const githubStarsCache = createGithubStarsCache(
+  trendsCacheConfig['github-stars'],
+)
+fastify.get<{
+  Querystring: GithubStarsPayload
+  Body: GithubStarsPayload
+}>('/trends-cache/github-stars', githubStarsCache.get)
+fastify.post<{
+  Querystring: GithubStarsPayload
+  Body: GithubStarsPayload
+}>('/trends-cache/github-stars', githubStarsCache.post)
+
+const githubSnapshotCache = createGithubSnapshotCache(
+  trendsCacheConfig['github-snapshot'],
+)
+fastify.get<{
+  Querystring: GithubRepositoryPayload
+  Body: GithubRepositoryPayload
+}>('/trends-cache/github-snapshot', githubSnapshotCache.get)
+fastify.post<{
+  Querystring: GithubRepositoryPayload
+  Body: GithubRepositoryPayload
+}>('/trends-cache/github-snapshot', githubSnapshotCache.post)
 
 const releasesCache = createReleasesCache(trendsCacheConfig.releases)
 fastify.get<{ Querystring: PackagePayload; Body: PackagePayload }>(

--- a/cache-service/middlewares/trends-cache.middleware.ts
+++ b/cache-service/middlewares/trends-cache.middleware.ts
@@ -8,17 +8,38 @@ const debug = createDebug('bp:cache')
 const MAX_ENTRIES = 500
 const MAX_TTL_MS = 24 * 60 * 60 * 1000
 
-type TrendsCacheRequest = FastifyRequest<{
-  Querystring: { key?: string }
-  Body: { key?: string; result?: CacheEntry }
-}>
+type CacheRequest<TQuery, TBody> = FastifyRequest<{
+  Querystring: TQuery
+}> & { body: TBody }
 
-export function createTrendsCacheMiddleware(ttlMs: number) {
+export interface CachePayload {
+  result?: CacheEntry
+}
+
+export interface DownloadsPayload extends CachePayload {
+  packageName?: string
+  range?: string
+}
+
+export interface GithubHistoryPayload extends CachePayload {
+  repository?: string
+  range?: string
+  source?: 'history' | 'snapshot' | 'stars'
+}
+
+export interface PackagePayload extends CachePayload {
+  packageName?: string
+}
+
+function createCache<TQuery, TBody extends CachePayload>(
+  ttlMs: number,
+  getKey: (request: CacheRequest<TQuery, TBody>) => string | undefined,
+) {
   const cache = new LRUCache<string, CacheEntry>({ max: MAX_ENTRIES })
 
   return {
-    async get(request: TrendsCacheRequest, reply: FastifyReply) {
-      const key = request.query.key
+    async get(request: CacheRequest<TQuery, TBody>, reply: FastifyReply) {
+      const key = getKey(request)
       if (!key) return reply.code(422).send()
 
       const result = cache.get(key)
@@ -27,15 +48,53 @@ export function createTrendsCacheMiddleware(ttlMs: number) {
       return reply.code(200).send(result)
     },
 
-    async post(request: TrendsCacheRequest, reply: FastifyReply) {
-      const { key, result } = request.body
-      if (!key || result === undefined) {
-        return reply.code(422).send()
-      }
+    async post(request: CacheRequest<TQuery, TBody>, reply: FastifyReply) {
+      const key = getKey(request)
+      const result = request.body.result
+      if (!key || result === undefined) return reply.code(422).send()
 
       cache.set(key, result, { ttl: Math.min(ttlMs, MAX_TTL_MS) })
       debug('set trends cache %s', key)
       return reply.code(201).send()
     },
   }
+}
+
+export function createDownloadsCache(ttlMs: number) {
+  return createCache<DownloadsPayload, DownloadsPayload>(
+    ttlMs,
+    ({ query, body }) => {
+      const packageName = query.packageName || body.packageName
+      const range = query.range || body.range
+      return packageName && range ? `${packageName}:${range}` : undefined
+    },
+  )
+}
+
+export function createGithubHistoryCache(ttlMs: number) {
+  return createCache<GithubHistoryPayload, GithubHistoryPayload>(
+    ttlMs,
+    ({ query, body }) => {
+      const repository = query.repository || body.repository
+      const source = query.source || body.source
+      const range = query.range || body.range || ''
+      return repository && source
+        ? `${source}:${repository}:${range}`
+        : undefined
+    },
+  )
+}
+
+export function createReleasesCache(ttlMs: number) {
+  return createCache<PackagePayload, PackagePayload>(
+    ttlMs,
+    ({ query, body }) => query.packageName || body.packageName,
+  )
+}
+
+export function createSizeHistoryCache(ttlMs: number) {
+  return createCache<PackagePayload, PackagePayload>(
+    ttlMs,
+    ({ query, body }) => query.packageName || body.packageName,
+  )
 }

--- a/cache-service/middlewares/trends-cache.middleware.ts
+++ b/cache-service/middlewares/trends-cache.middleware.ts
@@ -91,10 +91,3 @@ export function createReleasesCache(ttlMs: number) {
     ({ query, body }) => query.packageName || body.packageName,
   )
 }
-
-export function createSizeHistoryCache(ttlMs: number) {
-  return createCache<PackagePayload, PackagePayload>(
-    ttlMs,
-    ({ query, body }) => query.packageName || body.packageName,
-  )
-}

--- a/cache-service/middlewares/trends-cache.middleware.ts
+++ b/cache-service/middlewares/trends-cache.middleware.ts
@@ -1,0 +1,47 @@
+import createDebug from 'debug'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { LRUCache } from 'lru-cache'
+
+import type { CacheEntry } from '../types.ts'
+
+const debug = createDebug('bp:cache')
+const MAX_ENTRIES = 500
+const MAX_TTL_MS = 24 * 60 * 60 * 1000
+
+type TrendsCacheRequest = FastifyRequest<{
+  Querystring: { key?: string }
+  Body: { key?: string; result?: CacheEntry; ttlMs?: number }
+}>
+
+export function createTrendsCacheMiddleware() {
+  const cache = new LRUCache<string, CacheEntry>({ max: MAX_ENTRIES })
+
+  return {
+    async get(request: TrendsCacheRequest, reply: FastifyReply) {
+      const key = request.query.key
+      if (!key) return reply.code(422).send()
+
+      const result = cache.get(key)
+      if (result === undefined) return reply.code(404).send()
+
+      return reply.code(200).send(result)
+    },
+
+    async post(request: TrendsCacheRequest, reply: FastifyReply) {
+      const { key, result, ttlMs } = request.body
+      if (
+        !key ||
+        result === undefined ||
+        typeof ttlMs !== 'number' ||
+        !Number.isFinite(ttlMs) ||
+        ttlMs <= 0
+      ) {
+        return reply.code(422).send()
+      }
+
+      cache.set(key, result, { ttl: Math.min(ttlMs, MAX_TTL_MS) })
+      debug('set trends cache %s', key)
+      return reply.code(201).send()
+    },
+  }
+}

--- a/cache-service/middlewares/trends-cache.middleware.ts
+++ b/cache-service/middlewares/trends-cache.middleware.ts
@@ -21,10 +21,13 @@ export interface DownloadsPayload extends CachePayload {
   range?: string
 }
 
-export interface GithubHistoryPayload extends CachePayload {
+export interface GithubRepositoryPayload extends CachePayload {
+  repository?: string
+}
+
+export interface GithubStarsPayload extends CachePayload {
   repository?: string
   range?: string
-  source?: 'history' | 'snapshot' | 'stars'
 }
 
 export interface PackagePayload extends CachePayload {
@@ -72,16 +75,27 @@ export function createDownloadsCache(ttlMs: number) {
 }
 
 export function createGithubHistoryCache(ttlMs: number) {
-  return createCache<GithubHistoryPayload, GithubHistoryPayload>(
+  return createCache<GithubRepositoryPayload, GithubRepositoryPayload>(
+    ttlMs,
+    ({ query, body }) => query.repository || body.repository,
+  )
+}
+
+export function createGithubStarsCache(ttlMs: number) {
+  return createCache<GithubStarsPayload, GithubStarsPayload>(
     ttlMs,
     ({ query, body }) => {
       const repository = query.repository || body.repository
-      const source = query.source || body.source
-      const range = query.range || body.range || ''
-      return repository && source
-        ? `${source}:${repository}:${range}`
-        : undefined
+      const range = query.range || body.range
+      return repository && range ? `${repository}:${range}` : undefined
     },
+  )
+}
+
+export function createGithubSnapshotCache(ttlMs: number) {
+  return createCache<GithubRepositoryPayload, GithubRepositoryPayload>(
+    ttlMs,
+    ({ query, body }) => query.repository || body.repository,
   )
 }
 

--- a/cache-service/middlewares/trends-cache.middleware.ts
+++ b/cache-service/middlewares/trends-cache.middleware.ts
@@ -10,10 +10,10 @@ const MAX_TTL_MS = 24 * 60 * 60 * 1000
 
 type TrendsCacheRequest = FastifyRequest<{
   Querystring: { key?: string }
-  Body: { key?: string; result?: CacheEntry; ttlMs?: number }
+  Body: { key?: string; result?: CacheEntry }
 }>
 
-export function createTrendsCacheMiddleware() {
+export function createTrendsCacheMiddleware(ttlMs: number) {
   const cache = new LRUCache<string, CacheEntry>({ max: MAX_ENTRIES })
 
   return {
@@ -28,14 +28,8 @@ export function createTrendsCacheMiddleware() {
     },
 
     async post(request: TrendsCacheRequest, reply: FastifyReply) {
-      const { key, result, ttlMs } = request.body
-      if (
-        !key ||
-        result === undefined ||
-        typeof ttlMs !== 'number' ||
-        !Number.isFinite(ttlMs) ||
-        ttlMs <= 0
-      ) {
+      const { key, result } = request.body
+      if (!key || result === undefined) {
         return reply.code(422).send()
       }
 

--- a/server/clients/cacheService.ts
+++ b/server/clients/cacheService.ts
@@ -91,10 +91,6 @@ export default class CacheServiceClient {
     return this.getTrendsData('releases', { packageName })
   }
 
-  getSizeHistory<T>(packageName: string): Promise<T | undefined> {
-    return this.getTrendsData('size-history', { packageName })
-  }
-
   setDownloads<T>(
     packageName: string,
     range: string,
@@ -118,10 +114,6 @@ export default class CacheServiceClient {
 
   setReleases<T>(packageName: string, result: T): Promise<void> {
     return this.setTrendsData('releases', { packageName }, result)
-  }
-
-  setSizeHistory<T>(packageName: string, result: T): Promise<void> {
-    return this.setTrendsData('size-history', { packageName }, result)
   }
 
   private async getTrendsData<T>(

--- a/server/clients/cacheService.ts
+++ b/server/clients/cacheService.ts
@@ -3,7 +3,10 @@ import 'dotenv-defaults/config'
 import axios from 'axios'
 import createDebug from 'debug'
 
-import type { TrendsCacheName } from '../../types/cache-domain'
+import type {
+  GithubHistoryCacheSource,
+  TrendsCacheName,
+} from '../../types/cache-domain'
 import logger from '../Logger'
 
 const debug = createDebug('bp:cache')
@@ -72,45 +75,62 @@ export default class CacheServiceClient {
     }
   }
 
-  getDownloads<T>(key: string): Promise<T | undefined> {
-    return this.getTrendsData('downloads', key)
+  getDownloads<T>(packageName: string, range: string): Promise<T | undefined> {
+    return this.getTrendsData('downloads', { packageName, range })
   }
 
-  getGithubHistory<T>(key: string): Promise<T | undefined> {
-    return this.getTrendsData('github-history', key)
+  getGithubHistory<T>(
+    repository: string,
+    source: GithubHistoryCacheSource,
+    range?: string,
+  ): Promise<T | undefined> {
+    return this.getTrendsData('github-history', { repository, source, range })
   }
 
-  getReleases<T>(key: string): Promise<T | undefined> {
-    return this.getTrendsData('releases', key)
+  getReleases<T>(packageName: string): Promise<T | undefined> {
+    return this.getTrendsData('releases', { packageName })
   }
 
-  getSizeHistory<T>(key: string): Promise<T | undefined> {
-    return this.getTrendsData('size-history', key)
+  getSizeHistory<T>(packageName: string): Promise<T | undefined> {
+    return this.getTrendsData('size-history', { packageName })
   }
 
-  setDownloads<T>(key: string, result: T): Promise<void> {
-    return this.setTrendsData('downloads', key, result)
+  setDownloads<T>(
+    packageName: string,
+    range: string,
+    result: T,
+  ): Promise<void> {
+    return this.setTrendsData('downloads', { packageName, range }, result)
   }
 
-  setGithubHistory<T>(key: string, result: T): Promise<void> {
-    return this.setTrendsData('github-history', key, result)
+  setGithubHistory<T>(
+    repository: string,
+    source: GithubHistoryCacheSource,
+    result: T,
+    range?: string,
+  ): Promise<void> {
+    return this.setTrendsData(
+      'github-history',
+      { repository, source, range },
+      result,
+    )
   }
 
-  setReleases<T>(key: string, result: T): Promise<void> {
-    return this.setTrendsData('releases', key, result)
+  setReleases<T>(packageName: string, result: T): Promise<void> {
+    return this.setTrendsData('releases', { packageName }, result)
   }
 
-  setSizeHistory<T>(key: string, result: T): Promise<void> {
-    return this.setTrendsData('size-history', key, result)
+  setSizeHistory<T>(packageName: string, result: T): Promise<void> {
+    return this.setTrendsData('size-history', { packageName }, result)
   }
 
   private async getTrendsData<T>(
     cacheName: TrendsCacheName,
-    key: string,
+    params: Record<string, string | undefined>,
   ): Promise<T | undefined> {
     try {
       const result = await API.get<T>(`/trends-cache/${cacheName}`, {
-        params: key,
+        params,
       })
       return result.data
     } catch {
@@ -120,16 +140,16 @@ export default class CacheServiceClient {
 
   private async setTrendsData<T>(
     cacheName: TrendsCacheName,
-    key: string,
+    params: Record<string, string | undefined>,
     result: T,
   ): Promise<void> {
     try {
       await API.post(`/trends-cache/${cacheName}`, {
-        key,
+        ...params,
         result,
       })
     } catch (error) {
-      debug('failed to set trends cache %s: %O', key, error)
+      debug('failed to set trends cache %s: %O', cacheName, error)
     }
   }
 

--- a/server/clients/cacheService.ts
+++ b/server/clients/cacheService.ts
@@ -3,10 +3,7 @@ import 'dotenv-defaults/config'
 import axios from 'axios'
 import createDebug from 'debug'
 
-import type {
-  GithubHistoryCacheSource,
-  TrendsCacheName,
-} from '../../types/cache-domain'
+import type { TrendsCacheName } from '../../types/cache-domain'
 import logger from '../Logger'
 
 const debug = createDebug('bp:cache')
@@ -79,12 +76,16 @@ export default class CacheServiceClient {
     return this.getTrendsData('downloads', { packageName, range })
   }
 
-  getGithubHistory<T>(
-    repository: string,
-    source: GithubHistoryCacheSource,
-    range?: string,
-  ): Promise<T | undefined> {
-    return this.getTrendsData('github-history', { repository, source, range })
+  getGithubHistory<T>(repository: string): Promise<T | undefined> {
+    return this.getTrendsData('github-history', { repository })
+  }
+
+  getGithubStars<T>(repository: string, range: string): Promise<T | undefined> {
+    return this.getTrendsData('github-stars', { repository, range })
+  }
+
+  getGithubSnapshot<T>(repository: string): Promise<T | undefined> {
+    return this.getTrendsData('github-snapshot', { repository })
   }
 
   getReleases<T>(packageName: string): Promise<T | undefined> {
@@ -99,17 +100,20 @@ export default class CacheServiceClient {
     return this.setTrendsData('downloads', { packageName, range }, result)
   }
 
-  setGithubHistory<T>(
+  setGithubHistory<T>(repository: string, result: T): Promise<void> {
+    return this.setTrendsData('github-history', { repository }, result)
+  }
+
+  setGithubStars<T>(
     repository: string,
-    source: GithubHistoryCacheSource,
+    range: string,
     result: T,
-    range?: string,
   ): Promise<void> {
-    return this.setTrendsData(
-      'github-history',
-      { repository, source, range },
-      result,
-    )
+    return this.setTrendsData('github-stars', { repository, range }, result)
+  }
+
+  setGithubSnapshot<T>(repository: string, result: T): Promise<void> {
+    return this.setTrendsData('github-snapshot', { repository }, result)
   }
 
   setReleases<T>(packageName: string, result: T): Promise<void> {

--- a/server/clients/cacheService.ts
+++ b/server/clients/cacheService.ts
@@ -3,6 +3,7 @@ import 'dotenv-defaults/config'
 import axios from 'axios'
 import createDebug from 'debug'
 
+import type { TrendsCacheKey, TrendsCacheName } from '../../types/cache-domain'
 import logger from '../Logger'
 
 const debug = createDebug('bp:cache')
@@ -68,6 +69,37 @@ export default class CacheServiceClient {
         error,
         `CACHE ERROR for package exports ${key.name}@${key.version}`,
       )
+    }
+  }
+
+  async getTrendsData<T>(
+    cacheName: TrendsCacheName,
+    key: TrendsCacheKey,
+  ): Promise<T | undefined> {
+    try {
+      const result = await API.get<T>(`/trends-cache/${cacheName}`, {
+        params: key,
+      })
+      return result.data
+    } catch {
+      return undefined
+    }
+  }
+
+  async setTrendsData<T>(
+    cacheName: TrendsCacheName,
+    key: TrendsCacheKey,
+    result: T,
+    ttlMs: number,
+  ): Promise<void> {
+    try {
+      await API.post(`/trends-cache/${cacheName}`, {
+        ...key,
+        result,
+        ttlMs,
+      })
+    } catch (error) {
+      debug('failed to set trends cache %s: %O', key.key, error)
     }
   }
 

--- a/server/clients/cacheService.ts
+++ b/server/clients/cacheService.ts
@@ -3,7 +3,7 @@ import 'dotenv-defaults/config'
 import axios from 'axios'
 import createDebug from 'debug'
 
-import type { TrendsCacheKey, TrendsCacheName } from '../../types/cache-domain'
+import type { TrendsCacheName } from '../../types/cache-domain'
 import logger from '../Logger'
 
 const debug = createDebug('bp:cache')
@@ -72,9 +72,41 @@ export default class CacheServiceClient {
     }
   }
 
-  async getTrendsData<T>(
+  getDownloads<T>(key: string): Promise<T | undefined> {
+    return this.getTrendsData('downloads', key)
+  }
+
+  getGithubHistory<T>(key: string): Promise<T | undefined> {
+    return this.getTrendsData('github-history', key)
+  }
+
+  getReleases<T>(key: string): Promise<T | undefined> {
+    return this.getTrendsData('releases', key)
+  }
+
+  getSizeHistory<T>(key: string): Promise<T | undefined> {
+    return this.getTrendsData('size-history', key)
+  }
+
+  setDownloads<T>(key: string, result: T): Promise<void> {
+    return this.setTrendsData('downloads', key, result)
+  }
+
+  setGithubHistory<T>(key: string, result: T): Promise<void> {
+    return this.setTrendsData('github-history', key, result)
+  }
+
+  setReleases<T>(key: string, result: T): Promise<void> {
+    return this.setTrendsData('releases', key, result)
+  }
+
+  setSizeHistory<T>(key: string, result: T): Promise<void> {
+    return this.setTrendsData('size-history', key, result)
+  }
+
+  private async getTrendsData<T>(
     cacheName: TrendsCacheName,
-    key: TrendsCacheKey,
+    key: string,
   ): Promise<T | undefined> {
     try {
       const result = await API.get<T>(`/trends-cache/${cacheName}`, {
@@ -86,20 +118,18 @@ export default class CacheServiceClient {
     }
   }
 
-  async setTrendsData<T>(
+  private async setTrendsData<T>(
     cacheName: TrendsCacheName,
-    key: TrendsCacheKey,
+    key: string,
     result: T,
-    ttlMs: number,
   ): Promise<void> {
     try {
       await API.post(`/trends-cache/${cacheName}`, {
-        ...key,
+        key,
         result,
-        ttlMs,
       })
     } catch (error) {
-      debug('failed to set trends cache %s: %O', key.key, error)
+      debug('failed to set trends cache %s: %O', key, error)
     }
   }
 

--- a/types/cache-domain.ts
+++ b/types/cache-domain.ts
@@ -1,3 +1,6 @@
-export type TrendsCacheName = 'downloads' | 'github-history' | 'releases'
-
-export type GithubHistoryCacheSource = 'history' | 'snapshot' | 'stars'
+export type TrendsCacheName =
+  | 'downloads'
+  | 'github-history'
+  | 'github-stars'
+  | 'github-snapshot'
+  | 'releases'

--- a/types/cache-domain.ts
+++ b/types/cache-domain.ts
@@ -3,7 +3,3 @@ export type TrendsCacheName =
   | 'github-history'
   | 'releases'
   | 'size-history'
-
-export interface TrendsCacheKey {
-  key: string
-}

--- a/types/cache-domain.ts
+++ b/types/cache-domain.ts
@@ -1,7 +1,3 @@
-export type TrendsCacheName =
-  | 'downloads'
-  | 'github-history'
-  | 'releases'
-  | 'size-history'
+export type TrendsCacheName = 'downloads' | 'github-history' | 'releases'
 
 export type GithubHistoryCacheSource = 'history' | 'snapshot' | 'stars'

--- a/types/cache-domain.ts
+++ b/types/cache-domain.ts
@@ -3,3 +3,5 @@ export type TrendsCacheName =
   | 'github-history'
   | 'releases'
   | 'size-history'
+
+export type GithubHistoryCacheSource = 'history' | 'snapshot' | 'stars'

--- a/types/cache-domain.ts
+++ b/types/cache-domain.ts
@@ -1,0 +1,9 @@
+export type TrendsCacheName =
+  | 'downloads'
+  | 'github-history'
+  | 'releases'
+  | 'size-history'
+
+export interface TrendsCacheKey {
+  key: string
+}


### PR DESCRIPTION
## Summary

- add typed cache names and keys for trend data
- expose bounded in-memory LRU/TTL endpoints for downloads, GitHub history, releases, and size history
- add matching methods to the server cache client

This is a focused foundation slice; trend data-source services will follow separately.

## Validation

- `yarn typecheck`
- direct TypeScript check of the new cache middleware
- lint (existing repository warnings only)