### PR TITLE
perf: limit V8 heap size to prevent system OOM crashes

### DIFF
--- a/process.yml
+++ b/process.yml
@@ -4,6 +4,7 @@ apps:
     name: main
     node_args:
       - --require=./scripts/memory-diagnostics.cjs
+      - --max-old-space-size=400
     instances: 1
     max_memory_restart: 500M
     error_file: logs/index.log
@@ -27,6 +28,7 @@ apps:
     name: build-service
     node_args:
       - --require=./scripts/memory-diagnostics.cjs
+      - --max-old-space-size=900
     instances: 3
     max_memory_restart: 1000M
     exec_mode: cluster
@@ -46,6 +48,7 @@ apps:
     name: cache-service
     node_args:
       - --require=./scripts/memory-diagnostics.cjs
+      - --max-old-space-size=150
     instances: 1
     max_memory_restart: 200M
     exec_mode: cluster


### PR DESCRIPTION
## Summary

Limits the V8 heap size of the `main`, `build-service`, and `cache-service` processes in `process.yml`.

- Sets `--max-old-space-size=400` for `main` (aligns with PM2's 500MB max memory limit).
- Sets `--max-old-space-size=900` for `build-service` (aligns with PM2's 1000MB max memory limit).
- Sets `--max-old-space-size=150` for `cache-service` (aligns with PM2's 200MB max memory limit).

## Why this is needed
OOM killer logs in `/var/log/syslog` reveal that Node.js `build-service` worker processes frequently allocate up to **6.8 GB of RSS** during heavy or invalid package installations before PM2 has a chance to inspect and restart them (causing system-wide OOM kills and server reboots). 

Setting `--max-old-space-size` forces V8 garbage collection and cleanly crashes/restarts the service before memory can balloon past the threshold, keeping the server responsive.