### PR TITLE
Rollback pre-crash Carbon ad behavior

### DIFF
--- a/client/__tests__/analytics.test.ts
+++ b/client/__tests__/analytics.test.ts
@@ -56,23 +56,6 @@ describe('Analytics', () => {
     })
   })
 
-  it('tracks ad impressions and viewed slots without a creative separately', async () => {
-    Analytics.advertisementImpression({ placement: 'homepage' })
-    Analytics.advertisementUnavailable({
-      placement: 'package_result',
-      reason: 'creative_timeout',
-    })
-    await new Promise(resolve => setTimeout(resolve, 0))
-
-    expect(track).toHaveBeenNthCalledWith(1, 'advertisement_impression', {
-      placement: 'homepage',
-    })
-    expect(track).toHaveBeenNthCalledWith(2, 'advertisement_unavailable', {
-      placement: 'package_result',
-      reason: 'creative_timeout',
-    })
-  })
-
   it('does not throw when the browser tracker is unavailable', () => {
     Object.defineProperty(globalThis, 'window', {
       configurable: true,

--- a/client/analytics.ts
+++ b/client/analytics.ts
@@ -29,12 +29,6 @@ type HasToolName = {
 type HasAction = {
   action: string
 }
-type HasAdPlacement = {
-  placement: 'homepage' | 'package_result'
-}
-type HasAdUnavailableReason = HasAdPlacement & {
-  reason: 'script_error' | 'creative_timeout'
-}
 
 export default class Analytics {
   private static logEvent(
@@ -180,16 +174,5 @@ export default class Analytics {
 
   static mcpDocsOpened() {
     Analytics.logEvent('mcp_docs_opened')
-  }
-
-  static advertisementImpression({ placement }: HasAdPlacement) {
-    Analytics.logEvent('advertisement_impression', { placement })
-  }
-
-  static advertisementUnavailable({
-    placement,
-    reason,
-  }: HasAdUnavailableReason) {
-    Analytics.logEvent('advertisement_unavailable', { placement, reason })
   }
 }

--- a/client/components/CarbonAd/CarbonAd.scss
+++ b/client/components/CarbonAd/CarbonAd.scss
@@ -1,15 +1,3 @@
-.carbon-ad--pending {
-  visibility: hidden;
-
-  .carbon-ad__content {
-    min-height: clamp(160px, 60vw, 280px);
-  }
-}
-
-.carbon-ad--unavailable {
-  display: none;
-}
-
 .carbon-ad__content {
   position: relative;
   width: 100%;

--- a/client/components/CarbonAd/CarbonAd.tsx
+++ b/client/components/CarbonAd/CarbonAd.tsx
@@ -1,181 +1,59 @@
 import React from 'react'
 import cx from 'classnames'
 import { IconButton } from '../ui'
-import Analytics from '../../analytics'
-
-const AD_VIEW_DURATION_MS = 1000
-const AD_LOAD_TIMEOUT_MS = 5000
-
-type AdPlacement = 'homepage' | 'package_result'
-type AdLoadState = 'pending' | 'ready' | 'unavailable'
-type AdUnavailableReason = 'script_error' | 'creative_timeout'
 
 type CarbonAdProps = {
   className?: string
-  placement: AdPlacement
 }
 
-const CarbonAd = ({ className, placement }: CarbonAdProps) => {
-  const slotRef = React.useRef<HTMLElement>(null)
+const CarbonAd = ({ className }: CarbonAdProps) => {
   const containerRef = React.useRef<HTMLDivElement>(null)
   const [isVisible, setIsVisible] = React.useState(true)
-  const [adLoadState, setAdLoadState] = React.useState<AdLoadState>('pending')
-  const [unavailableReason, setUnavailableReason] =
-    React.useState<AdUnavailableReason>('creative_timeout')
-  const [slotHasBeenViewed, setSlotHasBeenViewed] = React.useState(false)
-  const impressionTracked = React.useRef(false)
-  const unavailableTracked = React.useRef(false)
-
-  const hasCreative = adLoadState === 'ready'
-
-  React.useEffect(() => {
-    const slot = slotRef.current
-    if (!slot || !('IntersectionObserver' in window)) return
-
-    const observer = new IntersectionObserver(
-      entries => {
-        if (entries.some(entry => entry.isIntersecting)) {
-          setSlotHasBeenViewed(true)
-          observer.disconnect()
-        }
-      },
-      { threshold: 0.5 },
-    )
-
-    observer.observe(slot)
-    return () => observer.disconnect()
-  }, [])
 
   React.useEffect(() => {
     const container = containerRef.current
     if (!container) return
 
-    const revealWhenCreativeIsRendered = () => {
-      const carbonAd = container.querySelector('#carbonads')
-      const hasAdContent = Boolean(
-        carbonAd?.querySelector('a, img, .carbon-text'),
-      )
-
-      if (hasAdContent) {
-        setAdLoadState('ready')
-      }
-    }
-
-    if (container.querySelector('script[data-carbon-slot-script]')) return
-
-    const observer = new MutationObserver(revealWhenCreativeIsRendered)
-    observer.observe(container, { childList: true, subtree: true })
-
     const script = document.createElement('script')
     script.async = true
     script.type = 'text/javascript'
-    script.dataset.carbonSlotScript = 'true'
     script.src =
       '//cdn.carbonads.com/carbon.js?serve=CW7D6K77&placement=bundlephobiacom&format=cover'
     script.id = '_carbonads_js'
-    script.onload = () => {
-      window.requestAnimationFrame(revealWhenCreativeIsRendered)
-    }
-    script.onerror = () => {
-      setUnavailableReason('script_error')
-      setAdLoadState('unavailable')
-    }
     container.appendChild(script)
 
-    const loadTimeout = window.setTimeout(() => {
-      setUnavailableReason('creative_timeout')
-      setAdLoadState(currentState =>
-        currentState === 'pending' ? 'unavailable' : currentState,
-      )
-    }, AD_LOAD_TIMEOUT_MS)
-
     return () => {
-      observer.disconnect()
-      window.clearTimeout(loadTimeout)
       container.querySelector('#carbonads')?.remove()
       script.remove()
     }
   }, [])
 
-  React.useEffect(() => {
-    if (
-      adLoadState !== 'unavailable' ||
-      !slotHasBeenViewed ||
-      unavailableTracked.current
-    ) {
-      return
-    }
-
-    unavailableTracked.current = true
-    Analytics.advertisementUnavailable({ placement, reason: unavailableReason })
-  }, [adLoadState, placement, slotHasBeenViewed, unavailableReason])
-
-  React.useEffect(() => {
-    if (!hasCreative || impressionTracked.current) return
-
-    const carbonAd = containerRef.current?.querySelector('#carbonads')
-    if (!carbonAd || !('IntersectionObserver' in window)) return
-
-    let viewTimeout: number | undefined
-    const observer = new IntersectionObserver(
-      entries => {
-        const isInView = entries.some(entry => entry.isIntersecting)
-
-        if (isInView && viewTimeout === undefined) {
-          viewTimeout = window.setTimeout(() => {
-            impressionTracked.current = true
-            Analytics.advertisementImpression({ placement })
-            observer.disconnect()
-          }, AD_VIEW_DURATION_MS)
-        }
-
-        if (!isInView && viewTimeout !== undefined) {
-          window.clearTimeout(viewTimeout)
-          viewTimeout = undefined
-        }
-      },
-      { threshold: 0.5 },
-    )
-
-    observer.observe(carbonAd)
-    return () => {
-      observer.disconnect()
-      if (viewTimeout !== undefined) window.clearTimeout(viewTimeout)
-    }
-  }, [hasCreative, placement])
-
   if (!isVisible) return null
 
   return (
-    <aside
-      ref={slotRef}
-      className={cx('carbon-ad', className, `carbon-ad--${adLoadState}`)}
-      aria-label={hasCreative ? 'Advertisement' : undefined}
-    >
+    <aside className={cx('carbon-ad', className)} aria-label="Advertisement">
       <div ref={containerRef} className="carbon-ad__content">
-        {hasCreative && (
-          <IconButton
-            className="carbon-ad__dismiss"
-            label="Dismiss advertisement"
-            size="sm"
-            onClick={() => setIsVisible(false)}
+        <IconButton
+          className="carbon-ad__dismiss"
+          label="Dismiss advertisement"
+          size="sm"
+          onClick={() => setIsVisible(false)}
+        >
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            aria-hidden="true"
           >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 12 12"
-              fill="none"
-              aria-hidden="true"
-            >
-              <path
-                d="M2 2l8 8M10 2l-8 8"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
-            </svg>
-          </IconButton>
-        )}
+            <path
+              d="M2 2l8 8M10 2l-8 8"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </IconButton>
       </div>
     </aside>
   )

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -23,8 +23,6 @@ addresses, IP addresses, or other personal information to event data.
 - package.json scan upload, parsing, and completion outcomes;
 - dependency graph interaction; and
 - MCP navigation, tool, copy, and failure interactions; and
-- ad impressions (a loaded creative is at least 50% visible for one second) and
-  viewed ad slots where no creative arrived.
 
 Event names are lowercase snake_case. Event properties are limited to the
 context required to analyze the action, such as a public package identifier,

--- a/pages/index.page.tsx
+++ b/pages/index.page.tsx
@@ -134,7 +134,7 @@ const Home = () => {
               autoFocus={true}
             />
           </AutocompleteInputBox>
-          <CarbonAd className="homepage__carbon-ad" placement="homepage" />
+          <CarbonAd className="homepage__carbon-ad" />
           <div className="homepage__or-divider">or</div>
           <div className="homepage__scan-link">
             <Link href="/scan">

--- a/pages/package/[...packageString]/ResultPage.tsx
+++ b/pages/package/[...packageString]/ResultPage.tsx
@@ -575,10 +575,7 @@ class ResultPage extends PureComponent<ResultPageProps, ResultPageState> {
           )}
 
           {resultsPromiseState === 'fulfilled' && results && (
-            <CarbonAd
-              className="result-page__carbon-ad"
-              placement="package_result"
-            />
+            <CarbonAd className="result-page__carbon-ad" />
           )}
 
           {resultsPromiseState === 'fulfilled' &&


### PR DESCRIPTION
## Summary

- restore the simpler pre-crash Carbon loader and dismiss behavior
- remove the later creative-readiness, timeout, viewability, duplicate-cleanup, and ad analytics lifecycle changes
- retain the mobile homepage placement fix and the restored 280px result-page ad height

This is an isolation rollback for the ad-earnings crash investigation. It does not deploy or merge production changes.

## Verification

- `corepack yarn format:check` on changed files
- `corepack yarn typecheck`
- `corepack yarn build`
- `git diff --check`

The commit hook completed successfully with pre-existing repository lint warnings.