### PR TITLE
Fix Carbon ad loader lifecycle and blocked-slot handling

### DIFF
--- a/client/components/CarbonAd/CarbonAd.scss
+++ b/client/components/CarbonAd/CarbonAd.scss
@@ -1,9 +1,13 @@
-.carbon-ad:not(.carbon-ad--ready) {
-  width: 1px;
-  height: 1px;
-  min-height: 1px;
-  margin: 0;
-  overflow: hidden;
+.carbon-ad--pending {
+  visibility: hidden;
+
+  .carbon-ad__content {
+    min-height: clamp(160px, 60vw, 280px);
+  }
+}
+
+.carbon-ad--unavailable {
+  display: none;
 }
 
 .carbon-ad__content {

--- a/client/components/CarbonAd/CarbonAd.tsx
+++ b/client/components/CarbonAd/CarbonAd.tsx
@@ -51,9 +51,7 @@ const CarbonAd = ({ className, placement }: CarbonAdProps) => {
     if (!container) return
 
     const revealWhenCreativeIsRendered = () => {
-      const carbonAds = Array.from(container.querySelectorAll('#carbonads'))
-      const [carbonAd, ...duplicateCarbonAds] = carbonAds
-      duplicateCarbonAds.forEach(carbonAd => carbonAd.remove())
+      const carbonAd = container.querySelector('#carbonads')
       const hasAdContent = Boolean(
         carbonAd?.querySelector('a, img, .carbon-text'),
       )
@@ -63,12 +61,15 @@ const CarbonAd = ({ className, placement }: CarbonAdProps) => {
       }
     }
 
+    if (container.querySelector('script[data-carbon-slot-script]')) return
+
     const observer = new MutationObserver(revealWhenCreativeIsRendered)
     observer.observe(container, { childList: true, subtree: true })
 
     const script = document.createElement('script')
     script.async = true
     script.type = 'text/javascript'
+    script.dataset.carbonSlotScript = 'true'
     script.src =
       '//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=cover'
     script.id = '_carbonads_js'
@@ -91,9 +92,7 @@ const CarbonAd = ({ className, placement }: CarbonAdProps) => {
     return () => {
       observer.disconnect()
       window.clearTimeout(loadTimeout)
-      container
-        .querySelectorAll('#carbonads')
-        .forEach(carbonAd => carbonAd.remove())
+      container.querySelector('#carbonads')?.remove()
       script.remove()
     }
   }, [])
@@ -150,9 +149,7 @@ const CarbonAd = ({ className, placement }: CarbonAdProps) => {
   return (
     <aside
       ref={slotRef}
-      className={cx('carbon-ad', className, {
-        'carbon-ad--ready': hasCreative,
-      })}
+      className={cx('carbon-ad', className, `carbon-ad--${adLoadState}`)}
       aria-label={hasCreative ? 'Advertisement' : undefined}
     >
       <div ref={containerRef} className="carbon-ad__content">


### PR DESCRIPTION
## Summary

Make Carbon ad loading explicit and resilient without deleting duplicate creatives or collapsing the slot before Carbon has had a chance to render.

## Changes

- Guard against adding a second Carbon script to the same slot.
- Stop deleting duplicate `#carbonads` nodes as a rendering-side cleanup workaround.
- Preserve bounded pending layout space while the creative loads.
- Keep the dismiss button limited to the ready state.
- Collapse the slot only after script failure or the existing creative timeout marks it unavailable.

## Verification

- `yarn build`
- `yarn format:check client/components/CarbonAd/CarbonAd.tsx client/components/CarbonAd/CarbonAd.scss`
- `yarn typecheck`
- `git diff --check`

Existing repository lint and dependency warnings remain unchanged.